### PR TITLE
application: colocate task-spec deep dives under application/task-spec/docs

### DIFF
--- a/application/task-spec/README.md
+++ b/application/task-spec/README.md
@@ -7,7 +7,7 @@ comparable, and reportable across tasks.
 
 **Start here if you are adding or editing a task under `application/tasks/`.**
 Operational copy-paste steps also live in
-[`../tasks/README.md`](../tasks/README.md) and [`task-guide.md`](../../docs/guides/task-guide.md);
+[`../tasks/README.md`](../tasks/README.md) and [`task-guide.md`](../../docs/application/task-guide.md);
 this document explains *why* the files exist and *how* they connect.
 
 ---
@@ -24,10 +24,10 @@ this document explains *why* the files exist and *how* they connect.
 | Kind of doc | Examples | You read it to… |
 |---|---|---|
 | **Onboarding** | this README | Follow the path + see big-picture diagrams below |
-| **File layouts** | [authoring-bundle.md](../../docs/task-spec/authoring-bundle.md) | Per-type file trees |
+| **File layouts** | [authoring-bundle.md](docs/authoring-bundle.md) | Per-type file trees |
 | **Type contract** | `survey/`, `chatbot/`, `web/`, `os-app/` README | **Per-type diagram** + metric detail |
-| **Cheat sheets** | [structured-output-quick-reference.md](../../docs/task-spec/structured-output-quick-reference.md) | Verifier context/facet keys |
-| **Deep reference** | [reporting-and-evaluation.md](../../docs/task-spec/reporting-and-evaluation.md) | Aggregation internals |
+| **Cheat sheets** | [structured-output-quick-reference.md](docs/structured-output-quick-reference.md) | Verifier context/facet keys |
+| **Deep reference** | [reporting-and-evaluation.md](docs/reporting-and-evaluation.md) | Aggregation internals |
 | **Copy-from** | `example-*` tasks, `*.example.json` | Start from working code |
 
 ---
@@ -139,7 +139,7 @@ need it.
 choose **web**. If the benchmark is **settings, files, mail, calendar, or
 cross-app operating work**, choose **os-app** — even when a browser appears
 along the way. Decision guide + shared facet keys:
-[shared-core-metrics.md](../../docs/task-spec/shared-core-metrics.md).
+[shared-core-metrics.md](docs/shared-core-metrics.md).
 
 Copy the closest `example-*` sibling, then rename the folder under
 `application/tasks/<your-task-name>/`.
@@ -158,14 +158,14 @@ and **`reporting.json`**. Supplementary files depend on type:
 | Scenario prose | `instruction.md` | `instruction.md` | `instruction.md` |
 | Background / product context | `input/context.md` | `input/context.md` | `input/context.md` (optional) |
 | Structured task input | `input/questionnaire.yaml` (includes `askRationale` / `askConfidence`) | `input/chatbot.yaml`, optional `input/protocol.md` | — |
-| Objective evidence / harness | platform writes `survey_result.json` + trajectory | platform-managed ([chatbot/eval_artifacts.md](../../docs/task-spec/eval_artifacts.md)) | prefer trace/state; optional agent submission inline in `instruction.md` |
+| Objective evidence / harness | platform writes `survey_result.json` + trajectory | platform-managed ([chatbot/eval_artifacts.md](docs/eval_artifacts.md)) | prefer trace/state; optional agent submission inline in `instruction.md` |
 | Persona self-report | — | `input/self_report_schema.yaml` | `input/self_report_schema.yaml` (optional) |
 | Batch policy stub | `reporting.json` | `reporting.json` | `reporting.json` |
 | Target cohort / sampling | `persona_strategy.json` | `persona_strategy.json` | `persona_strategy.json` |
 
 Per-type folder trees, `persona_strategy.json` schema, and edge cases:
-[authoring-bundle.md](../../docs/task-spec/authoring-bundle.md). Harbor metadata (`task.toml`,
-timeouts, `[environment].definition`): see [`task-guide.md`](../../docs/guides/task-guide.md).
+[authoring-bundle.md](docs/authoring-bundle.md). Harbor metadata (`task.toml`,
+timeouts, `[environment].definition`): see [`task-guide.md`](../../docs/application/task-guide.md).
 
 **Authoring rules that matter early:**
 
@@ -175,7 +175,7 @@ timeouts, `[environment].definition`): see [`task-guide.md`](../../docs/guides/t
   and/or `cohortId`, stratify axes, optional `sampleSize`) — not under `input/`.
   Playground applies them under Random / Stratified; operators can turn the task
   default off and edit filters. Schema:
