### PR TITLE
playground: matraix playground job / debrief / cockpit updates

### DIFF
--- a/application/playground/backend/run_dev.sh
+++ b/application/playground/backend/run_dev.sh
@@ -36,6 +36,8 @@ BACKEND_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EVAL_DIR="$(cd "${BACKEND_DIR}/.." && pwd)"  # application/playground
 REPO_ROOT="$(cd "${EVAL_DIR}/../.." && pwd)"
 PLAYGROUND_CORE_DIR="${REPO_ROOT}/packages/playground/src"
+MATRAIX_SRC_DIR="${REPO_ROOT}/src"
+MATRIX_AGENTS_DIR="${REPO_ROOT}/environment/agents"
 CHATBOT_API_DIR="${REPO_ROOT}/environment/task-environments/application/chatbot-api-sidecar_recai/recommender-api"
 
 # --- interpreter: $VENV/bin/python if VENV is set, else `python` on PATH -------
@@ -64,7 +66,8 @@ HOST="${HOST:-127.0.0.1}"
 APP="backend.api.app:app"
 
 # Make `backend`, `playground`, and task-owned `recbot` importable.
-export PYTHONPATH="${REPO_ROOT}:${REPO_ROOT}/environment/runtime:${PLAYGROUND_CORE_DIR}:${EVAL_DIR}:${CHATBOT_API_DIR}${PYTHONPATH:+:${PYTHONPATH}}"
+export PYTHONPATH="${REPO_ROOT}:${MATRAIX_SRC_DIR}:${REPO_ROOT}/environment/runtime:${MATRIX_AGENTS_DIR}:${PLAYGROUND_CORE_DIR}:${EVAL_DIR}:${CHATBOT_API_DIR}${PYTHONPATH:+:${PYTHONPATH}}"
+export MATRIX_HARBOR_COMMAND="${MATRIX_HARBOR_COMMAND:-uv run python -m harbor.cli.main run}"
 
 # The catalog is served from the real per-domain bundle under
 # recai/InteRecAgent/resources/<domain>/ (see backend.service.bundle_catalog).
@@ -79,9 +82,10 @@ fi
 
 echo "[run_dev] python      : ${VENV_PY}"
 echo "[run_dev] backend dir : ${BACKEND_DIR}"
-echo "[run_dev] PYTHONPATH  : ${REPO_ROOT}:${REPO_ROOT}/environment/runtime:${PLAYGROUND_CORE_DIR}:${EVAL_DIR}:${CHATBOT_API_DIR}"
+echo "[run_dev] PYTHONPATH  : ${REPO_ROOT}:${MATRAIX_SRC_DIR}:${REPO_ROOT}/environment/runtime:${MATRIX_AGENTS_DIR}:${PLAYGROUND_CORE_DIR}:${EVAL_DIR}:${CHATBOT_API_DIR}"
 echo "[run_dev] catalog     : ${INTERECAGENT_CATALOG_PATH:-(bundle default)}"
 echo "[run_dev] serving     : http://${HOST}:${PORT}  (app ${APP})"
+echo "[run_dev] harbor cmd  : ${MATRIX_HARBOR_COMMAND}"
 echo "[run_dev] frontend    : in another terminal, run:"
 echo "[run_dev]                 cd ${EVAL_DIR}/frontend && npm install && npm run dev"
 echo "[run_dev]               then open http://localhost:5173 (it proxies /api here)."

--- a/application/playground/backend/service/harbor_job_service.py
+++ b/application/playground/backend/service/harbor_job_service.py
@@ -441,6 +441,13 @@ STATUS_CODE_PENDING = 0
 STATUS_CODE_RUNNING = 1
 STATUS_CODE_DONE = 2
 STATUS_CODE_ERROR = 3
+_TRIAL_DEBRIEF_CACHE_MAX = 128
+
+
+@dataclass
+class _TrialDebriefCacheEntry:
+    fingerprint: tuple[tuple[str, int, int], ...]
+    payload: dict[str, Any]
 
 
 @dataclass
@@ -492,6 +499,8 @@ class HarborJobService:
     _guard: threading.Lock = field(default_factory=threading.Lock)
     _status_states: dict[str, "_JobStatusState"] = field(default_factory=dict)
     _status_guard: threading.Lock = field(default_factory=threading.Lock)
+    _debrief_cache: dict[tuple[str, str], _TrialDebriefCacheEntry] = field(default_factory=dict)
+    _debrief_cache_guard: threading.Lock = field(default_factory=threading.Lock)
     # Poll interval for per-trial host scoring while Harbor is still running.
     _host_score_poll_sec: float = 2.0
     _host_score_join_timeout_sec: float = 600.0
@@ -1046,6 +1055,22 @@ class HarborJobService:
             resolved_persona_ids = list(sampled["personaIds"])
             resolved_pool = str(sampled.get("pool") or resolved_pool)
 
+        # Hand-picked ids from the 1M root are preview-only until materialized.
+        # Mirror sample_production_1m: write a cohort, then launch against it.
+        from backend.service.persona_1m_pool import (
+            is_production_1m_root,
+            materialize_production_1m_persona_ids,
+        )
+
+        if is_production_1m_root(resolved_pool) and resolved_persona_ids:
+            materialized = materialize_production_1m_persona_ids(
+                repo_root=self.repo_root,
+                persona_ids=resolved_persona_ids,
+                seed=resolved_seed,
+            )
+            resolved_pool = str(materialized["pool"])
+            resolved_persona_ids = list(materialized["personaIds"])
+
         task_slug = _slug(Path(task_path).name)
         resolved_job_name = job_name or "pg-{}-{}".format(task_slug, uuid.uuid4().hex[:8])
         model = persona_model or default_persona_model()
@@ -1105,26 +1130,30 @@ class HarborJobService:
                     agent_cfg,
                     model_name=str(agent_cfg.get("model_name") or model),
                 )
-        if os_app_submission_profile:
-            for agent in job_config.get("agents", []):
-                if isinstance(agent, dict):
-                    kwargs = agent.setdefault("kwargs", {})
-                    if isinstance(kwargs, dict):
-                        kwargs["cua_submission_profile"] = os_app_submission_profile
+        # os_app_submission_profile / cua_submission_profile are no longer injected:
+        # agents mirror final_answer only; task verifiers recover named JSON.
         if os_app_backend:
             job_config["environment"] = resolve_job_environment(
                 execution_mode=execution_mode,
                 trial_profile=trial_profile,
                 cua_backend=os_app_backend,
             )
