### PR TITLE
docs: note Docker requirement for the smoke test

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ Details: [Handbook § Persona 1M](docs/README.md#3-persona-1m-optional).
 
 ### Smoke test
 
-No API key required:
+No API key required. **Requires Docker** (the smoke job uses
+`environment.type: docker`):
 
 ```bash
 uv run harbor run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml


### PR DESCRIPTION
## Summary
- Clarifies that the Quick Start smoke test needs Docker, not only “no API key”.

Closes #13

## Test plan
- [ ] README Quick Start smoke section mentions Docker
- [ ] Requirements still list Docker at the top


Made with [Cursor](https://cursor.com)