-  [authoring-bundle.md § persona_strategy.json](../../docs/task-spec/authoring-bundle.md#persona_strategyjson).
+  [authoring-bundle.md § persona_strategy.json](docs/authoring-bundle.md#persona_strategyjson).
 - Put **scenario and product background** in `input/context.md` for every task
   type when it helps; keep `instruction.md` focused on goals, steps, and schemas.
 - Keep **operator setup** (agent names, smoke commands) in the task's own
@@ -214,11 +214,11 @@ rename shared keys to fit one scenario.
 |---|---|
 | Survey | `question_response` (per question), `trial_summary` |
 | Chatbot | `task_outcome`, `conversation_summary`, `user_feedback` when self-report exists |
-| Web | shared core ([shared-core-metrics.md](../../docs/task-spec/shared-core-metrics.md)) + `decision` / `decision_process` for browse/choose tasks |
+| Web | shared core ([shared-core-metrics.md](docs/shared-core-metrics.md)) + `decision` / `decision_process` for browse/choose tasks |
 | OS / app | shared core + scenario-specific artifact or handoff contexts |
 
 Context/facet cheat sheet and JSON templates:
-[structured-output-quick-reference.md](../../docs/task-spec/structured-output-quick-reference.md).
+[structured-output-quick-reference.md](docs/structured-output-quick-reference.md).
 
 ---
 
@@ -242,7 +242,7 @@ Layer 1 still runs. Add `contextRules[]` when you want semantic summaries (for
 example "summarize `reason` grouped by `response`" on survey questions).
 
 End-to-end flow, Layer 1 internals, Layer 2 directives, and template index:
-[reporting-and-evaluation.md](../../docs/task-spec/reporting-and-evaluation.md).
+[reporting-and-evaluation.md](docs/reporting-and-evaluation.md).
 
 **Do not** hide reporting policy inside verifier code. The verifier writes
 **facts**; `reporting.json` declares **optional extra analysis**.
@@ -251,9 +251,9 @@ End-to-end flow, Layer 1 internals, Layer 2 directives, and template index:
 
 ### Step 5 — Smoke, batch, debrief
 
-1. **Smoke one persona** — [`quickstart.md`](../../docs/guides/quickstart.md)
+1. **Smoke one persona** — [`quickstart.md`](../../docs/quickstart.md)
 2. **Launch a batch job** — [`../tasks/README.md`](../tasks/README.md),
-   [Job Generation Scripts](../../docs/application.md#job-generation-scripts)
+   [Job Generation Scripts](../../docs/application/README.md)
 3. **Review aggregation** — Playground **Runs** UI or `report_job.py`
 
 Iterate on `instruction.md` / verifier until smoke passes, then scale personas.
@@ -270,7 +270,7 @@ Iterate on `instruction.md` / verifier until smoke passes, then scale personas.
 | **Verifier output** | `verifier/structured_output.json` | Author (`tests/`) | Normalized evaluation facts for one trial |
 | **Batch policy** | `reporting.json` | Author | Optional Layer 2 aggregation rules |
 | **Job summary** | `aggregation.json` | Platform | Cross-trial stats + optional LLM units |
-| **Persona profile** | `persona/datasets/*` | Persona team | Who the simulated user is |
+| **Persona profile** | `persona/datasets/*` | Dataset / release | Who the simulated user is |
 
 ---
 
@@ -284,7 +284,7 @@ ratings:
 3. Verifier maps into a `user_feedback` **context** in `structured_output.json`
 
 Shared facet names (`overall_experience_rating`, `trust_level`, …) live in
-[shared-core-metrics.md § Shared subjective channel](../../docs/task-spec/shared-core-metrics.md#shared-subjective-channel-interactive-tasks).
+[shared-core-metrics.md § Shared subjective channel](docs/shared-core-metrics.md#shared-subjective-channel-interactive-tasks).
 Family-specific slices (`experience` on web, conversation-only chatbot fields)
 **add on top** — they do not replace `user_feedback`.
 
@@ -296,7 +296,7 @@ The persona agent only sees the **protocol surface** for the task type (survey
 instrument, chat loop, browser/computer-use API, OS surface). Internal APIs,
 databases, and health checks belong to setup, reset, and verifier logic — not
 the agent's reachable interface. Full statement:
-[runtime-boundary.md](../../docs/task-spec/runtime-boundary.md).
+[runtime-boundary.md](docs/runtime-boundary.md).
 
 ---
 
@@ -306,29 +306,29 @@ Use this when a step above is not enough — not as a flat reading list.
 
 **Authoring & folder layout**
 
-- [authoring-bundle.md](../../docs/task-spec/authoring-bundle.md) — per-type file trees + `persona_strategy.json`
+- [authoring-bundle.md](docs/authoring-bundle.md) — per-type file trees + `persona_strategy.json`
 - [survey/README.md](survey/README.md) — `questionnaire.yaml` contract
 - [chatbot/README.md](chatbot/README.md) — chat loop + reporting contexts
-- [chatbot/eval_artifacts.md](../../docs/task-spec/eval_artifacts.md) — platform-managed chat artifacts
+- [chatbot/eval_artifacts.md](docs/eval_artifacts.md) — platform-managed chat artifacts
 - [web/README.md](web/README.md) — browser metrics + persona-sensitive browse tasks
 - [os-app/README.md](os-app/README.md) — outcome-based OS benchmarks
 
 **Evaluation & metrics**
 
-- [structured-output-quick-reference.md](../../docs/task-spec/structured-output-quick-reference.md) — contexts, facets, example JSON paths
-- [shared-core-metrics.md](../../docs/task-spec/shared-core-metrics.md) — web/os shared core + subjective channel
+- [structured-output-quick-reference.md](docs/structured-output-quick-reference.md) — contexts, facets, example JSON paths
+- [shared-core-metrics.md](docs/shared-core-metrics.md) — web/os shared core + subjective channel
 - `shared_core_metric_contract.example.json` — machine-readable shared core
 
 **Reporting & jobs**
 
-- [reporting-and-evaluation.md](../../docs/task-spec/reporting-and-evaluation.md) — Layer 1/2, mermaid flows, `contextRules`
+- [reporting-and-evaluation.md](docs/reporting-and-evaluation.md) — Layer 1/2, mermaid flows, `contextRules`
 - [`../tasks/README.md`](../tasks/README.md) — reporting policy examples, operational notes
 
 **Repo layout & operations**
 
-- [`task-guide.md`](../../docs/guides/task-guide.md) — `task.toml`, environments, verifier layout
-- [`quickstart.md`](../../docs/guides/quickstart.md) — first end-to-end run
-- [`choosing-an-agent.md`](../../docs/guides/choosing-an-agent.md) — agent + API keys
+- [`task-guide.md`](../../docs/application/task-guide.md) — `task.toml`, environments, verifier layout
+- [`quickstart.md`](../../docs/quickstart.md) — first end-to-end run
+- [`agents.md`](../../docs/environment/agents.md) — agent + API keys
 
 ---
 
@@ -339,8 +339,8 @@ Use this when a step above is not enough — not as a flat reading list.
 - [ ] `task.toml` `[metadata].type` matches the contract folder you followed
 - [ ] Verifier emits `structured_output.json` with shared context names where applicable
 - [ ] `reporting.json` exists (empty `contextRules` is fine)
-- [ ] `persona_strategy.json` at task root with a target cohort (`dimensionFilters` and/or `cohortId`; see [authoring-bundle.md](../../docs/task-spec/authoring-bundle.md#persona_strategyjson))
-- [ ] If strategy filters are narrower than `matraix-persona-dev-sample` coverage, sample from `matraix-persona-1m`, widen filters, or use a saved cohort (see [authoring-bundle.md](../../docs/task-spec/authoring-bundle.md#ensuring-pool-coverage))
+- [ ] `persona_strategy.json` at task root with a target cohort (`dimensionFilters` and/or `cohortId`; see [authoring-bundle.md](docs/authoring-bundle.md#persona_strategyjson))
+- [ ] If strategy filters are narrower than `matraix-persona-dev-sample` coverage, sample from `matraix-persona-1m`, widen filters, or use a saved cohort (see [authoring-bundle.md](docs/authoring-bundle.md#ensuring-pool-coverage))
 - [ ] Interactive tasks: `self_report_schema.yaml` → `user_feedback` context when used
 - [ ] Smoke run passes on at least one persona before batch scale-up
 - [ ] Multi-persona batch validation: attach the **Playground UI** batch PDF
@@ -354,14 +354,10 @@ Use this when a step above is not enough — not as a flat reading list.
 ## This directory at a glance
 
 ```text
-task-spec/
-├── README.md                          ← you are here (diagrams + onboarding)
+application/task-spec/
+├── README.md
+├── docs/                     authoring, reporting, metrics, …
+├── survey/ chatbot/ web/ os-app/
 ├── manifest.json
-├── survey/   chatbot/   web/   os-app/   ← type contracts + example JSON
 └── shared_core_metric_contract.example.json
-
-Deep-dive guides now live in the handbook under `docs/task-spec/`:
-authoring-bundle.md, reporting-and-evaluation.md,
-structured-output-quick-reference.md, shared-core-metrics.md,
-runtime-boundary.md, eval_artifacts.md.
 ```

--- a/application/task-spec/chatbot/README.md
+++ b/application/task-spec/chatbot/README.md
@@ -51,7 +51,7 @@ flowchart TB
 | `policy_and_trust`, `coordination` | Optional depth |
 
 **Do not** add per-task `output_schema.md` — platform owns harness artifacts in
-[`eval_artifacts.md`](../../../docs/task-spec/eval_artifacts.md).
+[`eval_artifacts.md`](../docs/eval_artifacts.md).
 
 ## Contract
 
@@ -88,7 +88,7 @@ supplementary materials under `input/`:
   for `user_feedback.json`
 
 Platform-managed eval artifacts (`transcript.json`, `application_result.json`) are
-documented in [`eval_artifacts.md`](../../../docs/task-spec/eval_artifacts.md). Chatbot tasks do **not**
+documented in [`eval_artifacts.md`](../docs/eval_artifacts.md). Chatbot tasks do **not**
 use per-task `input/output_schema.md`; subjective feedback is owned by
 `self_report_schema.yaml`.
 

--- a/application/task-spec/docs/authoring-bundle.md
+++ b/application/task-spec/docs/authoring-bundle.md
@@ -1,0 +1,144 @@
+# Authoring bundle
+
+Onboarding and diagrams: [`../README.md`](../README.md).
+
+Per-type file layouts for tasks under `application/tasks/<task-name>/`.
+Part of [task-spec README](../README.md) **Step 2**. Per-type **diagrams** are in each
+type README ([survey](../survey/README.md), [chatbot](../chatbot/README.md),
+[web](../web/README.md), [os-app](../os-app/README.md)).
+
+Each runnable task lives under `application/tasks/<task-name>/` and always
+includes `instruction.md`, `task.toml`, `tests/`, `reporting.json`, and
+`persona_strategy.json` (target cohort / Playground sampling defaults).
+Supplementary files differ by application type:
+
+### Survey
+
+```text
+instruction.md                 # short scenario / requirements
+reporting.json                 # batch aggregation policy (contextRules)
+persona_strategy.json          # target cohort + Playground sampling defaults
+input/
+  context.md                   # product concept (optional)
+  questionnaire.yaml           # questions + askRationale / askConfidence
+```
+
+Do **not** add `input/output_schema.md`. The platform derives the answer
+envelope from `questionnaire.yaml` and writes `survey_result.json`.
+
+### Chatbot
+
+```text
+instruction.md                 # conversation goal
+reporting.json                 # batch aggregation policy (contextRules)
+persona_strategy.json          # target cohort + Playground sampling defaults
+input/
+  context.md                   # application background (optional)
+  protocol.md                  # chat API / MCP contract (optional)
+  chatbot.yaml                 # runtime connection metadata
+  self_report_schema.yaml      # user_feedback.json
+```
+
+Platform-managed harness artifacts (`transcript.json`,
+`application_result.json`) are documented in
+[`eval_artifacts.md`](eval_artifacts.md), not in per-task files.
+
+### Web / OS-app
+
+```text
+instruction.md                 # task goal, steps, optional submission JSON schema
+reporting.json                 # batch aggregation policy (contextRules)
+persona_strategy.json          # target cohort + Playground sampling defaults
+input/
+  context.md                   # scenario / product background (optional)
+  self_report_schema.yaml      # user_feedback.json (optional)
+```
+
+Prefer verifying from browser/OS traces and final state. When state is hard to
+read, an agent submission schema may still live inline in `instruction.md`.
+Persona self-report uses the same `input/self_report_schema.yaml` convention as
+chatbot tasks.
+
+### Quick reference
+
+| Concern | survey | chatbot | web / os-app |
+|---|---|---|---|
+| Scenario | `instruction.md` | `instruction.md` | `instruction.md` |
+| Background context | `input/context.md` | `input/context.md` | `input/context.md` (optional) |
+| Structured input | `input/questionnaire.yaml` | `input/chatbot.yaml`, optional `protocol.md` | — |
+| Objective evidence | platform `survey_result.json` | platform harness artifacts | trace/state (optional agent submission) |
+| Persona self-report | — | `input/self_report_schema.yaml` | `input/self_report_schema.yaml` |
+| Batch reporting policy | `reporting.json` | `reporting.json` | `reporting.json` |
+| Target cohort / sampling | `persona_strategy.json` | `persona_strategy.json` | `persona_strategy.json` |
+
+### `persona_strategy.json`
+
+Lives at the **task root** next to `reporting.json`. Most tasks declare a
+**target cohort** with `dimensionFilters` (and/or `cohortId`). Field values may
+use defaults; the file itself and a cohort declaration are checked in CI.
+
+Playground uses this for Random / Stratified (and optional Quick pick) defaults.
+
+```json
+{
+  "schemaVersion": "1.0",
+  "defaultMode": "stratified",
+  "pool": "persona/datasets/matraix-persona-dev-sample",
+  "sources": ["Nemotron"],
+  "dimensionFilters": {
+    "age_bracket": ["25-34", "35-44"],
+    "region": ["North America"]
+  },
+  "stratifyFields": ["age_bracket", "region"],
+  "sampleSizePerValueGroup": 2,
+  "cohortId": null
+}
+```
+
+| Field | Notes |
+|---|---|
+| `schemaVersion` | Use `"1.0"` |
+| `defaultMode` | `single` \| `random` \| `stratified` |
+| `dimensionFilters` / `cohortId` | Non-empty filters and/or a saved `cohortId` — who this task is for |
+| `sources` | Optional source allow-list |
+| `stratifyFields` | Needed when `defaultMode` is `stratified`. **Every** stratify field must also appear under `dimensionFilters` with allowed values (so cell coverage is well-defined). |
+| `sampleSizePerValueGroup` | **Stratified strategy A (per-cell):** take **N per combination**. Total = `N × (# cells)`. **Do not also set `sampleSize`.** |
+| `sampleSize` | Random: hard sample count. **Stratified strategy B (total N):** spread as `ceil(sampleSize / #cells)` then clip to `sampleSize`. Must be **≥ # cells**. **Do not also set `sampleSizePerValueGroup`.** |
+| `cohortId` | Optional saved cohort under `persona/datasets/cohorts/` |
+| `pool` | Defaults to matraix-persona-dev-sample |
+
+**Stratified sampling — two mutually exclusive strategies:**
+
+| Strategy | Set this | Omit this | Cohort size |
+|---|---|---|---|
+| Per-cell | `sampleSizePerValueGroup` | `sampleSize` | `N × #cells` |
+| Total N | `sampleSize` | `sampleSizePerValueGroup` | exactly `sampleSize` |
+
+1. Thin / missing cells → sample from `matraix-persona-1m`, widen
+   `dimensionFilters` / sources, or use a saved cohort — sampling never
+   synthesizes personas.
+2. Per-cell: guarantee N in each cell; total follows from the grid.
+3. Total N: guarantee `ceil(sampleSize / #cells)` capacity per cell, sample,
+   clip to `sampleSize`. Author `sampleSize` ≥ # cells.
+4. Setting **both** fields is invalid (CI / Playground reject the strategy).
+
+Playground turns on **Task default strategy** from this file (filters / mode /
+per-cell N / sampleSize locked to the file). Operators can turn that switch off
+to edit filters themselves, then turn it back on to re-apply the task default.
+
+### Ensuring pool coverage
+
+`persona/datasets/matraix-persona-dev-sample/` is a small ~200-persona fixture for
+smoke and local UI work. Narrow `dimensionFilters` (and stratified cells) often
+undershoot it.
+
+**When coverage fails**, do one of:
+
+1. Sample from production: set `"pool"` to `persona/datasets/matraix-persona-1m`
+   (or choose that pool in Playground).
+2. Widen `dimensionFilters` / `sources` until the fixture (or 1M) has enough matches.
+3. Use a saved cohort under `persona/datasets/cohorts/` that already has enough
+   personas.
+
+Playground / job launch **does not** auto-synthesize `_generated` pools. Thin
+coverage raises an error with the same recovery hint.

--- a/application/task-spec/docs/eval_artifacts.md
+++ b/application/task-spec/docs/eval_artifacts.md
@@ -1,0 +1,149 @@
+# Chatbot eval artifacts (platform-managed)
+
+Playground **auto / host / user-sim** runs produce two artifact roots:
+
+| Root | Writer | Purpose |
+|------|--------|---------|
+| `/app/output/` | Harness / sidecar | Conversation trace and eval-run summary |
+| `verifier/` | Task verifier (`tests/test_state.py` or `tests/test.sh`) | Pass/fail and structured trial evaluation |
+
+Neither root is a SUT API contract and neither is a task-author output
+responsibility beyond implementing the verifier. The harness and verifier
+produce these files for traceability, UI debrief, and downstream scoring.
+
+Task `instruction.md` files describe **how to interact with the chatbot** only.
+They should not ask the agent to save files under `/app/output/` — harness and
+verifier artifacts are platform-managed (below).
+
+## Where `/app/output/` lives
+
+`/app/output/` is Harbor's **logical container path**, not necessarily a literal
+directory on the host.
+
+| Environment | Resolved path |
+|-------------|---------------|
+| Docker trial | `/app/output/` inside the main container |
+| Host trial (`user_sim_chat`) | `jobs/<job>/<trial>/artifacts/app/output/` |
+
+Harbor rewrites `/app/output/...` in shell commands to the resolved path. The
+verifier reads the same directory through `PLAYGROUND_OUTPUT_DIR` /
+`MATRIX_OUTPUT_DIR`, which the host environment sets to that mapped location.
+
+Collected artifacts also appear under `jobs/<job>/<trial>/artifacts/app/output/`
+after a trial completes.
+
+## Playground auto / user-sim writes harness artifacts
+
+Playground chat jobs use the **`persona-user-sim`** agent (`user_sim_chat`
+trial profile). That agent drives the multi-turn chat loop and **automatically
+writes** harness artifacts after the conversation:
+
+- `transcript.json` — fetched from the sidecar/API and normalized
+- `application_result.json` — slim eval-run summary
+- `user_feedback.json` — persona self-report from `input/self_report_schema.yaml`
+
+The agent does not read task `instruction.md` for artifact I/O. Manual save steps
+in older instructions were redundant for this path and have been removed from
+chatbot tasks.
+
+Non–user-sim agents (for example manual `curl` smoke runs) may still need to
+write `/app/output/` themselves; on host trials the path is rewritten as above.
+
+## Where `verifier/` lives
+
+In a normal Harbor trial:
+
+`jobs/<job>/<trial>/verifier/`
+
+Harbor sets `HARBOR_VERIFIER_DIR` to that path before running the verifier.
+Playground reads `verifier/structured_output.json` and `verifier/reward.txt`
+from the trial directory for debrief and aggregation.
+
+When running a verifier locally outside Harbor, the task falls back to
+`<task-root>/verifier/` if `/logs/verifier` cannot be created. Do **not**
+commit these directories; they are runtime output. If you run a verifier from
+the repo root without setting `HARBOR_VERIFIER_DIR`, a stray `./verifier/` may
+appear at the cwd — delete it or rerun from the task folder.
+
+## Harness artifacts (`/app/output/`)
+
+### `transcript.json`
+
+Conversation record for the trial. Includes user/assistant turns and any structured
+fields the task exposes via `input/chatbot.yaml` `structuredExposure.fields[]`
+(list capability id `structured_exposure` in `capabilities`; it is also
+auto-added when those fields exist; selectors are the source of truth for
+concrete field names).
+
+Harness may stamp run metadata on the root object:
+
+- `sessionId`: eval session handle (from the sidecar/API when available, otherwise harness-generated)
+- `applicationId`: configured application under test
+- `applicationContext`: configured scenario label
+
+Task-specific structured data (tool plans, persona-visible sidecars, etc.) live on
+individual turns in `transcript.json`, not in `application_result.json`.
+
+### `application_result.json`
+
+Slim **eval-run summary** written by the Playground harness after the chat loop:
+
+| Field | Meaning |
+|-------|---------|
+| `sessionId` | Same session handle as `transcript.json` |
+| `applicationId` | Configured application id for this run |
+| `applicationContext` | Configured scenario / context label |
+| `turnCount` | Number of completed user/assistant turns |
+
+Do **not** add SUT-specific fields here. Objective task metrics belong in
+`verifier/structured_output.json` (below); subjective feedback belongs in
+`user_feedback.json` (see task `input/self_report_schema.yaml`).
+
+### `user_feedback.json`
+
+Written by the persona self-report step when the task defines
+`input/self_report_schema.yaml`. Field semantics live in that YAML file.
+
+Common fields across chatbot tasks:
+
+| Field | Meaning |
+|-------|---------|
+| `needConstraintSatisfaction` | `yes` / `partially` / `no` |
+| `personalPreferenceSatisfaction` | `yes` / `partially` / `no` |
+| `overallExperienceRating` | integer 1–10 |
+| `reason` | short persona-voice explanation |
+| `askedUsefulClarificationQuestions` | boolean |
+| `clarifyingNotes` | which clarifications helped, or why not |
+| `trustLevel` | optional integer 1–10 |
+| `feltUnderstood` | optional boolean |
+
+The task verifier reads this file and copies normalized facets into
+`verifier/structured_output.json` under a `user_feedback` context (for example
+`clarification_questions_useful`, `feedback_reason`, `trust_level`) per the
+[`README.md`](../chatbot/README.md) reporting contract.
+
+## Verifier artifacts (`verifier/`)
+
+Written after the trial by the task verifier. Common files:
+
+| File | Meaning |
+|------|---------|
+| `reward.txt` | `1` = verifier passed, `0` = failed |
+| `structured_output.json` | Structured trial evaluation for reporting and UI debrief |
+| `test-stdout.txt` | Captured verifier stdout (Harbor runs) |
+
+### `structured_output.json`
+
+Machine-readable evaluation report. Follow the shared chatbot contract in
+[`README.md`](../chatbot/README.md) (`contexts[]`, `facets[]`, `taskType: "chatbot"`).
+Typical contents:
+
+- `presenceCheck`: required artifacts found or missing (e.g. `transcript.json`)
+- `sourceArtifacts`: paths to inputs the verifier read (`transcript.json`,
+  `user_feedback.json`, …)
+- `contexts`: normalized metrics such as `task_outcome`, `conversation_summary`,
+  and `user_feedback`
+
+Do **not** duplicate this shape in per-task docs. Task authors implement the
+verifier and emit contexts that match the shared contract; batch reporting and
+Playground UI consume the normalized shape from the trial `verifier/` directory.

--- a/application/task-spec/docs/reporting-and-evaluation.md
+++ b/application/task-spec/docs/reporting-and-evaluation.md
@@ -1,0 +1,268 @@
+# Reporting and evaluation
+
+Batch reporting turns many persona trials into one job-level summary (Playground
+**Runs** → job `aggregation.json`). As a task author you own two things: the
+per-trial **facts** (`tests/` verifier) and the optional cross-trial **policy**
+(`reporting.json`). The platform owns execution, aggregation, and the UI.
+
+See [README.md](../README.md) **Step 4** for the onboarding version; this is the full
+reference.
+
+## Pipeline
+
+```mermaid
+flowchart TB
+  subgraph trial ["Per trial — facts only (author)"]
+    V["tests/ verifier"] --> SO["structured_output.json<br/>contexts[] + facets[]"]
+    SR["input/self_report_schema.yaml"] -.->|"agent writes user_feedback.json"| UF["user_feedback context<br/>(auto-synthesized)"]
+    UF --> SO
+  end
+
+  subgraph job ["Per job — aggregation (platform)"]
+    SO --> AGG["build_job_aggregation()"]
+    RC["reporting.json<br/>(optional policy)"] -.-> AGG
+  end
+
+  AGG --> G["General analysis<br/>automatic, no config"]
+  AGG --> P["Persona insights<br/>declared distributions, no LLM"]
+  AGG --> C["Custom analysis<br/>LLM prose summaries"]
+```
+
+The verifier is the only file that **must** exist. `reporting.json` is optional —
+an empty stub still yields full General analysis:
+
+```json
+{ "schemaVersion": "1.0", "contextRules": [] }
+```
+
+## The three report views
+
+The batch **Detailed** report has three tabs. Which tab a result lands in is
+decided by the **directive type**, not by any separate rule list.
+
+| Tab | Produced from | LLM? | Answers |
+|---|---|---|---|
+| **General analysis** | Automatic Layer 1 over every facet | No | "What happened?" — stats + explanation previews |
+| **Persona insights** | `contextRules[].distributions[]` | No | "How do outcomes differ by customer segment?" |
+| **Custom analysis** | `contextRules[].summaryAnalyses` (LLM prose) | Yes | Narrative — SUT pain points **and** product/behavior analysis |
+
+**Lean default: let General do the heavy lifting, add a few `distributions[]` for
+persona insight, and reserve report-time LLM (Custom analysis) for prose the
+numbers can't give.** Structured signals belong in the verifier (below), not at
+report time. Most tasks need only bindings + 1–3 distributions.
+
+## What you author
+
+### 1. Verifier facts — `structured_output.json`
+
+The verifier normalizes one trial into **contexts** (typed slices, e.g.
+`task_outcome`, `user_feedback`) each holding **facets** (named fields). Reuse the
+shared context/facet names from your type README so reports stay comparable.
+
+Every facet has a `kind` and a `role`:
+
+| `kind` | Layer 1 stats |
+|---|---|
+| `numerical` | count, min, max, avg, std |
+| `categorical` | ranked value counts + distinctCount |
+| `textual` | count, uniqueCount, up to 5 samples |
+
+| `role` | Meaning |
+|---|---|
+| `primary` | the headline result of the context |
+| `score` | a numeric measure |
+| `evidence` | a supporting categorical signal |
+| `explanation` | free-text reason for another facet |
+
+### 2. Self-report — `input/self_report_schema.yaml`
+
+For interactive tasks, when the agent writes `user_feedback.json`, the platform
+**auto-synthesizes** a `user_feedback` context from the schema — no verifier code
+needed. Bind a free-text field to the field it explains so General can group it:
+
+```yaml
+fields:
+  - key: overallExperienceRating
+    prompt: Overall, rate the experience from 1 to 10.
+    kind: integer
+    minimum: 1
+    maximum: 10
+    explanation:              # this reason explains overallExperienceRating
+      key: reason
+      prompt: Briefly explain the rating in your own voice.
+```
+
+(`explanation:` desugars to a normal flat `reason` field plus the binding; a flat
+`explains: overallExperienceRating` on the text field is equivalent.)
+
+### 3. Cross-trial policy — `reporting.json`
+
+A list of `contextRules[]`; each rule `match`es a `contextType` and adds
+`distributions[]` (Persona insights) and/or `summaryAnalyses` (Custom analysis
+LLM prose).
+
+## General analysis (automatic, Layer 1)
+
+Runs whenever verifier output exists — **no config**. It emits per-facet stats
+(table above) and, for each free-text explanation, a **non-LLM** grouped preview
+(`crossFacetViews[]` of type `text_by_primary_category`).
+
+The grouping axis comes **only** from an explicit binding — the platform never
+guesses:
+
+- schema `explanation:` / `explains:` (self-report), or
+- `explainsFacetKey` on a verifier-emitted facet.
+
+```json
+// verifier facet: this reason explains outcome_status
+{ "key": "outcome_reason", "role": "explanation", "kind": "textual",
+  "explainsFacetKey": "outcome_status", "value": "…" }
+```
+
+Rules:
+
+- **The binding is authoritative for `role`**: any textual facet that declares a
+  target is treated as an explanation, whatever its name.
+- **Bind to the specific field it explains** — a context may carry several
+  explanations, each bound differently (`feedback_reason` →
+  `overall_experience_rating`, `outcome_reason` → `outcome_status`).
+- **Numeric targets are auto-binned** by distribution (Low / Medium / High);
+  categorical targets group by value.
+- An unbound reason still gets stats, just no grouped view.
+
+Because General already summarizes "explanation by its bound field" for free, you
+do **not** need a `summaryAnalyses` rule to reproduce it.
+
+## Persona insights (declared, no LLM)
+
+Each trial ran under a persona with ~60 `dimensions:` attributes
+(`persona/datasets/**/persona_*.yaml`, e.g. `age_bracket`, `life_stage`,
+`risk_tolerance`). Persona insights cross-tabs your chosen facets against those
+dimensions.
+
+Declare only the facets worth surfacing by default — auto-enumerating every
+facet × dimension floods the tab:
+
+```json
+"contextRules": [
+  {
+    "match": { "contextType": "user_feedback" },
+    "distributions": [
+      { "facetKey": "overall_experience_rating", "title": "Overall experience rating" },
+      { "facetKey": "need_constraint_satisfaction" }
+    ]
+  }
+]
+```
+
+- The platform emits one per-segment table per `(facet, dimension)` into
+  `context.personaDistributions[]`.
+- Dimensions default to `persona_strategy.json` → `stratifyFields`; if none, they
+  fall back to the keys of `dimensionFilters`. Override with
+  `groupByPersonaDimensions: [...]` (or a single `groupByPersonaDimension`).
+- The tab also renders an **interactive explorer**: every eligible
+  `(facet, dimension)` pairing is precomputed (non-LLM, cheap) into
+  `context.personaDistributionOptions[]`, so users can slice anything on demand
+  while authors declare only the defaults.
+
+## Custom analysis (LLM prose)
+
+Custom analysis is the only view that runs an LLM **at report time**, via
+`contextRules[].summaryAnalyses` (`summaryKind: "llm_bucket_summary"`). It groups
+trials into buckets and writes a short prose summary per bucket — the **narrative
+the numbers cannot give**, from two angles:
+
+- **SUT improvement** — recurring pain points, friction, and failure themes to fix.
+- **Product / application analysis** — how the product behaves and what each
+  customer segment valued or rejected (positioning / segmentation insight).
+
+Group by any facet with `groupByFacetKey`, or by a persona dimension with
+`groupByPersonaDimension` (which infers `groupByMode: "persona_attribute"`); the
+dimension is just the axis — output still lands in Custom analysis.
+
+```json
+{
+  "match": { "contextType": "decision" },
+  "summaryAnalyses": [
+    {
+      "id": "decision.reason_by_values_priority",
+      "title": "What each values segment optimized for",
+      "targetFacetKey": "reason",
+      "groupByPersonaDimension": "values_priority",
+      "summaryKind": "llm_bucket_summary",
+      "instruction": "For each segment, summarize in 1-2 sentences what tipped the decision."
+    }
+  ]
+}
+```
+
+LLM directives run in the background only when
+`PLAYGROUND_REPORTING_ENABLE_LLM=1` and cache into `aggregation.json` by
+fingerprint.
+
+### Structured signals live in the verifier
+
+A **signal** — a boolean/enum label read from free text (*stayed in research
+scope*, *safety escalation appropriate*, *substitution barrier*) — is a **fact**,
+so it belongs in the verifier, not in a report-time scan. Have the verifier call an
+LLM at verify time and emit the result as a normal categorical **facet**:
+
+```python
+# tests/ verifier — best-effort; grading never fails if the LLM is unavailable
+facets.extend(_llm_signal_facets(assistant_text, specs=[
+    ("safety_escalation_appropriate", "Flagged when to seek clinician / emergency care"),
+    ("overconfident_no_caveats", "Made absolute claims without caveats"),
+], context_desc="…", rubric="…"))
+```
+
+Once emitted, the signal is indistinguishable from a deterministic facet: it feeds
+General, Persona insights (`distributions[]`), and Custom analysis alike, and keeps
+report time non-LLM. Guard the call so a missing key / network / parse error
+returns nothing — the trial must still pass on its deterministic facts. Wire keys
+via `task.toml [verifier.env]` (`OPENAI_API_KEY = "${OPENAI_API_KEY}"`); the
+verifier phase has network egress by default. Reference pattern:
+[`chat_multi-agent-medical-assistant`](../../application/tasks/chat_multi-agent-medical-assistant),
+[`chat_openbb`](../../application/tasks/chat_openbb),
+[`os-app-ios_news-subscription-decision`](../../application/tasks/os-app-ios_news-subscription-decision).
+
+The platform still accepts a report-time `signalScans` directive (it routes to
+Custom analysis), but use it only as an **interim fallback** when the verifier
+cannot reach an LLM.
+
+## When there is no self-report (web / os-app)
+
+`user_feedback` exists only when the agent wrote `user_feedback.json`. Many web /
+os-app tasks skip self-report, leaving only artifact-derived contexts
+(`task_outcome`, `decision`, …). Rules whose `contextType` is absent simply
+produce nothing.
+
+To keep persona and custom lenses working, the **verifier** can derive facts from
+the run's own trajectory or result artifact and emit an **app-specific** context —
+a categorical `primary` the lenses can group by, plus a `textual` `explanation`
+facet. What is worth extracting is entirely task-specific, so keep it in the
+verifier; there is deliberately no shared "trajectory metrics" schema. The minimum
+fallback is to bind the explanations the agent already writes (`reason`,
+`comparison_notes`, `outcome_explanation`).
+
+## Files and ownership
+
+| File | Written by | Contains |
+|---|---|---|
+| `instruction.md`, `input/*`, `input/self_report_schema.yaml` | Author | Scenario, inputs, self-report questions |
+| `tests/` → `verifier/structured_output.json` | Verifier | Normalized contexts + facets (facts) for one trial |
+| `reporting.json` | Author | Optional cross-trial policy (distributions + LLM analyses) |
+| `aggregation.json` | Platform | Layer 1 stats + declared Layer 2 results |
+
+Keep policy out of verifier code, and keep facts out of `reporting.json`.
+
+## Type templates
+
+| Type | Reporting template | Notes |
+|---|---|---|
+| Survey | [`survey/survey_reporting.example.json`](../survey/survey_reporting.example.json) | per-question contexts; persona layer usually N/A |
+| Chatbot | [`chatbot/chatbot_reporting.example.json`](../chatbot/chatbot_reporting.example.json) | baseline covers outcome + conversation + feedback |
+| Web | [`web/web_metric_reporting.example.json`](../web/web_metric_reporting.example.json), [`web/persona_sensitive_reporting.example.json`](../web/persona_sensitive_reporting.example.json) | merge `contextRules[]` for both lenses |
+| OS / app | [`os-app/os_app_metric_reporting.example.json`](../os-app/os_app_metric_reporting.example.json), [`os-app/os_app_persona_reporting.example.json`](../os-app/os_app_persona_reporting.example.json) | merge `contextRules[]` for both lenses |
+
+Type READMEs define required facets per family. Chatbot harness artifacts:
+[`eval_artifacts.md`](eval_artifacts.md).

--- a/application/task-spec/docs/runtime-boundary.md
+++ b/application/task-spec/docs/runtime-boundary.md
@@ -1,0 +1,10 @@
+# Stable runtime boundary
+
+See [README.md](../README.md) § Runtime boundary for when this matters during onboarding.
+
+The persona agent interacts through the protocol surface only. For survey tasks
+that surface is the survey instrument and output schema. For chatbot tasks it is
+the task controller's chat loop. For web tasks it is the browser/computer-use
+runtime. For OS/app tasks it is the exposed desktop/mobile/browser operating
+surface plus task-owned artifacts. Internal APIs, databases, or service health
+checks are reserved for task setup, reset, and verifier logic.

--- a/application/task-spec/docs/shared-core-metrics.md
+++ b/application/task-spec/docs/shared-core-metrics.md
@@ -1,0 +1,193 @@
+# Shared core metrics
+
+Shared contracts for `web/` and `os-app/` tasks, plus the cross-family subjective
+channel. Read [README.md](../README.md) **Step 1** (web vs os-app) and **Step 3**
+(shared contexts) first.
+
+## Choosing `web` vs `os-app`
+
+Use `web/` when the benchmark target is primarily one website or web product:
+
+- the core task is search, browse, compare, filter, fill, submit, cart, checkout,
+  booking, or account management on web pages
+- the main observable errors are wrong page navigation, broken form filling,
+  search/filter misuse, or live-site brittleness
+- success is mainly judged from web-visible state or a site-backed submission
+
+Use `os-app/` when the benchmark target is primarily native app operation or a
+workflow that spans apps and local artifacts:
+
+- the core task is settings changes, file transforms, local document edits,
+  email/calendar/file-manager workflows, or mobile/desktop app operation
+- the main observable errors are wrong edits, destructive side effects, broken
+  cross-app handoff, or task completion with the wrong artifact
+- success is mainly judged from local app state, exported files, or cross-app
+  side effects
+
+If a task starts in a browser but the real benchmark target is a broader
+operating workflow, prefer `os-app/`. If the browser is the product under test,
+prefer `web/`.
+
+## Shared core for `web` and `os-app`
+
+If you author **web** or **OS/app** tasks, read
+[Structured output quick reference](structured-output-quick-reference.md)
+first, then use this section for the shared context names and facet keys that
+both families reuse. For full metric templates and reporting patterns, use
+[`web/README.md`](../web/README.md) and [`os-app/README.md`](../os-app/README.md).
+
+For a machine-readable companion to this section, see
+`shared_core_metric_contract.example.json`.
+
+### Shared Core Contexts
+
+Both `web` and `os-app` should reuse these context types with the same names
+and semantics:
+
+1. `task_outcome`
+   Required. The benchmark-facing result for the whole task.
+2. `goal_component`
+   Recommended. One context per major required subgoal or assertion group.
+3. `side_effects`
+   Recommended. Unexpected edits, destructive changes, duplicates, privacy
+   leaks, or other collateral damage.
+4. `execution_profile`
+   Recommended. Runtime and operating-shape diagnostics.
+5. `infeasibility`
+   Optional but strongly recommended when some tasks are intentionally blocked,
+   unsupported, or impossible.
+6. `user_feedback`
+   Recommended whenever the task collects post-run self-report.
+7. `persona_alignment`
+   Recommended when persona alignment is part of the evaluation target.
+8. `persona_constraint`
+   Recommended when the task has explicit or inferable persona constraints.
+
+Scenario-specific contexts such as `web_interaction`, `web_artifact`,
+`decision`, or `decision_process` should layer on top of this shared core, not
+replace it.
+
+### Shared Core Facet Keys
+
+These facet keys should stay identical across `web` and `os-app` so that
+reporting code can aggregate them without task-family-specific branching.
+
+For `task_outcome`:
+
+- `outcome_status`
+- `goal_completion_ratio`
+- `goal_completion_bucket`
+- `verifier_mode`
+- `primary_failure_reason`
+- `outcome_explanation`
+- `completion_evidence`
+
+For `goal_component`:
+
+- `goal_component_key`
+- `goal_component_label`
+- `goal_component_status`
+- `goal_component_weight`
+- `goal_component_required`
+- `goal_component_evidence`
+
+For `side_effects`:
+
+- `collateral_damage_present`
+- `blocking_side_effect_present`
+- `damage_severity`
+- `damage_type_primary`
+- `unsafe_action_present`
+- `side_effect_notes`
+
+For `execution_profile`:
+
+- `task_archetype`
+- `used_gui_primary`
+- `used_terminal_or_script`
+- `apps_touched_count`
+- `step_count`
+- `wall_clock_seconds`
+- `recovery_count`
+
+For `infeasibility`:
+
+- `infeasible_expected`
+- `agent_declared_infeasible`
+- `infeasibility_reason_match`
+- `declared_before_side_effects`
+- `infeasibility_notes`
+
+For `user_feedback`:
+
+- `overall_experience_rating`
+- `feedback_reason`
+- `need_constraint_satisfaction`
+- `personal_preference_satisfaction`
+- `trust_level`
+- `effort_rating`
+- `clarity_of_next_step`
+
+For persona-aware tasks:
+
+- `persona_alignment_status`
+- `persona_alignment_score`
+- `persona_preference_axis_primary`
+- `persona_signal_source`
+- `persona_alignment_explanation`
+- `persona_constraint_key`
+- `persona_constraint_type`
+- `persona_constraint_priority`
+- `persona_constraint_status`
+- `persona_constraint_evidence`
+
+### Shared Core Rules
+
+- Keep the shared context names and facet keys exactly as written.
+- Do not rename shared fields to fit one task family; add task-specific fields
+  behind a `task_` prefix or in scenario-specific contexts instead.
+- Keep `user_feedback` as the shared post-run subjective channel across
+  interactive tasks. Family-specific process contexts may add richer slices, but
+  they should not replace the shared feedback context.
+- Keep binary success outcome-based. Do not derive success from action-sequence
+  matching.
+- Use the same shared enums for common fields whenever possible so batch reports
+  can compare `web` and `os-app` runs directly.
+
+## Shared subjective channel (interactive tasks)
+
+When a task collects post-run persona feedback (`chatbot`, `web`, `os-app`):
+
+- write the raw artifact to `user_feedback.json`
+- define task-owned questions in `input/self_report_schema.yaml`
+- map the feedback into a `user_feedback` context in
+  `verifier/structured_output.json`
+
+The shared `user_feedback` context is the default reporting home for subjective
+signals such as satisfaction, effort, trust, or clarity. Family-specific
+contexts can still add narrower slices when that improves analysis:
+
+- chatbot may additionally emphasize conversation-only signals such as whether
+  clarification questions were useful or whether the user felt understood
+- web may optionally add an `experience` context for web-specific friction or UI
+  journey analysis
+- os-app may additionally surface persona alignment or archetype-specific
+  summaries when local workflow tradeoffs matter
+
+Recommended shared `user_feedback` facets:
+
+- `overall_experience_rating`
+- `feedback_reason`
+- `need_constraint_satisfaction`
+- `personal_preference_satisfaction`
+- `trust_level`
+- `effort_rating`
+- `clarity_of_next_step`
+
+Task families can extend this shared feedback contract with extra `task_*`
+fields or family-specific fields when needed, but `user_feedback` should remain
+the common subjective reporting entry point.
+
+Across application tasks, prefer `shared-*` environment folders when the runtime
+is reusable across multiple tasks. Reserve task-named environment folders for
+truly task-specific app hosts or sidecar topologies.

--- a/application/task-spec/docs/structured-output-quick-reference.md
+++ b/application/task-spec/docs/structured-output-quick-reference.md
@@ -1,0 +1,141 @@
+# Structured output quick reference
+
+Cheat sheet for verifier output and `reporting.json` across all task types.
+Start from [README.md](../README.md) **Step 3** for the onboarding context.
+
+Every application task uses the same shape:
+
+```text
+structured_output.json
+  contexts[]
+    key: "task_outcome.primary"     ← stable instance id (you choose the suffix)
+    contextType: "task_outcome"     ← type label used by reporting.json match rules
+    facets[]
+      key: "outcome_status"         ← standard field name from the contract
+      kind: numerical | categorical | textual
+      value: ...
+```
+
+Three responsibilities:
+
+| Piece | Who owns it | What it does |
+|---|---|---|
+| Verifier facts | Task author in `tests/` | Emit `contexts[]` + `facets[]` for one trial |
+| Layer 1 automatic aggregation | Platform | Always aggregates every facet (`numerical` stats, `categorical` counts, `textual` samples) |
+| Layer 2 extra batch analysis | Task author in `reporting.json` | Optional LLM bucket summaries and judge scans |
+
+Extension rule for all types:
+
+- keep shared `contextType` and facet keys exactly as written
+- add task-specific details in new scenario contexts or behind a `task_` prefix
+- do not rename shared fields to fit one task
+
+### Survey
+
+Full guide: [`survey/README.md`](../survey/README.md)
+
+Canonical task: `application/tasks/example-survey_product-feedback`
+
+| Context type | Required | How many | Standard facet keys |
+|---|---|---|---|
+| `question_response` | Yes | one per answered question (`question.<questionId>`) | `response` (required), `reason`, `confidence` |
+| `trial_summary` | Yes | one per trial (`survey.summary`) | `answer_count`, `trajectory_event_count`, `mean_numeric_answer` |
+
+`response` kind depends on question type:
+
+- likert → `numerical`
+- single/multi choice → `categorical` (option id)
+- free text → `textual`
+
+Default reporting: summarize `reason` by `response` for each `question_response`.
+
+Templates:
+
+- `survey/survey_structured_output.example.json`
+- `survey/survey_reporting.example.json`
+
+### Chatbot
+
+Full guide: [`chatbot/README.md`](../chatbot/README.md)
+
+Canonical task: `application/tasks/chat_recai`
+
+| Context type | Required | Standard facet keys |
+|---|---|---|
+| `task_outcome` | Yes | `outcome_status`, `resolution_basis`, `outcome_reason`, `next_step_owner`, `task_goal_label` |
+| `conversation_summary` | Recommended | `conversation_path`, `user_turn_count`, `assistant_turn_count`, `message_count`, `process_notes`, `clarification_question_count` |
+| `user_feedback` | Recommended when self-report exists | `overall_experience_rating`, `feedback_reason`, `need_constraint_satisfaction`, `personal_preference_satisfaction`, `clarification_questions_useful`, `trust_level`, `effort_rating`, `felt_understood` |
+| `policy_and_trust` | Optional | `policy_compliance`, `groundedness_primary`, `policy_notes`, `handoff_appropriateness` |
+| `coordination` | Optional | `coordination_mode`, `state_change_achieved`, `user_action_required`, `guidance_quality`, `coordination_notes` |
+
+Note: chatbot uses `outcome_reason` in `task_outcome`. Web and OS/app use
+`outcome_explanation` for the same role.
+
+Default reporting: summarize `outcome_reason` by `outcome_status`, `process_notes`
+by `conversation_path`, and `feedback_reason` by satisfaction-style facets.
+
+Templates:
+
+- `chatbot/chatbot_structured_output.example.json`
+- `chatbot/chatbot_reporting.example.json`
+
+### Web
+
+Full guide: [`web/README.md`](../web/README.md)
+
+Canonical task: `application/tasks/example-web-playwright_quote-choice`
+
+Web tasks use **two layers**:
+
+1. **Shared core** — same contexts and facet keys as OS/app (see
+   [Shared core metrics](shared-core-metrics.md#shared-core-for-web-and-os-app) below)
+2. **Web-specific layer** — persona-sensitive browse/choose semantics
+
+| Context type | Required | Standard facet keys |
+|---|---|---|
+| `decision` | Yes for browse/choose tasks | `decision_outcome`, `basis_primary`, `reason`, `decision_subject_label`, `decision_subject_id`, `basis_secondary`, `decision_confidence` |
+| `decision_process` | Recommended | `exploration_style`, `options_considered_count`, `used_search`, `used_filter_or_sort`, `comparison_notes` |
+| `web_interaction` | Optional | task-specific navigation/interaction facets |
+| `web_artifact` | Optional | artifact validation facets |
+| `experience` | Optional | web-only subjective friction/UI facets |
+
+Default reporting: shared core rules plus decision/process summaries. Merge
+templates when needed:
+
+- `web/web_metric_reporting.example.json`
+- `web/persona_sensitive_reporting.example.json`
+
+Templates:
+
+- `web/web_metric_structured_output.example.json`
+- `web/persona_sensitive_structured_output.example.json`
+
+### OS / app
+
+Full guide: [`os-app/README.md`](../os-app/README.md)
+
+Canonical task: `application/tasks/example-computer-use-ios_photo-access-review`
+
+OS/app tasks reuse the **same shared core** as web (see [shared core metrics](shared-core-metrics.md)). Add
+scenario-specific contexts such as local artifact checks or cross-app handoff
+slices on top of that core rather than replacing it.
+
+Templates:
+
+- `os-app/os_app_metric_structured_output.example.json`
+- `os-app/os_app_persona_structured_output.example.json`
+- `os-app/os_app_metric_reporting.example.json`
+- `os-app/os_app_persona_reporting.example.json`
+
+Machine-readable shared core: `shared_core_metric_contract.example.json`
+
+### Example template index
+
+| Type | Structured output | Reporting |
+|---|---|---|
+| Survey | `survey/survey_structured_output.example.json` | `survey/survey_reporting.example.json` |
+| Chatbot | `chatbot/chatbot_structured_output.example.json` | `chatbot/chatbot_reporting.example.json` |
+| Web | `web/web_metric_structured_output.example.json`, `web/persona_sensitive_structured_output.example.json` | `web/web_metric_reporting.example.json`, `web/persona_sensitive_reporting.example.json` |
+| OS / app | `os-app/os_app_metric_structured_output.example.json`, `os-app/os_app_persona_structured_output.example.json` | `os-app/os_app_metric_reporting.example.json`, `os-app/os_app_persona_reporting.example.json` |
+| Web + OS shared core | `shared_core_metric_contract.example.json` | covered by the web/os templates above |
+

--- a/application/task-spec/os-app/README.md
+++ b/application/task-spec/os-app/README.md
@@ -41,7 +41,7 @@ flowchart TB
 ```
 
 Outcome-based verification (final state, not action sequence). Reuse the **same shared core**
-as web ([shared-core-metrics.md](../../../docs/task-spec/shared-core-metrics.md)); add scenario-specific contexts on top.
+as web ([shared-core-metrics.md](../../../application/task-spec/docs/shared-core-metrics.md)); add scenario-specific contexts on top.
 Put long scenario or product background in `input/context.md`; keep steps and the
 submission JSON schema in `instruction.md` (same convention as survey, chatbot, and web tasks).
 
@@ -61,7 +61,7 @@ Use this folder when the benchmark question is fundamentally:
 Use `../web/README.md` for browser-mediated web tasks. Use this folder for
 native app, settings, file, and cross-app operating benchmarks.
 
-Use [`shared-core-metrics.md`](../../../docs/task-spec/shared-core-metrics.md) as the source of truth for the shared core context names,
+Use [`shared-core-metrics.md`](../../../application/task-spec/docs/shared-core-metrics.md) as the source of truth for the shared core context names,
 facet keys, and reuse rules that `os-app/` shares with `web/`. See
 `../shared_core_metric_contract.example.json` for the machine-readable
 companion.

--- a/application/task-spec/web/README.md
+++ b/application/task-spec/web/README.md
@@ -41,7 +41,7 @@ flowchart TB
   W_REF -.-> folder
 ```
 
-Web verifiers use **two layers**: shared core ([shared-core-metrics.md](../../../docs/task-spec/shared-core-metrics.md))
+Web verifiers use **two layers**: shared core ([shared-core-metrics.md](../../../application/task-spec/docs/shared-core-metrics.md))
 plus web-specific contexts (`decision`, `decision_process`, `web_interaction`, …).
 **No** `input/output_schema.md` — put the submission JSON schema in `instruction.md`.
 
@@ -92,7 +92,7 @@ Web tasks should still reuse the same core benchmark contexts as `os-app/`:
 
 So the two folders are aligned, not identical.
 
-Use [`shared-core-metrics.md`](../../../docs/task-spec/shared-core-metrics.md) as the source of truth for the shared core context names,
+Use [`shared-core-metrics.md`](../../../application/task-spec/docs/shared-core-metrics.md) as the source of truth for the shared core context names,
 facet keys, and reuse rules. See
 `../shared_core_metric_contract.example.json` for the machine-readable
 companion.


### PR DESCRIPTION
## Summary
- Add task-spec deep-dive docs under `application/task-spec/docs`
- Update task-spec READMEs so contracts and authoring guides live together

## Test plan
- [ ] Confirm `application/task-spec/docs/*` files exist
- [ ] Follow README links into the colocated deep dives
- [ ] Merge after or with the docs handbook PR so `docs/task-spec` removal stays consistent


Made with [Cursor](https://cursor.com)