+            env_type = ""
+            env_block = job_config.get("environment")
+            if isinstance(env_block, dict):
+                env_type = str(env_block.get("type") or "")
             for agent in job_config.get("agents", []):
                 if isinstance(agent, dict):
                     kwargs = agent.setdefault("kwargs", {})
                     if isinstance(kwargs, dict):
                         kwargs["cua_backend"] = os_app_backend
-                        # use.computer defaults to 50 steps; stocks/news-style
-                        # browse+decide tasks routinely need more headroom.
-                        kwargs.setdefault("max_steps", 100)
+                        # use.computer CUA agents take max_steps (default 50);
+                        # Docker Computer1 takes max_turns. Give both more
+                        # headroom for stocks/news-style browse+decide tasks.
+                        if env_type == "use-computer":
+                            kwargs.setdefault("max_steps", 100)
+                        else:
+                            kwargs.setdefault("max_turns", 100)
         # use-computer OS-app tasks hand in JSON; sandbox path remap makes
         # *remote* in-VM verify flaky. Disable Harbor's per-trial verifier and
         # score on the Playground host as each trial finishes (watcher), with a
@@ -1265,7 +1294,9 @@ class HarborJobService:
         path_entries = [entry for entry in existing.split(":") if entry]
         required_paths = [
             str(self.repo_root),
+            str(self.repo_root / "src"),
             str(self.repo_root / "environment" / "runtime"),
+            str(self.repo_root / "environment" / "agents"),
             str(self.repo_root / "packages" / "playground" / "src"),
             str(self.repo_root / "application" / "playground"),
             str(
@@ -1911,16 +1942,133 @@ class HarborJobService:
 
         return {"jobName": job_name, "retried": len(failed_dirs)}
 
+    def _trial_debrief_fingerprint(
+        self,
+        job_name: str,
+        trial_name: str,
+    ) -> tuple[tuple[str, int, int], ...] | None:
+        """Stable cache key for completed trial debrief inputs."""
+        trial_dir = self.jobs_dir / job_name / trial_name
+        if not (trial_dir / "result.json").is_file():
+            return None
+
+        entries: list[tuple[str, int, int]] = []
+
+        def add_file(path: Path) -> None:
+            try:
+                stat = path.stat()
+            except OSError:
+                return
+            if not path.is_file():
+                return
+            try:
+                label = str(path.relative_to(self.repo_root))
+            except ValueError:
+                label = str(path)
+            entries.append((label.replace("\\", "/"), stat.st_mtime_ns, stat.st_size))
+
+        for rel in (
+            "config.json",
+            "result.json",
+            "events.jsonl",
+            "exception.txt",
+            "reward.txt",
+            "persona_meta.json",
+            "instruction.md",
+            "task_instruction.md",
+            "context.md",
+            "questionnaire.md",
+            "output_schema.md",
+            "verifier/reward.txt",
+            "verifier/test-stdout.txt",
+            "verifier/structured_output.json",
+            "verifier/user_feedback.json",
+            "logs/verifier/reward.txt",
+            "logs/verifier/test-stdout.txt",
+            "logs/verifier/structured_output.json",
+            "logs/verifier/user_feedback.json",
+            "agent/trajectory.json",
+        ):
+            add_file(trial_dir / rel)
+
+        output_dir = trial_dir / "artifacts" / "app" / "output"
+        if output_dir.is_dir():
+            for path in sorted(output_dir.iterdir()):
+                if path.is_file():
+                    add_file(path)
+
+        task_path = _task_path_from_trial_config(trial_dir)
+        if task_path:
+            task_dir = self.repo_root / task_path
+            for rel in (
+                "task.toml",
+                "instruction.md",
+                "input/context.md",
+                "input/questionnaire.yaml",
+                "input/self_report_schema.yaml",
+                "input/chatbot.yaml",
+                "reporting.json",
+            ):
+                add_file(task_dir / rel)
+
+        return tuple(sorted(entries))
+
+    def _cached_trial_debrief(
+        self,
+        key: tuple[str, str],
+        fingerprint: tuple[tuple[str, int, int], ...] | None,
+    ) -> dict[str, Any] | None:
+        if fingerprint is None:
+            return None
+        with self._debrief_cache_guard:
+            entry = self._debrief_cache.get(key)
+            if entry is None or entry.fingerprint != fingerprint:
+                return None
+            self._debrief_cache.pop(key, None)
+            self._debrief_cache[key] = entry
+            return entry.payload
+
+    def _store_trial_debrief(
+        self,
+        key: tuple[str, str],
+        fingerprint: tuple[tuple[str, int, int], ...] | None,
+        payload: dict[str, Any],
+    ) -> None:
+        if fingerprint is None:
+            return
+        with self._debrief_cache_guard:
+            self._debrief_cache[key] = _TrialDebriefCacheEntry(
+                fingerprint=fingerprint,
+                payload=payload,
+            )
+            while len(self._debrief_cache) > _TRIAL_DEBRIEF_CACHE_MAX:
+                oldest = next(iter(self._debrief_cache))
+                self._debrief_cache.pop(oldest, None)
+
     def get_trial_debrief(self, job_name: str, trial_name: str) -> dict[str, Any]:
         from backend.service.harbor_trial_debrief import map_trial_debrief
 
+        key = (job_name, trial_name)
+        fingerprint = self._trial_debrief_fingerprint(job_name, trial_name)
+        cached = self._cached_trial_debrief(key, fingerprint)
+        if cached is not None:
+            return cached
+
         try:
-            return map_trial_debrief(
+            payload = map_trial_debrief(
                 repo_root=self.repo_root,
                 jobs_dir=self.jobs_dir,
                 job_name=job_name,
                 trial_name=trial_name,
             )
+            # Mapping can materialize missing artifacts, so cache the final
+            # on-disk state that produced this payload.
+            self._store_trial_debrief(
+                key,
+                self._trial_debrief_fingerprint(job_name, trial_name),
+                payload,
+            )
+            return payload
         except FileNotFoundError as exc:
             raise ValueError(str(exc)) from exc
 

--- a/application/playground/backend/service/harbor_trial_debrief.py
+++ b/application/playground/backend/service/harbor_trial_debrief.py
@@ -116,17 +116,24 @@ def _persona_path_from_trial(trial_dir: Path, repo_root: Path) -> str | None:
     return None
 
 
+def _persona_from_catalog_stem(stem: str) -> Persona | None:
+    """Lookup a curated catalog persona by stem/id. Avoid on path-backed loads."""
+    try:
+        from playground.persona_catalog import get_persona
+
+        return get_persona(stem)
+    except KeyError:
+        return None
+
+
 def _load_playground_persona(repo_root: Path, persona_rel: str | None) -> Persona:
     if persona_rel:
         abs_path = (repo_root / persona_rel).resolve()
+        stem = abs_path.stem if abs_path.name else Path(persona_rel).stem
+        # Path-backed personas (wiki cohorts, trial snapshots): load that file
+        # only. Never scan the curated catalog first — get_persona() reloads
+        # every curated YAML and dominated trail-report open latency (~3s).
         if abs_path.is_file():
-            stem = abs_path.stem
-            try:
-                from playground.persona_catalog import get_persona
-
-                return get_persona(stem)
-            except KeyError:
-                pass
             try:
                 from matraix.agents.persona.loader import load_persona as load_harbor_persona
 
@@ -149,7 +156,10 @@ def _load_playground_persona(repo_root: Path, persona_rel: str | None) -> Person
                     source=str(raw.get("source") or ""),
                     context=context,
                 )
-            raw = yaml.safe_load(abs_path.read_text(encoding="utf-8"))
+            try:
+                raw = yaml.safe_load(abs_path.read_text(encoding="utf-8"))
+            except Exception:  # noqa: BLE001
+                raw = None
             if isinstance(raw, dict):
                 pid = str(raw.get("persona_id") or raw.get("id") or stem)
                 return Persona(
@@ -158,8 +168,10 @@ def _load_playground_persona(repo_root: Path, persona_rel: str | None) -> Person
                     source=str(raw.get("source") or ""),
                     context=str(raw.get("system_prompt") or raw.get("summary") or pid),
                 )
+        catalog = _persona_from_catalog_stem(stem)
+        if catalog is not None:
+            return catalog
     return Persona(id="unknown", name="Persona", source="", context="")
-
 
 def _task_path_from_trial(trial_dir: Path) -> str | None:
     config_path = trial_dir / "config.json"
@@ -540,34 +552,50 @@ def _read_trial_snapshot_doc(trial_dir: Path, filename: str) -> str | None:
     return text or None
 
 
-def _read_trial_task_doc(trial_dir: Path, filename: str, repo_root: Path) -> str | None:
+_TASK_DOC_DETAIL_KEYS = {
+    "task_instruction.md": "instructionMarkdown",
+    "context.md": "contextMarkdown",
+    "questionnaire.md": "questionnaireMarkdown",
+    "output_schema.md": "outputSchemaMarkdown",
+}
+
+
+def _live_task_detail_for_trial(trial_dir: Path, repo_root: Path) -> dict[str, Any] | None:
+    """Load live task detail once per debrief (shared by rail doc readers)."""
+    task_rel = _task_path_from_trial(trial_dir)
+    if not task_rel:
+        return None
+    from backend.service.task_detail_service import get_task_detail
+
+    try:
+        detail = get_task_detail(task_rel, repo_root=repo_root)
+    except (FileNotFoundError, ValueError, OSError):
+        return None
+    return detail if isinstance(detail, dict) else None
+
+
+def _read_trial_task_doc(
+    trial_dir: Path,
+    filename: str,
+    repo_root: Path,
+    *,
+    task_detail: dict[str, Any] | None = None,
+) -> str | None:
     """Read a task doc for debrief rails.
 
     For contributor-facing docs (``context.md``, questionnaire, instruction),
     prefer the live task definition via ``get_task_detail`` so Playground
     reflects authoring edits. Trial snapshots are only a fallback.
     """
-    task_rel = _task_path_from_trial(trial_dir)
-    mapping = {
-        "task_instruction.md": "instructionMarkdown",
-        "context.md": "contextMarkdown",
-        "questionnaire.md": "questionnaireMarkdown",
-        "output_schema.md": "outputSchemaMarkdown",
-    }
-    key = mapping.get(filename)
-    if task_rel and key:
-        from backend.service.task_detail_service import get_task_detail
-
-        try:
-            detail = get_task_detail(task_rel, repo_root=repo_root)
-        except (FileNotFoundError, ValueError, OSError):
-            detail = None
-        if isinstance(detail, dict):
-            value = str(detail.get(key) or "").strip()
-            if value:
-                return value
+    key = _TASK_DOC_DETAIL_KEYS.get(filename)
+    detail = task_detail
+    if detail is None and key:
+        detail = _live_task_detail_for_trial(trial_dir, repo_root)
+    if isinstance(detail, dict) and key:
+        value = str(detail.get(key) or "").strip()
+        if value:
+            return value
     return _read_trial_snapshot_doc(trial_dir, filename)
-
 def _persona_prompt_abs_path(repo_root: Path, persona_rel: str | None) -> str | None:
     if not persona_rel:
         return None
@@ -580,26 +608,24 @@ def _humanize_dimension_key(key: str) -> str:
 
 
 def _format_persona_dimensions_from_yaml(raw: dict[str, Any]) -> str:
-    persona_id = str(raw.get("persona_id") or raw.get("id") or "").strip()
-    source = str(raw.get("source") or "").strip()
-    name = str(raw.get("display_name") or "").strip() or (
-        "persona-{}".format(persona_id) if persona_id else "Persona"
-    )
-    lines = [name]
-    if source:
-        lines.append("Source: {}".format(source))
+    display_name = str(raw.get("display_name") or "").strip()
+    lines: list[str] = []
+    if display_name:
+        lines.append("You are {}.".format(display_name))
+        lines.append("")
     dims = raw.get("dimensions")
     if isinstance(dims, dict) and dims:
-        lines.extend(["", "Profile dimensions"])
+        lines.append("## Who you are")
+        lines.append("")
         for key in sorted(dims.keys()):
             value = dims.get(key)
             if value is None or str(value).strip() == "":
                 continue
             lines.append("- {}: {}".format(_humanize_dimension_key(key), value))
     elif raw.get("system_prompt"):
-        lines.extend(["", str(raw.get("system_prompt")).strip()])
+        lines.append(str(raw.get("system_prompt")).strip())
     elif raw.get("summary"):
-        lines.extend(["", str(raw.get("summary")).strip()])
+        lines.append(str(raw.get("summary")).strip())
     return "\n".join(lines).strip()
 
 
@@ -617,16 +643,18 @@ def _read_persona_yaml_raw(repo_root: Path, persona_rel: str | None) -> dict[str
 def _render_persona_prompt(
     repo_root: Path, persona_rel: str | None, persona: Persona
 ) -> str:
-    raw = _read_persona_yaml_raw(repo_root, persona_rel)
-    if raw:
-        block = _format_persona_dimensions_from_yaml(raw)
-        if block and not _is_thin_persona_prompt(block, persona=persona):
-            return "## Persona\n{}".format(block).strip()
     from playground.user_sim.prompt import render_persona_block
 
     yaml_path = _persona_prompt_abs_path(repo_root, persona_rel)
-    block = render_persona_block(persona, persona_yaml_path=yaml_path)
-    return "## Persona\n{}".format(block).strip()
+    block = render_persona_block(persona, persona_yaml_path=yaml_path).strip()
+    if block and not _is_thin_persona_prompt(block, persona=persona):
+        return block
+    raw = _read_persona_yaml_raw(repo_root, persona_rel)
+    if raw:
+        fallback = _format_persona_dimensions_from_yaml(raw)
+        if fallback and not _is_thin_persona_prompt(fallback, persona=persona):
+            return fallback
+    return block
 
 
 def _is_thin_persona_prompt(text: str, *, persona: Persona) -> bool:
@@ -636,7 +664,9 @@ def _is_thin_persona_prompt(text: str, *, persona: Persona) -> bool:
     if "You are a simulated user with predefined persona attributes" in stripped:
         return True
     body = stripped
-    if body.startswith("## Persona"):
+    if body.startswith("## Who you are"):
+        pass
+    elif body.startswith("## Persona"):
         body = body.split("\n", 1)[1].strip() if "\n" in body else ""
     if not body:
         return True
@@ -712,9 +742,17 @@ def _enrich_debrief_prompts(
 
     task_prompt = str(prompts.get("taskPrompt") or "").strip()
     instruction = _read_trial_instruction_markdown(trial_dir, repo_root)
-    context_markdown = _read_trial_task_doc(trial_dir, "context.md", repo_root)
-    questionnaire_markdown = _read_trial_task_doc(trial_dir, "questionnaire.md", repo_root)
-    output_schema_markdown = _read_trial_task_doc(trial_dir, "output_schema.md", repo_root)
+    # One live task-detail fetch for all rails — avoid 3× questionnaire scans.
+    task_detail = _live_task_detail_for_trial(trial_dir, repo_root)
+    context_markdown = _read_trial_task_doc(
+        trial_dir, "context.md", repo_root, task_detail=task_detail
+    )
+    questionnaire_markdown = _read_trial_task_doc(
+        trial_dir, "questionnaire.md", repo_root, task_detail=task_detail
+    )
+    output_schema_markdown = _read_trial_task_doc(
+        trial_dir, "output_schema.md", repo_root, task_detail=task_detail
+    )
     if instruction:
         if not task_prompt:
             prompts["taskPrompt"] = instruction

--- a/application/playground/backend/service/local_appworld_eval.py
+++ b/application/playground/backend/service/local_appworld_eval.py
@@ -49,7 +49,7 @@ class LocalAppWorldEvalRunner:
             if on_event is not None:
                 on_event(event)
 
-        persona_prompt = "## Persona\n{}".format(render_persona_block(persona).strip())
+        persona_prompt = render_persona_block(persona).strip()
         task_prompt = build_appworld_task_prompt(task)
         prompts = {
             "personaPrompt": persona_prompt,

--- a/application/playground/backend/service/persona_1m_pool.py
+++ b/application/playground/backend/service/persona_1m_pool.py
@@ -919,11 +919,22 @@ def _find_row_by_persona_id(
     persona_id: str,
 ) -> dict[str, Any] | None:
     """Locate one persona by id using cheap source/index matching, then decode."""
+    found = _find_rows_by_persona_ids(paths, codec, [persona_id])
+    return found.get(persona_id.strip())
+
+
+def _find_rows_by_persona_ids(
+    paths: Persona1MPaths,
+    codec,
+    persona_ids: list[str],
+) -> dict[str, dict[str, Any]]:
+    """Locate many personas by id in a single Parquet pass."""
     import pyarrow.parquet as pq
 
-    wanted = persona_id.strip()
+    wanted = {pid.strip() for pid in persona_ids if isinstance(pid, str) and pid.strip()}
     if not wanted:
-        return None
+        return {}
+    found: dict[str, dict[str, Any]] = {}
     for parquet_path in paths.parquet_files:
         parquet = pq.ParquetFile(parquet_path)
         cursor = 0
@@ -933,12 +944,113 @@ def _find_row_by_persona_id(
         ):
             sources = batch.column("source").to_pylist()
             row_indices = batch.column("source_row_index").to_pylist()
+            hits: list[tuple[str, int]] = []
             for local_idx, (source, row_index) in enumerate(zip(sources, row_indices)):
-                if _persona_id(str(source or "unknown"), int(row_index)) == wanted:
-                    decoded = _read_decoded_rows_at(parquet_path, codec, [cursor + local_idx])
-                    return decoded[0] if decoded else None
+                persona_id = _persona_id(str(source or "unknown"), int(row_index))
+                if persona_id in wanted and persona_id not in found:
+                    hits.append((persona_id, cursor + local_idx))
+            if hits:
+                decoded = _read_decoded_rows_at(
+                    parquet_path, codec, [offset for _, offset in hits]
+                )
+                for (persona_id, _), row in zip(hits, decoded):
+                    found[persona_id] = row
+                if len(found) >= len(wanted):
+                    return found
             cursor += len(batch)
-    return None
+    return found
+
+
+def _row_from_cohort_yaml(yaml_path: Path, *, persona_id: str) -> dict[str, Any] | None:
+    try:
+        payload = yaml.safe_load(yaml_path.read_text(encoding="utf-8")) or {}
+    except (OSError, yaml.YAMLError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return {
+        "persona_id": str(payload.get("persona_id") or persona_id),
+        "source": payload.get("source") or "unknown",
+        "dimensions": payload.get("dimensions") or {},
+    }
+
+
+def materialize_production_1m_persona_ids(
+    *,
+    repo_root: Path,
+    persona_ids: list[str],
+    seed: int = 42,
+) -> dict[str, Any]:
+    """Materialize an explicit 1M persona-id selection into a local cohort.
+
+    Playground can preview ids from the HF/Parquet index without on-disk YAML.
+    Harbor launch needs YAML under a cohort pool — this bridges the gap for
+    hand-picked single (or few) personas from ``matraix-persona-1m``.
+    """
+    ordered_ids: list[str] = []
+    seen: set[str] = set()
+    for raw in persona_ids:
+        pid = str(raw or "").strip()
+        if not pid or pid in seen:
+            continue
+        seen.add(pid)
+        ordered_ids.append(pid)
+    if not ordered_ids:
+        raise ValueError("persona_ids must not be empty")
+
+    rows_by_id: dict[str, dict[str, Any]] = {}
+    missing = list(ordered_ids)
+
+    # Prefer already-materialized cohort YAMLs (exact launch artifacts).
+    cohorts_root = repo_root / PRODUCTION_1M_POOL / "cohorts"
+    if cohorts_root.is_dir():
+        still_missing: list[str] = []
+        for pid in missing:
+            hit: dict[str, Any] | None = None
+            for cohort_dir in sorted(cohorts_root.iterdir()):
+                if not cohort_dir.is_dir():
+                    continue
+                yaml_path = cohort_dir / f"persona_{pid}.yaml"
+                if not yaml_path.is_file():
+                    continue
+                hit = _row_from_cohort_yaml(yaml_path, persona_id=pid)
+                if hit is not None:
+                    break
+            if hit is None:
+                still_missing.append(pid)
+            else:
+                rows_by_id[pid] = hit
+        missing = still_missing
+
+    if missing:
+        paths = resolve_1m_paths(repo_root)
+        codec = load_codec(paths.schema_path)
+        found = _find_rows_by_persona_ids(paths, codec, missing)
+        rows_by_id.update(found)
+        missing = [pid for pid in missing if pid not in found]
+
+    if missing:
+        raise ValueError(
+            "unknown persona in matraix-persona-1m: {}".format(", ".join(missing))
+        )
+
+    rows = [rows_by_id[pid] for pid in ordered_ids]
+    cohort = materialize_cohort(
+        repo_root=repo_root,
+        rows=rows,
+        seed=seed,
+        sample_size=len(rows),
+    )
+    return {
+        "pool": cohort["pool"],
+        "matchedCount": len(rows),
+        "sampleSize": len(cohort["personaIds"]),
+        "seed": seed,
+        "personaIds": cohort["personaIds"],
+        "personas": cohort["personas"],
+        "stratifyFields": [],
+        "productionSource": HF_1M_REPO,
+    }
 
 
 def get_production_1m_persona_detail(

--- a/application/playground/backend/service/playground_task_registry.py
+++ b/application/playground/backend/service/playground_task_registry.py
@@ -62,7 +62,6 @@ PLAYGROUND_TASK_INDEX: Dict[str, PlaygroundTaskEntry] = {
         os_app_platform="ios",
         environment_label="use.computer iOS · persona-computer-1",
         output_artifact="decision.json",
-        os_app_submission_profile="ios_news_subscription",
     ),
     "os-app-macos_shortcuts-gallery-picks": PlaygroundTaskEntry(
         application_type="os-app",

--- a/application/playground/backend/service/recommender_eval.py
+++ b/application/playground/backend/service/recommender_eval.py
@@ -118,9 +118,9 @@ def build_recommender_simulation_prompt(
     """Build the application-owned task prompt for a Harbor persona agent."""
     return f"""# Application task prompt: recommender simulation
 
-Harbor supplies the persona system prompt. Use that persona as your identity,
-communication style, preferences, and decision-making style. This application
-supplies only the task-specific simulation prompt below.
+Harbor supplies who you are. Use that identity for your communication style,
+preferences, and decision-making. This application supplies only the
+task-specific prompt below.
 
 You are testing a {domain} recommendation system.
 
@@ -128,9 +128,9 @@ You are testing a {domain} recommendation system.
 
 Goal context: {goal_context_description}
 
-Start by deciding, silently and in character, what kind of {domain} items you
-realistically want and which constraints or personal preferences matter. Do not
-reveal everything at once.
+Start by deciding, silently, what kind of {domain} items you realistically want
+and which constraints or personal preferences matter. Do not reveal everything
+at once.
 
 Interact naturally with the recommender, answer its follow-up questions, push
 back when recommendations do not fit, and stop when you can judge whether the

--- a/application/playground/backend/service/survey_instruction_builder.py
+++ b/application/playground/backend/service/survey_instruction_builder.py
@@ -65,7 +65,7 @@ def render_survey_task_instruction_markdown(instrument: SurveyInstrument) -> str
     goal = blurb or "Answer every required question using the task context and questionnaire."
     return "\n".join(
         [
-            "Answer **{}** as the assigned persona.".format(title),
+            "Answer **{}**.".format(title),
             "",
             goal,
             "",

--- a/application/playground/backend/tests/test_harbor_job_service.py
+++ b/application/playground/backend/tests/test_harbor_job_service.py
@@ -415,7 +415,9 @@ def test_launch_auto_chat_uses_local_distributed_executor(tmp_path, monkeypatch)
     assert env["MATRIX_CHATBOT_TASK_PATH"] == "application/tasks/chat_recai"
     pythonpath = env["PYTHONPATH"].split(":")
     assert str(repo) in pythonpath
+    assert str(repo / "src") in pythonpath
     assert str(repo / "environment" / "runtime") in pythonpath
+    assert str(repo / "environment" / "agents") in pythonpath
     assert str(repo / "packages" / "playground" / "src") in pythonpath
     assert str(repo / "application" / "playground") in pythonpath
     service.shutdown()
@@ -610,6 +612,55 @@ def test_launch_ios_cua_uses_use_computer_environment(tmp_path, monkeypatch):
     assert "type: use-computer" in text
     assert "platform: ios" in text
     assert "cua_backend: ios" in text
+    assert "max_steps: 100" in text
+    assert "max_turns:" not in text
+    service.shutdown()
+
+
+def test_launch_docker_cua_injects_max_turns_not_max_steps(tmp_path, monkeypatch):
+    repo = tmp_path
+    jobs_dir = repo / "jobs"
+    jobs_dir.mkdir()
+    pool = repo / "persona" / "datasets" / "matraix-persona-dev-sample"
+    pool.mkdir(parents=True)
+    (pool / "persona_0020.yaml").write_text(
+        "persona_id: '0020'\nversion: '1.0'\nsource: OASIS\ndimensions: {}\n",
+        encoding="utf-8",
+    )
+    task_dir = repo / "application" / "tasks" / "example-computer-use-linux_note-to-csv"
+    task_dir.mkdir(parents=True)
+    (task_dir / "task.toml").write_text("metadata:\n  type: computer\n", encoding="utf-8")
+
+    def _fake_run(command, *, cwd, env):
+        return 0
+
+    monkeypatch.setattr(
+        "playground.harbor.playground._repo_root",
+        lambda: repo,
+    )
+    service = HarborJobService(
+        repo_root=repo,
+        jobs_dir=jobs_dir,
+        generated_configs_dir=repo / "configs" / "jobs" / "application-task-job-recipe",
+        command_runner=_fake_run,
+        harbor_command=("echo", "harbor"),
+    )
+
+    job_name = service.launch(
+        task_path="application/tasks/example-computer-use-linux_note-to-csv",
+        persona_ids=["0020"],
+        persona_model="anthropic/claude-sonnet-4-6",
+        cua_backend="docker",
+        job_name="docker-cua-job",
+    )
+    assert job_name == "docker-cua-job"
+    text = (
+        repo / "configs" / "jobs" / "application-task-job-recipe" / "docker-cua-job.yaml"
+    ).read_text(encoding="utf-8")
+    assert "type: docker" in text
+    assert "cua_backend: docker" in text
+    assert "max_turns: 100" in text
+    assert "max_steps:" not in text
     service.shutdown()
 
 

--- a/application/playground/backend/tests/test_harbor_playground.py
+++ b/application/playground/backend/tests/test_harbor_playground.py
@@ -4,8 +4,10 @@ from pathlib import Path
 import pytest
 import yaml
 
+from playground.harbor import playground as harbor_playground_module
 from playground.harbor.playground import (
     HarborPlaygroundRunner,
+    _default_harbor_command,
     _harbor_failure_summary,
     build_chatbot_simulation_prompt,
     build_result_from_harbor_artifacts,
@@ -1441,6 +1443,26 @@ def test_harbor_runner_default_command_uses_configured_harbor_command(
         "--frozen",
         "harbor",
     ]
+
+
+def test_default_harbor_command_prefers_project_uv_run_without_venv_script(
+    tmp_path, monkeypatch
+):
+    monkeypatch.delenv("MATRIX_HARBOR_COMMAND", raising=False)
+    monkeypatch.delenv("HARBOR_COMMAND", raising=False)
+    monkeypatch.delenv("MATRIX_HARBOR_BIN", raising=False)
+    monkeypatch.delenv("HARBOR_BIN", raising=False)
+    monkeypatch.setattr(harbor_playground_module, "_repo_root", lambda: tmp_path)
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'demo'\n")
+
+    assert _default_harbor_command() == (
+        "uv",
+        "run",
+        "python",
+        "-m",
+        "harbor.cli.main",
+        "run",
+    )
 
 
 def test_harbor_runner_surfaces_trial_errors_when_artifacts_are_missing(tmp_path):

--- a/application/playground/backend/tests/test_harbor_trial_debrief.py
+++ b/application/playground/backend/tests/test_harbor_trial_debrief.py
@@ -153,7 +153,7 @@ def _write_example_survey_task(repo: Path) -> None:
             [
                 "# Survey Product Feedback",
                 "",
-                "Answer this product-concept survey as the assigned persona.",
+                "Answer this product-concept survey.",
                 "",
                 "You are reacting to FocusLoop. Use the task context, then complete",
                 "every required question in the questionnaire.",
@@ -181,9 +181,9 @@ def test_map_trial_debrief_chatbot_enriches_prompts_from_events(tmp_path: Path) 
         encoding="utf-8",
     )
     prompts = {
-        "personaPrompt": "## Persona\n# Simulated person: 0042\n## Who you are\n\nA detailed persona biography.",
-        "harborPrompt": "## Persona\n# Simulated person: 0042\n## Who you are\n\nA detailed persona biography.\n\n## Task instruction\nStay in character.\n\n## Task context\nThis chatbot helps people discover movies.",
-        "taskPrompt": "## Task instruction\nStay in character.\n\n## Application kickoff\nReveal needs gradually.",
+        "personaPrompt": "You are Casey Brooks.\n\n## Who you are\n\nA detailed biography.",
+        "harborPrompt": "You are Casey Brooks.\n\n## Who you are\n\nA detailed biography.\n\n## Task instruction\nJudge the chatbot honestly.\n\n## Task context\nThis chatbot helps people discover movies.",
+        "taskPrompt": "## Task instruction\nJudge the chatbot honestly.\n\n## Application kickoff\nReveal needs gradually.",
     }
     (trial_dir / "events.jsonl").write_text(
         json.dumps({"type": "prompts", "prompts": prompts}) + "\n",
@@ -195,7 +195,9 @@ def test_map_trial_debrief_chatbot_enriches_prompts_from_events(tmp_path: Path) 
         job_name="job-prompts",
         trial_name="trial-prompts",
     )
-    assert "## Persona" in debrief["prompts"]["personaPrompt"]
+    assert "You are Casey Brooks." in debrief["prompts"]["personaPrompt"]
+    assert "Simulated person" not in debrief["prompts"]["personaPrompt"]
+    assert "## Persona" not in debrief["prompts"]["personaPrompt"]
     assert "Task context" in debrief["prompts"]["harborPrompt"]
     assert "Task instruction" in debrief["prompts"]["taskPrompt"]
     assert debrief["instructionMarkdown"].startswith("# Task instruction")

--- a/application/playground/backend/tests/test_inprocess_survey_prompt.py
+++ b/application/playground/backend/tests/test_inprocess_survey_prompt.py
@@ -78,8 +78,9 @@ def test_persona_system_prompt_renders_dimensions_yaml(tmp_path: Path):
 
     prompt = persona_system_prompt(persona, persona_yaml_path=str(yaml_path))
 
-    assert "## Persona" in prompt
-    assert "Who you are" in prompt or "Simulated person: 0902" in prompt
+    assert "Who you are" in prompt
+    assert "Simulated person" not in prompt
+    assert "## Persona" not in prompt
     assert "65" in prompt or "South Asia" in prompt or "Retirement" in prompt
 
 

--- a/application/playground/backend/tests/test_persona_1m_pool.py
+++ b/application/playground/backend/tests/test_persona_1m_pool.py
@@ -172,6 +172,56 @@ def test_sample_production_1m_materializes_cohort(tmp_path, monkeypatch):
     assert all(card["source"] == "wiki" for card in result["personas"])
 
 
+def test_materialize_production_1m_persona_ids(tmp_path, monkeypatch):
+    release = _write_tiny_release(tmp_path)
+    monkeypatch.setenv(pool_mod.ENV_1M_DIR, str(release))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "persona/schema").mkdir(parents=True)
+    (repo / "persona/schema/dimension_categories.json").write_text(
+        json.dumps({"schemaVersion": "1.0", "personaSources": [], "devProfile": {"groups": []}}),
+        encoding="utf-8",
+    )
+
+    preview = pool_mod.sample_production_1m(
+        repo_root=repo,
+        sample_size=3,
+        seed=11,
+        sources=["wiki"],
+    )
+    target_ids = preview["personaIds"][:2]
+
+    # Drop the sampled cohort so lookup must go through Parquet.
+    import shutil
+
+    shutil.rmtree(repo / preview["pool"])
+
+    result = pool_mod.materialize_production_1m_persona_ids(
+        repo_root=repo,
+        persona_ids=target_ids,
+        seed=11,
+    )
+    assert result["personaIds"] == target_ids
+    assert result["pool"].startswith("persona/datasets/matraix-persona-1m/cohorts/")
+    out = repo / result["pool"]
+    assert (out / "manifest.json").is_file()
+    for persona_id in target_ids:
+        assert (out / f"persona_{persona_id}.yaml").is_file()
+
+
+def test_materialize_production_1m_persona_ids_unknown(tmp_path, monkeypatch):
+    release = _write_tiny_release(tmp_path)
+    monkeypatch.setenv(pool_mod.ENV_1M_DIR, str(release))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    with pytest.raises(ValueError, match="unknown persona"):
+        pool_mod.materialize_production_1m_persona_ids(
+            repo_root=repo,
+            persona_ids=["wiki-does-not-exist"],
+            seed=1,
+        )
+
+
 def test_persona_pool_service_samples_production_1m(tmp_path, monkeypatch):
     release = _write_tiny_release(tmp_path)
     monkeypatch.setenv(pool_mod.ENV_1M_DIR, str(release))

--- a/application/playground/backend/tests/test_remote_runner_dispatch.py
+++ b/application/playground/backend/tests/test_remote_runner_dispatch.py
@@ -46,7 +46,9 @@ def test_run_harbor_job_invokes_command_runner(tmp_path, monkeypatch) -> None:
     assert calls[0]["env"]["MATRIX_SURVEY_TASK_PATH"] == "application/tasks/survey_product-attitudes"
     pythonpath = calls[0]["env"]["PYTHONPATH"].split(":")
     assert str(tmp_path) in pythonpath
+    assert str(tmp_path / "src") in pythonpath
     assert str(tmp_path / "environment" / "runtime") in pythonpath
+    assert str(tmp_path / "environment" / "agents") in pythonpath
     assert str(tmp_path / "packages" / "playground" / "src") in pythonpath
     assert str(tmp_path / "application" / "playground") in pythonpath
 

--- a/application/playground/backend/tests/test_web_submission_materialize.py
+++ b/application/playground/backend/tests/test_web_submission_materialize.py
@@ -1,4 +1,4 @@
-"""Tests for CUA submission extraction and task-agnostic final_answer hand-in."""
+"""Tests for task-agnostic final_answer hand-in helpers."""
 
 from __future__ import annotations
 
@@ -6,52 +6,10 @@ import json
 from types import SimpleNamespace
 
 from matraix.agents.persona.cua_submission import (
-    extract_ecommerce_interaction_from_trajectory,
     extract_final_answer_text,
     materialize_final_answer_file,
     parse_json_payload,
 )
-
-
-def _payload() -> dict[str, object]:
-    return {
-        "selected_product_id": "desk-002",
-        "selected_product_name": "FocusDesk Pro",
-        "need_satisfaction": 8,
-        "ease_of_use": 7,
-        "overall_experience_rating": 6,
-        "reason": (
-            "The FocusDesk Pro matched my workspace needs with drawer storage "
-            "and cable routing for multiple devices."
-        ),
-    }
-
-
-def test_extract_ecommerce_interaction_from_trajectory_message_fence() -> None:
-    trajectory = {
-        "steps": [
-            {
-                "source": "agent",
-                "message": "Summary\n```json\n{}\n```".format(json.dumps(_payload())),
-            }
-        ]
-    }
-    recovered = extract_ecommerce_interaction_from_trajectory(trajectory)
-    assert recovered == _payload()
-
-
-def test_extract_ecommerce_interaction_rejects_short_reason() -> None:
-    bad = dict(_payload())
-    bad["reason"] = "too short"
-    trajectory = {
-        "steps": [
-            {
-                "source": "agent",
-                "message": "```json\n{}\n```".format(json.dumps(bad)),
-            }
-        ]
-    }
-    assert extract_ecommerce_interaction_from_trajectory(trajectory) is None
 
 
 def test_parse_json_payload_uses_first_object_when_agent_keeps_talking() -> None:

--- a/application/playground/frontend/package-lock.json
+++ b/application/playground/frontend/package-lock.json
@@ -1344,6 +1344,7 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/raf": {
@@ -1356,6 +1357,7 @@
       "version": "18.3.31",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1796,6 +1798,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {

--- a/application/playground/frontend/src/components/HarborJobDetail.tsx
+++ b/application/playground/frontend/src/components/HarborJobDetail.tsx
@@ -3,7 +3,7 @@
  */
 import { useId, useMemo, useRef, useState, type ReactNode } from "react";
 import { flushSync } from "react-dom";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { api, ApiError } from "@/lib/api";
 import {
@@ -2698,10 +2698,21 @@ function personaPoolFromPath(personaPath: string | null | undefined): string | n
   if (parts.length < 2) return null;
   const leaf = parts[parts.length - 1] ?? "";
   const parent = parts[parts.length - 2] ?? "";
-  if (/^persona_\d+/i.test(leaf) || leaf.endsWith(".yaml") || leaf.endsWith(".yml")) {
-    return parent || null;
+  const isPersonaFile =
+    /^persona_/i.test(leaf) || leaf.endsWith(".yaml") || leaf.endsWith(".yml");
+  if (!isPersonaFile) {
+    return parent || leaf || null;
   }
-  return parent || leaf || null;
+  // .../<dataset>/cohorts/cohort-<id>/persona_*.yaml → keep both dataset and cohort
+  if (
+    parent.startsWith("cohort-") &&
+    parts.length >= 4 &&
+    parts[parts.length - 3] === "cohorts"
+  ) {
+    const dataset = parts[parts.length - 4] ?? "";
+    return dataset ? `${dataset} · ${parent}` : parent;
+  }
+  return parent || null;
 }
 
 function readPersonaPool(config: Record<string, unknown> | null): string | null {
@@ -2957,7 +2968,7 @@ function BatchReportMetaByline({ meta }: { meta: BatchReportPdfMeta }) {
     facts.push({
       label: "Dataset",
       value: meta.personaPool,
-      title: "Persona pool actually used",
+      title: "Source dataset and cohort actually used for this job",
     });
   }
   if (personasRun > 0) {
@@ -5492,6 +5503,7 @@ function MetricLine({ label, value }: { label: string; value: string }) {
 }
 
 export function HarborJobDetail({ jobName, onBack, onOpenTrial }: HarborJobDetailProps) {
+  const queryClient = useQueryClient();
   const query = useQuery<HarborJobDetail>({
     queryKey: ["harbor-job", jobName],
     queryFn: () => api.getHarborJob(jobName),
@@ -5557,6 +5569,14 @@ export function HarborJobDetail({ jobName, onBack, onOpenTrial }: HarborJobDetai
     if (aggregationQuery.isEnabled) {
       void aggregationQuery.refetch();
     }
+  };
+  const prefetchTrialDebrief = (trialName: string) => {
+    if (!onOpenTrial) return;
+    void queryClient.prefetchQuery({
+      queryKey: ["harbor-trial-debrief", jobName, trialName],
+      queryFn: () => api.getHarborTrialDebrief(jobName, trialName),
+      staleTime: 60_000,
+    });
   };
 
   return (
@@ -5705,7 +5725,12 @@ export function HarborJobDetail({ jobName, onBack, onOpenTrial }: HarborJobDetai
                       <button
                         type="button"
                         disabled={!clickable}
-                        onClick={() => onOpenTrial?.(trial.trialName)}
+                        onPointerEnter={() => prefetchTrialDebrief(trial.trialName)}
+                        onFocus={() => prefetchTrialDebrief(trial.trialName)}
+                        onClick={() => {
+                          prefetchTrialDebrief(trial.trialName);
+                          onOpenTrial?.(trial.trialName);
+                        }}
                         className={`grid w-full grid-cols-[minmax(0,1.4fr)_minmax(0,1.2fr)_5.5rem_2rem] items-center gap-3 px-4 py-3 text-left text-[15px] ${
                           clickable ? "hover:bg-surface/40" : ""
                         } ${FOCUS_RING}`}

--- a/application/playground/frontend/src/components/RunDetail.tsx
+++ b/application/playground/frontend/src/components/RunDetail.tsx
@@ -95,6 +95,7 @@ export function RunDetail({ harborTrial, onBack }: RunDetailProps) {
   const query = useQuery<PlaygroundResult>({
     queryKey: ["harbor-trial-debrief", harborTrial.jobName, harborTrial.trialName],
     queryFn: () => api.getHarborTrialDebrief(harborTrial.jobName, harborTrial.trialName),
+    staleTime: 60_000,
   });
 
   const run = useMemo(() => (query.data ? asRunDetail(query.data) : null), [query.data]);

--- a/application/playground/frontend/src/components/cockpit/OsAppEvalCockpit.tsx
+++ b/application/playground/frontend/src/components/cockpit/OsAppEvalCockpit.tsx
@@ -847,7 +847,7 @@ function OsAppResults({
             <p className="text-[12px] text-text-variant">{task.description}</p>
           </div>
         )}
-        {hasLiveView && (
+        {hasLiveView ? (
           <section
             ref={liveViewRef}
             className={
@@ -888,6 +888,10 @@ function OsAppResults({
               </div>
             )}
           </section>
+        ) : (
+          // Docker Linux has no published VNC / use.computer screenshot — still
+          // show the polled trajectory steps so single-trial runs are not a blank pane.
+          <div className="min-h-0 flex-1">{stepsPanel}</div>
         )}
       </div>
     );

--- a/application/playground/frontend/src/components/cockpit/WebEvalCockpit.tsx
+++ b/application/playground/frontend/src/components/cockpit/WebEvalCockpit.tsx
@@ -284,7 +284,8 @@ export function WebEvalCockpit({
           );
         }
       } catch {
-        // trajectory.json is written once near the end of a Cocoa run
+        // trajectory.json is flushed mid-run for computer-1 / browser-use / Cocoa /
+        // OpenHands; keep polling until the first checkpoint appears.
       }
     };
 

--- a/application/playground/frontend/src/components/cockpit/setup/cockpitPersonaSetupStorage.ts
+++ b/application/playground/frontend/src/components/cockpit/setup/cockpitPersonaSetupStorage.ts
@@ -9,10 +9,17 @@ import {
   type PersonaSamplingMode,
 } from "./personaSamplingTypes";
 
+/** Legacy pool slug renamed to matraix-persona-dev-sample (directory removed). */
+const LEGACY_BENCH_DEV_SAMPLE = "persona/datasets/bench-dev-sample";
+
 /** Drop legacy synthetic strategy pools from restored setup. */
 export function sanitizePersonaPool(pool: string | null | undefined): string {
   const text = (pool ?? "").trim();
   if (!text || text.includes("/_generated/")) return PERSONA_BENCH_POOL;
+  // Old cockpit / task setups still point at the removed bench-dev-sample path.
+  if (text === LEGACY_BENCH_DEV_SAMPLE || text.endsWith("/bench-dev-sample")) {
+    return PERSONA_BENCH_POOL;
+  }
   return text;
 }
 

--- a/application/playground/frontend/src/lib/exportBatchReportPdf.ts
+++ b/application/playground/frontend/src/lib/exportBatchReportPdf.ts
@@ -755,6 +755,7 @@ export function formatBatchReportMetaLines(meta: BatchReportPdfMeta): string[] {
   const lines: string[] = [];
   lines.push(`Job: ${meta.jobName}`);
   if (meta.taskTitle || meta.taskPath) lines.push(`Task: ${meta.taskTitle || meta.taskPath}`);
+  if (meta.personaPool) lines.push(`Dataset: ${meta.personaPool}`);
   if (meta.agentModel) lines.push(`Agent model: ${meta.agentModel}`);
   if (meta.parallelism != null) lines.push(`Parallelism: ${meta.parallelism}`);
   if (meta.personas?.length) lines.push(`Personas: ${meta.personas.length}`);

--- a/application/playground/frontend/src/lib/fallbackTasks.ts
+++ b/application/playground/frontend/src/lib/fallbackTasks.ts
@@ -40,7 +40,6 @@ export const FALLBACK_WEB_TASKS: WebEvalTask[] = [
     description: "Browse books.toscrape.com with screenshot-based computer use in Docker and choose one book.",
     taskPath: "application/tasks/example-web-cua_bookshop-choice",
     outputArtifact: "book_interest.json",
-    submissionProfile: "book_interest",
   },
 ];
 


### PR DESCRIPTION
## Summary
- Update matraix playground job service, trial debrief, and related playground backend services
- Refresh web/OS-app cockpits, persona setup storage, and batch report export
- Keep backend tests aligned with the new job/debrief behavior

## Test plan
- [ ] Load Playground UI and open a matraix playground job detail / run detail view
- [ ] Smoke web and OS-app cockpits for persona setup + launch path
- [ ] Run affected backend tests under `application/playground/backend/tests`


Made with [Cursor](https://cursor.com)