### PR TITLE
fix(viewer): restrict harbor view CORS to local Vite origins

### DIFF
--- a/environment/runtime/harbor/viewer/server.py
+++ b/environment/runtime/harbor/viewer/server.py
@@ -143,10 +143,15 @@ def create_app(
         lifespan=lifespan,
     )
 
-    # Allow CORS for local development
+    # harbor view is a retained local inspector (Playground Runs is the usual
+    # UI). Default bind is 127.0.0.1; CORS only matters for `harbor view --dev`
+    # when Vite is on :5173. Do not use allow_origins=["*"] with credentials.
     app.add_middleware(
         CORSMiddleware,  # type: ignore[arg-type]
-        allow_origins=["*"],
+        allow_origins=[
+            "http://localhost:5173",
+            "http://127.0.0.1:5173",
+        ],
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],


### PR DESCRIPTION
## Summary
- Trivial CORS hygiene for the retained `harbor view` inspector (Playground Runs is the usual UI; viewer stays for local job browsing).
- Replaces `allow_origins=["*"]` + `allow_credentials=True` with localhost Vite origins (`:5173`), matching the same local-dev pattern Playground already uses.
- Default `harbor view` still binds `127.0.0.1` and serves same-origin static files; this mainly matters for `harbor view --dev`.

Closes #9

## Test plan
- [ ] `harbor view <jobs-dir>` still loads locally
- [ ] Optional: `harbor view <jobs-dir> --dev` can call the API from Vite on `:5173`


Made with [Cursor](https://cursor.com)