### PR TITLE
docs: embed demo video inline in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@
 </div>
 
 <div align="center">
-  <a href="https://www.youtube.com/watch?v=cNFkz9Wo1y4">
-    <img src="https://img.youtube.com/vi/cNFkz9Wo1y4/maxresdefault.jpg" alt="Watch the MatrAIx demo video" width="900">
-  </a>
+  <video src="https://github.com/user-attachments/assets/7c9ae1d9-5d80-4821-9e30-5981ecc77afc" controls playsinline width="900">
+    Your browser does not support the video tag.
+    <a href="https://www.youtube.com/watch?v=cNFkz9Wo1y4">Watch the MatrAIx demo on YouTube</a>
+  </video>
 </div>
 
 ---


### PR DESCRIPTION
## Summary
- Replace the YouTube thumbnail click-through with an inline `<video>` player
- Host the compressed roadshow demo via GitHub user-attachments so it plays on the repo page

## Test plan
- [ ] Open the PR/README preview and confirm the video plays inline with controls
- [ ] Confirm fallback YouTube link remains in the video element for non-supporting clients


Made with [Cursor](https://cursor.com)