### PR TITLE
fix: replace personabench imports with matraix in persona scripts

### DIFF
--- a/persona/curation/scripts/add_bench_display_names.py
+++ b/persona/curation/scripts/add_bench_display_names.py
@@ -13,7 +13,7 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 if str(REPO_ROOT / "src") not in sys.path:
     sys.path.insert(0, str(REPO_ROOT / "src"))
 
-from personabench.persona_display_name import synthetic_display_name  # noqa: E402
+from matraix.persona_display_name import synthetic_display_name  # noqa: E402
 
 POOL_DIR = REPO_ROOT / "persona" / "datasets" / "matraix-persona-dev-sample"
 MANIFEST_PATH = POOL_DIR / "manifest.json"

--- a/persona/reporting/eval_grounding_job.py
+++ b/persona/reporting/eval_grounding_job.py
@@ -7,7 +7,7 @@ import argparse
 import json
 from pathlib import Path
 
-from personabench.persona_grounding import (
+from matraix.persona_grounding import (
     build_job_grounding_report,
     discover_trial_dirs,
     load_trial_grounding,

--- a/persona/scripts/generate_dev_personas.py
+++ b/persona/scripts/generate_dev_personas.py
@@ -16,9 +16,9 @@ import json
 import re
 from pathlib import Path
 
-from personabench.persona_consistency import validate_dimensions
-from personabench.persona_dimension_catalog import values_for_dimension
-from personabench.persona_generator import (
+from matraix.persona_consistency import validate_dimensions
+from matraix.persona_dimension_catalog import values_for_dimension
+from matraix.persona_generator import (
     PERSONA_SOURCES,
     build_filter_strata,
     build_probe_strata,
@@ -26,7 +26,7 @@ from personabench.persona_generator import (
     generate_persona_pool,
     write_persona_dataset,
 )
-from personabench.task_catalog import (
+from matraix.task_catalog import (
     confounder_values_from_grounding,
     get_task_grounding_spec,
     probe_dimension_from_grounding,

--- a/persona/scripts/generate_persona_job.py
+++ b/persona/scripts/generate_persona_job.py
@@ -10,14 +10,14 @@ from pathlib import Path
 
 import yaml
 
-from personabench.persona_job import (
+from matraix.persona_job import (
     DEFAULT_DATASET,
     DEFAULT_STRATIFY_FIELDS,
     SMOKE_PERSONA_PATH,
     build_job_config,
     parse_stratify_field_args,
 )
-from personabench.task_catalog import (
+from matraix.task_catalog import (
     confounder_values_from_grounding,
     get_task_grounding_spec,
 )

--- a/tests/environment/test_persona_agents.py
+++ b/tests/environment/test_persona_agents.py
@@ -21,6 +21,26 @@ def test_persona_agents_use_matraix_namespace() -> None:
         assert "personabench" not in text.lower(), path
 
 
+def test_persona_scripts_use_matraix_imports() -> None:
+    """Persona tooling scripts must import matraix, not the retired personabench package."""
+    roots = (
+        ROOT / "persona" / "scripts",
+        ROOT / "persona" / "reporting",
+        ROOT / "persona" / "curation" / "scripts",
+    )
+    py_files = [
+        path
+        for root in roots
+        if root.is_dir()
+        for path in root.rglob("*.py")
+        if path.is_file()
+    ]
+    assert py_files
+    for path in py_files:
+        text = path.read_text(encoding="utf-8")
+        assert "personabench" not in text, path
+
+
 def test_harbor_factory_registers_matraix_persona_agents() -> None:
     factory_source = (
         ROOT / "environment/runtime/harbor/agents/factory.py"


### PR DESCRIPTION
## Summary
- Replace leftover `personabench` imports with `matraix` in the four persona scripts called out in #8.
- Extend the namespace regression test to cover `persona/scripts`, `persona/reporting`, and `persona/curation/scripts`.

Closes #8

## Test plan
- [x] `pytest tests/environment/test_persona_agents.py -q`
- [ ] `uv run python -c "import persona.scripts.generate_dev_personas"` after `uv pip install -e .` (or run the documented script entrypoints)


Made with [Cursor](https://cursor.com)