### PR TITLE
Launch large persona cohorts by pool ref

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -260,6 +260,8 @@ persona/curation/attribute_pool/sources/raw/
 # persona/datasets/matraix-persona-dev-sample/ (not matched by this pattern).
 persona/datasets/bench-dev-*/
 persona/datasets/_generated/
+# Launch caches next to a source dataset (dev sample, saved datasets, …).
+persona/datasets/*/cohorts/
 # Production 1M release mirror + sampled cohorts (large / machine-local).
 persona/datasets/matraix-persona-1m/release/
 persona/datasets/matraix-persona-1m/cohorts/

--- a/application/playground/backend/api/app.py
+++ b/application/playground/backend/api/app.py
@@ -830,6 +830,7 @@ def create_app(catalog_path: Optional[str] = None) -> FastAPI:
                 persona_sources=body.personaSources,
                 persona_filters=body.personaFilters,
                 cohort_id=body.cohortId,
+                use_entire_pool=body.useEntirePool,
             )
         except ValueError as exc:
             raise HTTPException(status_code=422, detail=str(exc)) from exc
@@ -1152,6 +1153,8 @@ def create_app(catalog_path: Optional[str] = None) -> FastAPI:
                 stratify_fields=body.stratifyFields,
                 sample_size_per_value_group=body.sampleSizePerValueGroup,
                 task_path=body.taskPath,
+                preview_limit=body.previewLimit,
+                include_persona_ids=body.includePersonaIds,
             )
         except ValueError as exc:
             raise HTTPException(status_code=422, detail=str(exc)) from exc

--- a/application/playground/backend/api/schemas.py
+++ b/application/playground/backend/api/schemas.py
@@ -720,6 +720,7 @@ class HarborJobLaunchRequest(BaseModel):
     personaSources: Optional[List[str]] = None
     personaFilters: Optional[Dict[str, str]] = None
     cohortId: Optional[str] = None
+    useEntirePool: bool = False
     agentName: Optional[str] = None
     personaModel: Optional[str] = None
     nConcurrentTrials: int = 2
@@ -913,6 +914,7 @@ class PersonaPoolIdsResponse(BaseModel):
     pool: str
     personaIds: List[str] = Field(default_factory=list)
     count: int = 0
+    idsTruncated: bool = False
 
 
 class PersonaPoolSampleRequest(BaseModel):
@@ -925,6 +927,8 @@ class PersonaPoolSampleRequest(BaseModel):
     sampleSizePerValueGroup: Optional[int] = None
     taskPath: Optional[str] = None
     """Optional task path — included in coverage error hints."""
+    previewLimit: int = 32
+    includePersonaIds: Optional[bool] = None
 
 
 class PersonaPoolPersonaCard(BaseModel):
@@ -1022,8 +1026,10 @@ class PersonaPoolSampleResponse(BaseModel):
     matchedCount: int
     sampleSize: int
     seed: int
-    personaIds: List[str]
+    personaIds: List[str] = Field(default_factory=list)
     personas: List[Dict[str, Any]] = Field(default_factory=list)
+    selectedCount: Optional[int] = None
+    idsTruncated: bool = False
 
 
 class PersonaCohortSaveRequest(BaseModel):

--- a/application/playground/backend/service/harbor_job_service.py
+++ b/application/playground/backend/service/harbor_job_service.py
@@ -992,6 +992,7 @@ class HarborJobService:
         persona_sources: list[str] | None = None,
         persona_filters: dict[str, str] | None = None,
         cohort_id: str | None = None,
+        use_entire_pool: bool = False,
         os_app_submission_profile: str | None = None,
         os_app_backend: str | None = None,
         cua_backend: str | None = None,
@@ -1018,7 +1019,7 @@ class HarborJobService:
             os_app_backend = cua_backend
         if persona_ids is not None and len(persona_ids) == 0:
             raise ValueError("persona_ids must not be empty when provided")
-        if not persona_ids and sample_size < 1:
+        if not persona_ids and not use_entire_pool and sample_size < 1:
             raise ValueError("sample_size must be >= 1")
 
         resolved_persona_ids = list(persona_ids or [])
@@ -1026,6 +1027,7 @@ class HarborJobService:
         resolved_seed = seed
         resolved_sources = persona_sources
         resolved_filters = persona_filters
+        resolved_use_entire_pool = bool(use_entire_pool)
 
         if cohort_id:
             from backend.service.persona_pool_service import PersonaPoolService
@@ -1041,7 +1043,11 @@ class HarborJobService:
             if resolved.get("personaIds"):
                 resolved_persona_ids = list(resolved["personaIds"])
 
-        if not resolved_persona_ids and (resolved_sources or resolved_filters):
+        if (
+            not resolved_persona_ids
+            and not resolved_use_entire_pool
+            and (resolved_sources or resolved_filters)
+        ):
             from backend.service.persona_pool_service import PersonaPoolService
 
             sampled = PersonaPoolService.from_repo(repo_root=self.repo_root).sample_pool(
@@ -1051,6 +1057,7 @@ class HarborJobService:
                 sources=resolved_sources,
                 dimension_filters=resolved_filters,
                 task_path=task_path,
+                include_persona_ids=True,
             )
             resolved_persona_ids = list(sampled["personaIds"])
             resolved_pool = str(sampled.get("pool") or resolved_pool)
@@ -1108,6 +1115,7 @@ class HarborJobService:
             "sample_size": len(resolved_persona_ids) if resolved_persona_ids else sample_size,
             "seed": resolved_seed,
             "persona_ids": resolved_persona_ids,
+            "use_entire_pool": resolved_use_entire_pool and not resolved_persona_ids,
             "execution_mode": execution_mode,
             "trial_profile": trial_profile,
             "cua_backend": os_app_backend,

--- a/application/playground/backend/service/persona_pool_service.py
+++ b/application/playground/backend/service/persona_pool_service.py
@@ -32,11 +32,14 @@ DEFAULT_PERSONA_POOL = "persona/datasets/matraix-persona-dev-sample"
 DATASETS_DIR = "persona/datasets"
 COHORTS_DIR = "persona/datasets/cohorts"
 # Top-level dirs under persona/datasets that are not selectable pools.
-_DATASETS_SKIP_TOP_LEVEL = frozenset({"_generated", "cohorts", "matraix-persona-1m"})
+_DATASETS_SKIP_TOP_LEVEL = frozenset(
+    {"_generated", "_sampled", "cohorts", "matraix-persona-1m"}
+)
 # Names that cannot be used when saving a pool as a named dataset.
 _RESERVED_DATASET_SLUGS = frozenset(
     {
         "_generated",
+        "_sampled",
         "cohorts",
         "matraix-persona-1m",
         "matraix-persona-dev-sample",
@@ -45,16 +48,20 @@ _RESERVED_DATASET_SLUGS = frozenset(
 DIMENSION_CATEGORIES_PATH = "persona/schema/dimension_categories.json"
 # Soft guard for stratify cell cartesian products from dimensionFilters.
 MAX_FILTER_STRATA = 2048
+# UI keeps a full personaId list only at or below this size; larger cohorts are ref-based.
+PERSONA_UI_ID_LIST_MAX = 100
+PERSONA_CARD_PREVIEW_DEFAULT = 32
 CohortKind = Literal["recipe", "frozen"]
 
 
 def coverage_recovery_hint(*, task_path: str | None = None) -> str:
-    """Hint when a fixture pool cannot satisfy filters — prefer production 1M."""
+    """Hint when a dataset cannot satisfy filters — never synthesize personas."""
     _ = task_path
     return (
-        "Pool coverage is too thin for these filters. Sample from "
-        "persona/datasets/matraix-persona-1m, widen dimensionFilters / sources, "
-        "or launch a saved cohort that already has enough matches."
+        "Not enough matching personas in this dataset for the current filters. "
+        "Widen filters / sources, switch dataset (dev sample vs matraix-persona-1m), "
+        "or use a saved cohort that already has enough matches. "
+        "Playground does not synthesize missing personas."
     )
 
 
@@ -76,6 +83,15 @@ def _cohort_slug(value: str) -> str:
     if not slug:
         raise ValueError("cohort id must not be empty")
     return slug
+
+
+def _sampled_cohort_pool(parent_pool: str, digest: str) -> str:
+    """``<source-dataset>/cohorts/cohort-<digest>`` so the parent pool is visible."""
+    pool = (parent_pool or DEFAULT_PERSONA_POOL).strip().rstrip("/")
+    marker = "/cohorts/cohort-"
+    if marker in pool:
+        pool = pool.split(marker, 1)[0]
+    return f"{pool}/cohorts/cohort-{digest}"
 
 
 def _repo_root() -> Path:
@@ -369,7 +385,8 @@ class PersonaPoolService:
         """Discover selectable persona pools under ``persona/datasets/``.
 
         Surfaces checked-in local pools, plus the production MatrAIx 1M pool.
-        Legacy ``_generated`` synthetic pools are intentionally omitted.
+        Launch caches (``<dataset>/cohorts/``) and leftover ``_generated`` dirs
+        are omitted.
         """
         from backend.service.persona_1m_pool import (
             production_1m_available,
@@ -443,10 +460,10 @@ class PersonaPoolService:
             raise ValueError("source_pool is required")
         from backend.service.persona_1m_pool import is_production_1m_root
 
-        if is_production_1m_root(src_rel):
+        if is_production_1m_root(src_rel) or src_rel.rstrip("/") == DEFAULT_PERSONA_POOL:
             raise ValueError(
-                "Cannot save the full MatrAIx Persona 1M root as a dataset. "
-                "Generate a cohort first, then save that cohort."
+                "Cannot save a full source dataset as a new dataset. "
+                "Pull a cohort first, then save that cohort."
             )
 
         src_dir = self._pool_dir(src_rel)
@@ -749,10 +766,13 @@ class PersonaPoolService:
                     if pid:
                         ids.append(pid)
 
+        count = len(ids)
+        truncated = count > PERSONA_UI_ID_LIST_MAX
         return {
             "pool": persona_pool,
-            "personaIds": ids,
-            "count": len(ids),
+            "personaIds": ids[:PERSONA_CARD_PREVIEW_DEFAULT] if truncated else ids,
+            "count": count,
+            "idsTruncated": truncated,
         }
 
     def list_persona_cards(
@@ -1000,6 +1020,126 @@ class PersonaPoolService:
         more = f" (+{len(short) - 6} more)" if len(short) > 6 else ""
         return f"Incomplete stratify coverage: {preview}{more}"
 
+    def _shape_sample_response(
+        self,
+        result: dict[str, Any],
+        *,
+        preview_limit: int = PERSONA_CARD_PREVIEW_DEFAULT,
+        include_persona_ids: bool | None = None,
+    ) -> dict[str, Any]:
+        """Truncate cards/IDs for UI; keep selectedCount as the full cohort size."""
+        ids = [str(pid) for pid in (result.get("personaIds") or []) if str(pid).strip()]
+        personas = [row for row in (result.get("personas") or []) if isinstance(row, dict)]
+        sample_size = int(result.get("sampleSize") or len(ids) or len(personas) or 0)
+        if include_persona_ids is None:
+            include_persona_ids = sample_size <= PERSONA_UI_ID_LIST_MAX
+        if sample_size <= PERSONA_UI_ID_LIST_MAX:
+            card_limit = min(sample_size, max(int(preview_limit), sample_size), 100)
+        else:
+            card_limit = min(sample_size, max(1, int(preview_limit)))
+        preview_cards = personas[:card_limit]
+        if not preview_cards and ids:
+            preview_cards = [
+                {
+                    "personaId": pid,
+                    "name": f"persona-{pid}",
+                    "dimensions": {},
+                }
+                for pid in ids[:card_limit]
+            ]
+        preview_ids = [
+            str(row.get("personaId") or "").strip()
+            for row in preview_cards
+            if str(row.get("personaId") or "").strip()
+        ]
+        shaped = dict(result)
+        shaped["sampleSize"] = sample_size
+        shaped["selectedCount"] = sample_size
+        shaped["personas"] = preview_cards
+        shaped["personaIds"] = ids if include_persona_ids else preview_ids
+        shaped["idsTruncated"] = (not include_persona_ids) and sample_size > len(shaped["personaIds"])
+        return shaped
+
+    def _materialize_sample_cohort(
+        self,
+        chosen: list[dict[str, Any]],
+        *,
+        parent_pool: str,
+        seed: int,
+    ) -> dict[str, Any]:
+        """Copy chosen YAML personas into a stable cohort dir for ref-based launch."""
+        import hashlib
+
+        persona_ids = [
+            str(entry.get("persona_id") or entry.get("id") or "").strip()
+            for entry in chosen
+        ]
+        persona_ids = [pid for pid in persona_ids if pid]
+        digest = hashlib.sha1(
+            json.dumps(
+                {"pool": parent_pool, "seed": seed, "ids": persona_ids},
+                sort_keys=True,
+            ).encode("utf-8")
+        ).hexdigest()[:12]
+        rel_pool = _sampled_cohort_pool(parent_pool, digest)
+        out_dir = self.repo_root / rel_pool
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        manifest_personas: list[dict[str, Any]] = []
+        cards: list[dict[str, Any]] = []
+        for entry in chosen:
+            persona_id = str(entry.get("persona_id") or entry.get("id") or "").strip()
+            if not persona_id:
+                continue
+            source_path = _resolve_persona_yaml_path(
+                self.repo_root, entry, persona_id, self._pool_dir(parent_pool)
+            )
+            rel_yaml = f"{rel_pool}/persona_{persona_id}.yaml"
+            dest = self.repo_root / rel_yaml
+            if source_path.is_file():
+                shutil.copy2(source_path, dest)
+            else:
+                payload = {
+                    "persona_id": persona_id,
+                    "version": "1.0",
+                    "source": str(entry.get("source") or "unknown"),
+                    "dimensions": dict(entry.get("dimensions") or {}),
+                }
+                dest.write_text(
+                    yaml.safe_dump(payload, sort_keys=False, allow_unicode=False),
+                    encoding="utf-8",
+                )
+            card = self._persona_card({**entry, "path": rel_yaml, "persona_id": persona_id})
+            cards.append(card)
+            manifest_personas.append(
+                {
+                    "persona_id": persona_id,
+                    "path": rel_yaml,
+                    "source": card.get("source"),
+                    "dimensions": dict(card.get("dimensions") or {}),
+                }
+            )
+
+        manifest = {
+            "kind": "matraix-sample-cohort",
+            "parent_pool": parent_pool,
+            "count": len(manifest_personas),
+            "seed": seed,
+            "schema_version": "1.0",
+            "created_at": _utc_now(),
+            "personas": manifest_personas,
+        }
+        (out_dir / "manifest.json").write_text(
+            json.dumps(manifest, indent=2, ensure_ascii=True) + "\n",
+            encoding="utf-8",
+        )
+        return {
+            "pool": rel_pool,
+            "personaIds": [item["persona_id"] for item in manifest_personas],
+            "personas": cards,
+            "count": len(manifest_personas),
+        }
+
     def sample_pool(
         self,
         *,
@@ -1011,6 +1151,8 @@ class PersonaPoolService:
         stratify_fields: list[str] | None = None,
         sample_size_per_value_group: int | None = None,
         task_path: str | None = None,
+        preview_limit: int = PERSONA_CARD_PREVIEW_DEFAULT,
+        include_persona_ids: bool | None = None,
     ) -> dict[str, Any]:
         from backend.service.persona_1m_pool import (
             is_production_1m_root,
@@ -1021,7 +1163,7 @@ class PersonaPoolService:
 
         # Production 1M: sample + materialize a YAML cohort. Never synthesize.
         if is_production_1m_root(persona_pool):
-            return sample_production_1m(
+            result = sample_production_1m(
                 repo_root=self.repo_root,
                 sample_size=sample_size,
                 seed=seed,
@@ -1029,6 +1171,11 @@ class PersonaPoolService:
                 dimension_filters=list_filters or None,
                 stratify_fields=stratify_fields,
                 sample_size_per_value_group=sample_size_per_value_group,
+            )
+            return self._shape_sample_response(
+                result,
+                preview_limit=preview_limit,
+                include_persona_ids=include_persona_ids,
             )
 
         # Stratified quotas:
@@ -1081,7 +1228,7 @@ class PersonaPoolService:
                 raise ValueError(with_coverage_hint(gap, task_path=task_path))
 
         try:
-            return self._sample_pool_inner(
+            result = self._sample_pool_inner(
                 persona_pool=persona_pool,
                 sample_size=sample_size,
                 seed=seed,
@@ -1092,6 +1239,11 @@ class PersonaPoolService:
             )
         except ValueError as exc:
             raise ValueError(with_coverage_hint(str(exc), task_path=task_path)) from exc
+        return self._shape_sample_response(
+            result,
+            preview_limit=preview_limit,
+            include_persona_ids=include_persona_ids,
+        )
 
     def _sample_pool_inner(
         self,
@@ -1157,12 +1309,23 @@ class PersonaPoolService:
                 )
             chosen = sample_personas(matched, sample_size=sample_size, seed=seed)
         personas = [self._persona_card(entry) for entry in chosen]
+        persona_ids = [row["personaId"] for row in personas if row["personaId"]]
+        pool_out = persona_pool
+        if len(persona_ids) > PERSONA_UI_ID_LIST_MAX:
+            materialized = self._materialize_sample_cohort(
+                chosen,
+                parent_pool=persona_pool,
+                seed=seed,
+            )
+            pool_out = str(materialized["pool"])
+            persona_ids = list(materialized["personaIds"])
+            personas = list(materialized["personas"])
         return {
-            "pool": persona_pool,
+            "pool": pool_out,
             "matchedCount": len(matched),
-            "sampleSize": len(personas),
+            "sampleSize": len(persona_ids),
             "seed": seed,
-            "personaIds": [row["personaId"] for row in personas if row["personaId"]],
+            "personaIds": persona_ids,
             "personas": personas,
             "stratifyFields": list(stratify_fields or []),
         }

--- a/application/playground/backend/tests/test_persona_pool_service.py
+++ b/application/playground/backend/tests/test_persona_pool_service.py
@@ -209,6 +209,36 @@ def test_save_pool_as_dataset(tmp_path):
     assert again["pool"] == "persona/datasets/my-robinhood-cohort"
 
 
+def test_save_pool_as_dataset_from_sample_cohort(tmp_path, monkeypatch):
+    repo = tmp_path
+    _write_pool(repo)
+    monkeypatch.setattr(
+        "playground.harbor.playground._repo_root",
+        lambda: repo,
+    )
+    cohort = (
+        repo / "persona" / "datasets" / "matraix-persona-dev-sample" / "cohorts" / "cohort-dev110"
+    )
+    cohort.mkdir(parents=True)
+    (cohort / "persona_0001.yaml").write_text(
+        "persona_id: '0001'\nversion: '1.0'\nsource: Nemotron\ndimensions: {}\n",
+        encoding="utf-8",
+    )
+    (cohort / "persona_0002.yaml").write_text(
+        "persona_id: '0002'\nversion: '1.0'\nsource: OASIS\ndimensions: {}\n",
+        encoding="utf-8",
+    )
+    service = PersonaPoolService(repo_root=repo)
+    saved = service.save_pool_as_dataset(
+        source_pool="persona/datasets/matraix-persona-dev-sample/cohorts/cohort-dev110",
+        name="Dev Feedback 110",
+    )
+    assert saved["pool"] == "persona/datasets/dev-feedback-110"
+    assert saved["count"] == 2
+    listed = {item["pool"] for item in service.list_datasets()}
+    assert "persona/datasets/dev-feedback-110" in listed
+
+
 def test_save_list_and_resolve_cohort(tmp_path, monkeypatch):
     repo = tmp_path
     _write_pool(repo)
@@ -574,3 +604,105 @@ def test_list_persona_cards_all_personas(tmp_path, monkeypatch):
 
     full_pool = service.list_persona_cards(limit=500, all_personas=True)
     assert [card["personaId"] for card in full_pool["personas"]] == ["0001", "0002"]
+
+
+def _write_large_pool(repo: Path, count: int = 120) -> None:
+    pool = repo / "persona" / "datasets" / "matraix-persona-dev-sample"
+    pool.mkdir(parents=True, exist_ok=True)
+    personas = []
+    for i in range(1, count + 1):
+        pid = f"{i:04d}"
+        (pool / f"persona_{pid}.yaml").write_text(
+            f"persona_id: '{pid}'\nversion: '1.0'\nsource: Nemotron\ndimensions:\n  economic_motivation: Price-sensitive\n",
+            encoding="utf-8",
+        )
+        personas.append(
+            {
+                "persona_id": pid,
+                "path": f"persona/datasets/matraix-persona-dev-sample/persona_{pid}.yaml",
+                "source": "Nemotron",
+                "dimensions": {"economic_motivation": "Price-sensitive"},
+            }
+        )
+    (pool / "manifest.json").write_text(
+        json.dumps(
+            {
+                "count": count,
+                "smoke_persona_id": "0001",
+                "schema_version": "1.0",
+                "source_counts": {"Nemotron": count},
+                "dimension_categories": "persona/schema/dimension_categories.json",
+                "personas": personas,
+            }
+        ),
+        encoding="utf-8",
+    )
+    schema = repo / "persona" / "schema"
+    schema.mkdir(parents=True, exist_ok=True)
+    (schema / "dimension_categories.json").write_text(
+        json.dumps(
+            {
+                "schemaVersion": "1.0",
+                "personaSources": ["Nemotron"],
+                "devProfile": {
+                    "dimensionCount": 1,
+                    "groups": [
+                        {
+                            "id": "values",
+                            "label": "Values",
+                            "dimensionIds": ["economic_motivation"],
+                        }
+                    ],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (schema / "dimensions.json").write_text(
+        json.dumps(
+            {
+                "schemaVersion": "1.0",
+                "dimensions": [
+                    {
+                        "id": "economic_motivation",
+                        "label": "Economic motivation",
+                        "category": "Values & Motivation",
+                        "values": ["Price-sensitive"],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_sample_pool_truncates_ids_and_materializes_large_cohort(tmp_path, monkeypatch):
+    repo = tmp_path
+    _write_large_pool(repo, count=120)
+    monkeypatch.setattr(
+        "playground.harbor.playground._repo_root",
+        lambda: repo,
+    )
+    service = PersonaPoolService(repo_root=repo)
+    result = service.sample_pool(sample_size=120, seed=7)
+    assert result["selectedCount"] == 120
+    assert result["sampleSize"] == 120
+    assert result["idsTruncated"] is True
+    assert len(result["personaIds"]) <= 32
+    assert len(result["personas"]) <= 32
+    assert result["pool"].startswith("persona/datasets/matraix-persona-dev-sample/cohorts/")
+    assert (repo / result["pool"]).is_dir()
+
+
+def test_list_persona_ids_truncates_over_ui_max(tmp_path, monkeypatch):
+    repo = tmp_path
+    _write_large_pool(repo, count=120)
+    monkeypatch.setattr(
+        "playground.harbor.playground._repo_root",
+        lambda: repo,
+    )
+    service = PersonaPoolService(repo_root=repo)
+    listed = service.list_persona_ids("persona/datasets/matraix-persona-dev-sample")
+    assert listed["count"] == 120
+    assert listed["idsTruncated"] is True
+    assert len(listed["personaIds"]) <= 32

--- a/application/playground/frontend/scripts/cohort-ref-contract.test.mjs
+++ b/application/playground/frontend/scripts/cohort-ref-contract.test.mjs
@@ -1,0 +1,48 @@
+/**
+ * Contract checks for cohort-ref frontend helpers (no vitest runner in package).
+ * Run: node --test application/playground/frontend/scripts/cohort-ref-contract.test.mjs
+ */
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+function read(rel) {
+  return readFileSync(join(root, rel), "utf8");
+}
+
+test("PERSONA_UI_ID_LIST_MAX is 100", () => {
+  const types = read("src/lib/types.ts");
+  assert.match(types, /export const PERSONA_UI_ID_LIST_MAX = 100/);
+});
+
+test("Save as dataset is offered for both 1M and dev sample launch caches", () => {
+  const rail = read("src/components/cockpit/setup/PersonaSamplingRail.tsx");
+  assert.match(rail, /isMaterializedCohortPool/);
+  assert.match(rail, /parentDatasetFromCohortPool/);
+  assert.match(rail, /canSaveAsDataset/);
+});
+
+test("storage persists selectedCount / useEntirePool without giant ID arrays", () => {
+  const storage = read("src/components/cockpit/setup/cockpitPersonaSetupStorage.ts");
+  assert.match(storage, /selectedCount/);
+  assert.match(storage, /useEntirePool/);
+  assert.match(storage, /PERSONA_UI_ID_LIST_MAX/);
+  assert.match(storage, /cohorts\\\/cohort-/);
+});
+
+test("launch helper omits personaIds when useEntirePool", () => {
+  const launch = read("src/components/cockpit/setup/personaLaunchFields.ts");
+  assert.match(launch, /useEntirePool:\s*true/);
+  assert.match(launch, /personaIds:\s*input\.selectedPersonaIds/);
+});
+
+test("parallel trials are not hard-capped by task type", () => {
+  assert.throws(() => read("src/components/cockpit/setup/cockpitParallelCaps.ts"), /ENOENT/);
+  const bar = read("src/components/cockpit/setup/RunLaunchBar.tsx");
+  assert.doesNotMatch(bar, /parallelCap/);
+  assert.match(bar, /const parallelMax = Math\.max\(1, personaCount\)/);
+});

--- a/application/playground/frontend/src/components/cockpit/OsAppEvalCockpit.tsx
+++ b/application/playground/frontend/src/components/cockpit/OsAppEvalCockpit.tsx
@@ -35,6 +35,11 @@ import { InstructionPanel } from "./InstructionPanel";
 import { OsAppEvalScorecard } from "./TaskEvalScorecard";
 import { CockpitSetupShell } from "./setup/CockpitSetupShell";
 import { PersonaSamplingRail } from "./setup/PersonaSamplingRail";
+import {
+  buildPersonaLaunchFields,
+  hasLaunchableCohort,
+  resolveCohortSize,
+} from "./setup/personaLaunchFields";
 import { CockpitPipelineDiagram } from "./setup/CockpitPipelineDiagram";
 import { TaskSelectionRail } from "./setup/TaskSelectionRail";
 import { CockpitRunCenter } from "./setup/CockpitRunCenter";
@@ -146,6 +151,10 @@ export function OsAppEvalCockpit({
     setSamplingMode,
     selectedPersonaIds,
     setSelectedPersonaIds,
+    selectedCount,
+    setSelectedCount,
+    useEntirePool,
+    setUseEntirePool,
     groupFilters,
     setGroupFilters,
     stratifyFields,
@@ -183,7 +192,7 @@ export function OsAppEvalCockpit({
     expectedTrialCount,
     completedTrials: batchCompletedTrials,
     batchError,
-  } = useCockpitBatchJob(selectedPersonaIds, parallelTrials, "os-app");
+  } = useCockpitBatchJob(selectedPersonaIds, parallelTrials, "os-app", selectedCount);
 
 
   const { setupLocked, visiblePersonaIds } = useCockpitSetupLock(
@@ -267,20 +276,35 @@ export function OsAppEvalCockpit({
   const taskCards = useMemo(() => osAppTaskCards(tasks), [tasks]);
 
   const harborLaunchBody = useCallback(
-    (targetTask: OsAppEvalTask) => ({
-      taskPath: targetTask.taskPath,
-      sampleSize: selectedPersonaIds.length,
+    (targetTask: OsAppEvalTask) => {
+      const personaFields = buildPersonaLaunchFields({
+        personaPool,
+        selectedPersonaIds,
+        selectedCount,
+        useEntirePool,
+        parallelTrials,
+      });
+      return {
+        taskPath: targetTask.taskPath,
+        seed,
+        personaModel,
+        agentName: "persona-computer-1",
+        osAppBackend: resolveCuaRuntime(targetTask.id, targetTask.platform),
+        ...personaFields,
+        mode: "auto" as const,
+        osAppSubmissionProfile: targetTask.osAppSubmissionProfile ?? undefined,
+      };
+    },
+    [
+      selectedPersonaIds,
+      selectedCount,
+      useEntirePool,
       seed,
       personaModel,
-      agentName: "persona-computer-1",
-      osAppBackend: resolveCuaRuntime(targetTask.id, targetTask.platform),
+      resolveCuaRuntime,
+      parallelTrials,
       personaPool,
-      personaIds: selectedPersonaIds,
-      nConcurrentTrials: Math.min(parallelTrials, selectedPersonaIds.length),
-      mode: "auto" as const,
-      osAppSubmissionProfile: targetTask.osAppSubmissionProfile ?? undefined,
-    }),
-    [selectedPersonaIds, seed, personaModel, resolveCuaRuntime, parallelTrials, personaPool],
+    ],
   );
 
   const handleRun = useCallback(() => {
@@ -306,7 +330,13 @@ export function OsAppEvalCockpit({
   }, [persona, task, isRunning, run, personaModel, activeCuaRuntime]);
 
   const handleLaunch = useCallback(async () => {
-    if (selectedPersonaIds.length === 0 || !task || isRunning) return;
+    if (
+      !hasLaunchableCohort({ selectedPersonaIds, selectedCount, useEntirePool }) ||
+      !task ||
+      isRunning
+    ) {
+      return;
+    }
     if (isBatchRun) {
       setLaunchError(null);
       try {
@@ -319,7 +349,17 @@ export function OsAppEvalCockpit({
       return;
     }
     handleRun();
-  }, [selectedPersonaIds, task, isRunning, isBatchRun, harborLaunchBody, handleRun]);
+  }, [
+    selectedPersonaIds,
+    selectedCount,
+    useEntirePool,
+    task,
+    isRunning,
+    isBatchRun,
+    harborLaunchBody,
+    handleRun,
+    setBatchJobName,
+  ]);
 
   const handleNewRun = useCallback(() => {
     reset();
@@ -450,6 +490,10 @@ export function OsAppEvalCockpit({
           onModeChange={setSamplingMode}
           selectedPersonaIds={visiblePersonaIds}
           onSelectedPersonaIdsChange={setSelectedPersonaIds}
+          selectedCount={selectedCount}
+          onSelectedCountChange={setSelectedCount}
+          useEntirePool={useEntirePool}
+          onUseEntirePoolChange={setUseEntirePool}
           sampleSize={sampleSize}
           onSampleSizeChange={setSampleSize}
           sampleSizePerValueGroup={sampleSizePerValueGroup}
@@ -491,9 +535,16 @@ export function OsAppEvalCockpit({
           progressSublabel={
             batchJobName && batchComplete ? BATCH_RUN_COMPLETE_HINT : undefined
           }
-          canRun={visiblePersonaIds.length > 0 && Boolean(task) && !runBusy}
+          canRun={
+            hasLaunchableCohort({ selectedPersonaIds, selectedCount, useEntirePool }) &&
+            Boolean(task) &&
+            !runBusy
+          }
           isBatch={isBatchRun}
-          personaCount={visiblePersonaIds.length}
+          personaCount={Math.max(
+            resolveCohortSize({ selectedPersonaIds, selectedCount }),
+            visiblePersonaIds.length,
+          )}
           parallelTrials={parallelTrials}
           onParallelTrialsChange={setParallelTrials}
           runBusy={runBusy}

--- a/application/playground/frontend/src/components/cockpit/PlaygroundCockpit.tsx
+++ b/application/playground/frontend/src/components/cockpit/PlaygroundCockpit.tsx
@@ -33,6 +33,11 @@ import { OsAppEvalCockpit } from "./OsAppEvalCockpit";
 import { type PlaygroundTaskType } from "./TaskTypeSwitch";
 import { CockpitSetupShell } from "./setup/CockpitSetupShell";
 import { PersonaSamplingRail } from "./setup/PersonaSamplingRail";
+import {
+  buildPersonaLaunchFields,
+  hasLaunchableCohort,
+  resolveCohortSize,
+} from "./setup/personaLaunchFields";
 import { CockpitPipelineDiagram } from "./setup/CockpitPipelineDiagram";
 import { TaskSelectionRail, type ChatTransport, type TaskCardModel } from "./setup/TaskSelectionRail";
 import { BatchTrialGrid } from "./setup/BatchTrialGrid";
@@ -309,6 +314,10 @@ function ChatbotEvalCockpit({
     setSamplingMode,
     selectedPersonaIds,
     setSelectedPersonaIds,
+    selectedCount,
+    setSelectedCount,
+    useEntirePool,
+    setUseEntirePool,
     groupFilters,
     setGroupFilters,
     stratifyFields,
@@ -352,7 +361,7 @@ function ChatbotEvalCockpit({
     expectedTrialCount,
     personaById,
     batchError,
-  } = useCockpitBatchJob(selectedPersonaIds, parallelTrials, "chatbot");
+  } = useCockpitBatchJob(selectedPersonaIds, parallelTrials, "chatbot", selectedCount);
   const [exportSnapshot, setExportSnapshot] = useState<ExportSnapshot | null>(null);
 
   // After navigating away/back, single-trial restore brings back the transcript
@@ -543,18 +552,29 @@ function ChatbotEvalCockpit({
   ]);
 
   const handleLaunch = useCallback(async () => {
-    if (selectedPersonaIds.length === 0 || isRunning || !chatTaskPath || !selectedTask) return;
+    if (
+      !hasLaunchableCohort({ selectedPersonaIds, selectedCount, useEntirePool }) ||
+      isRunning ||
+      !chatTaskPath ||
+      !selectedTask
+    ) {
+      return;
+    }
     if (isBatchRun) {
       setLaunchError(null);
       try {
+        const personaFields = buildPersonaLaunchFields({
+          personaPool,
+          selectedPersonaIds,
+          selectedCount,
+          useEntirePool,
+          parallelTrials,
+        });
         const launched = await api.launchHarborJob({
           taskPath: chatTaskPath,
-          sampleSize: selectedPersonaIds.length,
           seed,
           personaModel,
-          personaPool,
-          personaIds: selectedPersonaIds,
-          nConcurrentTrials: Math.min(parallelTrials, selectedPersonaIds.length),
+          ...personaFields,
           mode: "auto",
           chatDomain: requestDomain,
           chatApplicationId: knownLaunchApplicationId ?? undefined,
@@ -571,6 +591,8 @@ function ChatbotEvalCockpit({
     handleRun();
   }, [
     selectedPersonaIds,
+    selectedCount,
+    useEntirePool,
     isRunning,
     isBatchRun,
     applicationId,
@@ -585,6 +607,7 @@ function ChatbotEvalCockpit({
     chatTaskPath,
     selectedTask,
     handleRun,
+    setBatchJobName,
   ]);
 
   const handleRetry = useCallback(() => {
@@ -809,6 +832,10 @@ function ChatbotEvalCockpit({
           onModeChange={setSamplingMode}
           selectedPersonaIds={visiblePersonaIds}
           onSelectedPersonaIdsChange={setSelectedPersonaIds}
+          selectedCount={selectedCount}
+          onSelectedCountChange={setSelectedCount}
+          useEntirePool={useEntirePool}
+          onUseEntirePoolChange={setUseEntirePool}
           sampleSize={sampleSize}
           onSampleSizeChange={setSampleSize}
           sampleSizePerValueGroup={sampleSizePerValueGroup}
@@ -873,9 +900,16 @@ function ChatbotEvalCockpit({
             </div>
           )}
           <RunLaunchBar
-            canRun={visiblePersonaIds.length > 0 && Boolean(chatTaskPath) && !runBusy}
+            canRun={
+              hasLaunchableCohort({ selectedPersonaIds, selectedCount, useEntirePool }) &&
+              Boolean(chatTaskPath) &&
+              !runBusy
+            }
             isBatch={isBatchRun}
-            personaCount={visiblePersonaIds.length}
+            personaCount={Math.max(
+              resolveCohortSize({ selectedPersonaIds, selectedCount }),
+              visiblePersonaIds.length,
+            )}
             parallelTrials={parallelTrials}
             onParallelTrialsChange={setParallelTrials}
             isRunning={runBusy}

--- a/application/playground/frontend/src/components/cockpit/SurveyEvalCockpit.tsx
+++ b/application/playground/frontend/src/components/cockpit/SurveyEvalCockpit.tsx
@@ -57,6 +57,11 @@ import { InstructionPanel } from "./InstructionPanel";
 import { SurveyEvalScorecard } from "./TaskEvalScorecard";
 import { CockpitSetupShell } from "./setup/CockpitSetupShell";
 import { PersonaSamplingRail } from "./setup/PersonaSamplingRail";
+import {
+  buildPersonaLaunchFields,
+  hasLaunchableCohort,
+  resolveCohortSize,
+} from "./setup/personaLaunchFields";
 import { CockpitPipelineDiagram } from "./setup/CockpitPipelineDiagram";
 import { TaskSelectionRail } from "./setup/TaskSelectionRail";
 import { CockpitRunCenter } from "./setup/CockpitRunCenter";
@@ -209,6 +214,10 @@ export function SurveyEvalCockpit({
     setSamplingMode,
     selectedPersonaIds,
     setSelectedPersonaIds,
+    selectedCount,
+    setSelectedCount,
+    useEntirePool,
+    setUseEntirePool,
     groupFilters,
     setGroupFilters,
     stratifyFields,
@@ -246,7 +255,7 @@ export function SurveyEvalCockpit({
     expectedTrialCount,
     completedTrials: batchCompletedTrials,
     batchError,
-  } = useCockpitBatchJob(selectedPersonaIds, parallelTrials, "survey");
+  } = useCockpitBatchJob(selectedPersonaIds, parallelTrials, "survey", selectedCount);
   const setupLocked = phase !== "idle" || Boolean(batchJobName);
   const visiblePersonaIds = setupLocked && batchPersonaIds.length > 0 ? batchPersonaIds : selectedPersonaIds;
   const activeTaskId = batchJobName && batchTaskId ? batchTaskId : selectedTaskId;
@@ -370,22 +379,30 @@ export function SurveyEvalCockpit({
   }, [selectedCard, launchSurveyRun]);
 
   const handleLaunch = useCallback(async () => {
-    if (selectedPersonaIds.length === 0 || !selectedCard || isRunning) return;
+    if (
+      !hasLaunchableCohort({ selectedPersonaIds, selectedCount, useEntirePool }) ||
+      !selectedCard ||
+      isRunning
+    ) {
+      return;
+    }
     if (isBatchRun) {
       setLaunchError(null);
       try {
-        const launched = await api.launchHarborJob(
-          {
-            taskPath: selectedCard.taskPath || HARBOR_TASK_PATHS.survey,
-            sampleSize: selectedPersonaIds.length,
-            seed,
-            personaModel,
-            personaPool,
-            personaIds: selectedPersonaIds,
-            nConcurrentTrials: Math.min(parallelTrials, selectedPersonaIds.length),
-            mode: "auto",
-          },
-        );
+        const personaFields = buildPersonaLaunchFields({
+          personaPool,
+          selectedPersonaIds,
+          selectedCount,
+          useEntirePool,
+          parallelTrials,
+        });
+        const launched = await api.launchHarborJob({
+          taskPath: selectedCard.taskPath || HARBOR_TASK_PATHS.survey,
+          seed,
+          personaModel,
+          ...personaFields,
+          mode: "auto",
+        });
         setBatchJobName(launched.jobName, { taskId: selectedCard.id });
       } catch (exc) {
         const message = exc instanceof ApiError ? exc.message : exc instanceof Error ? exc.message : String(exc);
@@ -396,6 +413,8 @@ export function SurveyEvalCockpit({
     handleRun();
   }, [
     selectedPersonaIds,
+    selectedCount,
+    useEntirePool,
     selectedCard,
     isRunning,
     isBatchRun,
@@ -404,6 +423,7 @@ export function SurveyEvalCockpit({
     parallelTrials,
     personaPool,
     handleRun,
+    setBatchJobName,
   ]);
 
   const handleNewRun = useCallback(() => {
@@ -545,6 +565,10 @@ export function SurveyEvalCockpit({
           onModeChange={setSamplingMode}
           selectedPersonaIds={visiblePersonaIds}
           onSelectedPersonaIdsChange={setSelectedPersonaIds}
+          selectedCount={selectedCount}
+          onSelectedCountChange={setSelectedCount}
+          useEntirePool={useEntirePool}
+          onUseEntirePoolChange={setUseEntirePool}
           sampleSize={sampleSize}
           onSampleSizeChange={setSampleSize}
           sampleSizePerValueGroup={sampleSizePerValueGroup}
@@ -584,9 +608,16 @@ export function SurveyEvalCockpit({
           progressSublabel={
             batchJobName && batchComplete ? BATCH_RUN_COMPLETE_HINT : undefined
           }
-          canRun={selectedPersonaIds.length > 0 && Boolean(selectedCard) && !runBusy}
+          canRun={
+            hasLaunchableCohort({ selectedPersonaIds, selectedCount, useEntirePool }) &&
+            Boolean(selectedCard) &&
+            !runBusy
+          }
           isBatch={isBatchRun}
-          personaCount={visiblePersonaIds.length}
+          personaCount={Math.max(
+            resolveCohortSize({ selectedPersonaIds, selectedCount }),
+            visiblePersonaIds.length,
+          )}
           parallelTrials={parallelTrials}
           onParallelTrialsChange={setParallelTrials}
           runBusy={runBusy}

--- a/application/playground/frontend/src/components/cockpit/WebEvalCockpit.tsx
+++ b/application/playground/frontend/src/components/cockpit/WebEvalCockpit.tsx
@@ -52,6 +52,11 @@ import { InstructionPanel } from "./InstructionPanel";
 import { WebEvalScorecard } from "./TaskEvalScorecard";
 import { CockpitSetupShell } from "./setup/CockpitSetupShell";
 import { PersonaSamplingRail } from "./setup/PersonaSamplingRail";
+import {
+  buildPersonaLaunchFields,
+  hasLaunchableCohort,
+  resolveCohortSize,
+} from "./setup/personaLaunchFields";
 import { CockpitPipelineDiagram } from "./setup/CockpitPipelineDiagram";
 import { TaskSelectionRail } from "./setup/TaskSelectionRail";
 import { CockpitRunCenter } from "./setup/CockpitRunCenter";
@@ -170,6 +175,10 @@ export function WebEvalCockpit({
     setSamplingMode,
     selectedPersonaIds,
     setSelectedPersonaIds,
+    selectedCount,
+    setSelectedCount,
+    useEntirePool,
+    setUseEntirePool,
     groupFilters,
     setGroupFilters,
     stratifyFields,
@@ -207,7 +216,7 @@ export function WebEvalCockpit({
     expectedTrialCount,
     completedTrials: batchCompletedTrials,
     batchError,
-  } = useCockpitBatchJob(selectedPersonaIds, parallelTrials, "web");
+  } = useCockpitBatchJob(selectedPersonaIds, parallelTrials, "web", selectedCount);
 
 
   const { setupLocked, visiblePersonaIds } = useCockpitSetupLock(
@@ -335,19 +344,29 @@ export function WebEvalCockpit({
     });
   }, [persona, task, isRunning, run, personaModel, activeWebAgent]);
   const handleLaunch = useCallback(async () => {
-    if (selectedPersonaIds.length === 0 || !task?.taskPath || isRunning) return;
+    if (
+      !hasLaunchableCohort({ selectedPersonaIds, selectedCount, useEntirePool }) ||
+      !task?.taskPath ||
+      isRunning
+    ) {
+      return;
+    }
     if (isBatchRun) {
       setLaunchError(null);
       try {
+        const personaFields = buildPersonaLaunchFields({
+          personaPool,
+          selectedPersonaIds,
+          selectedCount,
+          useEntirePool,
+          parallelTrials,
+        });
         const launched = await api.launchHarborJob({
           taskPath: task.taskPath,
-          sampleSize: selectedPersonaIds.length,
           seed,
           personaModel,
           agentName: activeWebAgent,
-          personaPool,
-          personaIds: selectedPersonaIds,
-          nConcurrentTrials: Math.min(parallelTrials, selectedPersonaIds.length),
+          ...personaFields,
           mode: "auto",
         });
         setBatchJobName(launched.jobName, { taskId: task.id });
@@ -360,6 +379,8 @@ export function WebEvalCockpit({
     handleRun();
   }, [
     selectedPersonaIds,
+    selectedCount,
+    useEntirePool,
     task,
     isRunning,
     isBatchRun,
@@ -369,6 +390,7 @@ export function WebEvalCockpit({
     parallelTrials,
     personaPool,
     handleRun,
+    setBatchJobName,
   ]);
 
   const handleNewRun = useCallback(() => {
@@ -497,6 +519,10 @@ export function WebEvalCockpit({
           onModeChange={setSamplingMode}
           selectedPersonaIds={visiblePersonaIds}
           onSelectedPersonaIdsChange={setSelectedPersonaIds}
+          selectedCount={selectedCount}
+          onSelectedCountChange={setSelectedCount}
+          useEntirePool={useEntirePool}
+          onUseEntirePoolChange={setUseEntirePool}
           sampleSize={sampleSize}
           onSampleSizeChange={setSampleSize}
           sampleSizePerValueGroup={sampleSizePerValueGroup}
@@ -545,9 +571,16 @@ export function WebEvalCockpit({
           progressSublabel={
             batchJobName && batchComplete ? BATCH_RUN_COMPLETE_HINT : undefined
           }
-          canRun={visiblePersonaIds.length > 0 && Boolean(task?.taskPath) && !runBusy}
+          canRun={
+            hasLaunchableCohort({ selectedPersonaIds, selectedCount, useEntirePool }) &&
+            Boolean(task?.taskPath) &&
+            !runBusy
+          }
           isBatch={isBatchRun}
-          personaCount={visiblePersonaIds.length}
+          personaCount={Math.max(
+            resolveCohortSize({ selectedPersonaIds, selectedCount }),
+            visiblePersonaIds.length,
+          )}
           parallelTrials={parallelTrials}
           onParallelTrialsChange={setParallelTrials}
           runBusy={runBusy}

--- a/application/playground/frontend/src/components/cockpit/setup/BatchTrialGrid.tsx
+++ b/application/playground/frontend/src/components/cockpit/setup/BatchTrialGrid.tsx
@@ -398,6 +398,7 @@ function personaMetaFromCard(card: PersonaPoolPersonaCard | undefined): BatchTri
 function resolveBatchGridSlots(
   personaIds: string[],
   harborTrials: HarborTrialRow[] | undefined,
+  expectedTotal = 0,
 ): BatchGridSlot[] {
   const trials = harborTrials ?? [];
   if (personaIds.length > 0) {
@@ -417,16 +418,31 @@ function resolveBatchGridSlots(
         unmatched.push(trial);
       }
     }
+    const previewKeys = new Set(personaIds.map((id) => personaDisplayId(id)));
+    const leftovers = [...byPersona.entries()]
+      .filter(([key]) => !previewKeys.has(key))
+      .map(([, trial]) => trial);
     let nextUnmatched = 0;
-    return personaIds.map((personaId) => {
-      let trial = byPersona.get(personaDisplayId(personaId));
+    let nextLeftover = 0;
+    const slotCount = Math.max(personaIds.length, expectedTotal, trials.length);
+    return Array.from({ length: slotCount }, (_, index) => {
+      const personaId = personaIds[index];
+      let trial = personaId ? byPersona.get(personaDisplayId(personaId)) : undefined;
+      if (!trial && nextLeftover < leftovers.length) {
+        trial = leftovers[nextLeftover++];
+      }
       if (!trial && nextUnmatched < unmatched.length) {
         // Temporarily show an unattributed live trial on a still-empty slot so
         // the running count stays accurate; it snaps to the right cell once
         // persona_meta lands.
         trial = unmatched[nextUnmatched++];
       }
-      return { personaId, label: `persona-${personaId}`, trial };
+      const id = personaId ?? trial?.personaId ?? trial?.trialName ?? `pending-${index}`;
+      return {
+        personaId: id,
+        label: trial?.personaName ?? (personaId ? `persona-${personaId}` : `persona-${index + 1}`),
+        trial,
+      };
     });
   }
   return trials.map((trial) => ({
@@ -446,10 +462,11 @@ export function buildBatchGridCells(
     jobStarted?: boolean;
     parallelTrials?: number;
     personaById?: Record<string, PersonaPoolPersonaCard>;
+    expectedTotal?: number;
   } = {},
 ): BatchTrialCell[] {
-  const { personaById = {} } = opts;
-  const slots = resolveBatchGridSlots(personaIds, harborTrials);
+  const { personaById = {}, expectedTotal = 0 } = opts;
+  const slots = resolveBatchGridSlots(personaIds, harborTrials, expectedTotal);
   if (slots.length === 0) return [];
 
   return slots.map((slot) => {

--- a/application/playground/frontend/src/components/cockpit/setup/PersonaSamplingRail.tsx
+++ b/application/playground/frontend/src/components/cockpit/setup/PersonaSamplingRail.tsx
@@ -8,6 +8,7 @@ import {
   PERSONA_PRODUCTION_1M_POOL,
   PERSONA_SAMPLE_SIZE_MAX_DEV,
   PERSONA_SAMPLE_SIZE_MAX_PRODUCTION,
+  PERSONA_UI_ID_LIST_MAX,
   type PersonaPoolPersonaCard,
   type TaskPersonaStrategy,
 } from "@/lib/types";
@@ -64,10 +65,31 @@ function isProduction1mCohortPool(pool: string): boolean {
   return pool.includes("/matraix-persona-1m/cohorts/");
 }
 
+/** ``persona/datasets/<source>/cohorts/cohort-…`` — source dataset stays in the path. */
+function parentDatasetFromCohortPool(pool: string): string | null {
+  const match = pool.match(/^(persona\/datasets\/[^/]+)\/cohorts\/cohort-/);
+  return match?.[1] ?? null;
+}
+
+function isSampleCohortPool(pool: string): boolean {
+  const parent = parentDatasetFromCohortPool(pool);
+  return Boolean(parent) && parent !== PERSONA_PRODUCTION_1M_POOL;
+}
+
+/** Pulled launch cache (1M or local dataset) — can be saved as a reusable dataset. */
+function isMaterializedCohortPool(pool: string): boolean {
+  return isProduction1mCohortPool(pool) || isSampleCohortPool(pool);
+}
+
 /** Dataset dropdown source — cohorts are launch caches, not selectable sources. */
 function datasetSourcePool(pool: string): string {
   if (pool === PERSONA_PRODUCTION_1M_POOL || isProduction1mCohortPool(pool)) {
     return PERSONA_PRODUCTION_1M_POOL;
+  }
+  const parent = parentDatasetFromCohortPool(pool);
+  if (parent) return parent;
+  if (isSampleCohortPool(pool)) {
+    return PERSONA_BENCH_POOL;
   }
   return pool;
 }
@@ -188,6 +210,10 @@ export interface PersonaSamplingRailProps {
   onModeChange: (mode: PersonaSamplingMode) => void;
   selectedPersonaIds: string[];
   onSelectedPersonaIdsChange: (ids: string[]) => void;
+  selectedCount?: number;
+  onSelectedCountChange?: (count: number) => void;
+  useEntirePool?: boolean;
+  onUseEntirePoolChange?: (value: boolean) => void;
   sampleSize: number;
   onSampleSizeChange: (size: number) => void;
   /** Personas per stratify combination; null = cap at sampleSize (no explicit per-cell). */
@@ -205,7 +231,7 @@ export interface PersonaSamplingRailProps {
   taskPersonaStrategy?: TaskPersonaStrategy | null;
   useTaskDefaultStrategy?: boolean;
   onUseTaskDefaultStrategyChange?: (useDefault: boolean) => void;
-  /** Called when sampling resolves to a (possibly auto-generated) pool path. */
+  /** Called when sampling resolves to a (possibly materialized) pool path. */
   onPersonaPoolChange?: (pool: string) => void;
   /** Active pool path for the footer label (defaults to matraix-persona-dev-sample). */
   personaPool?: string | null;
@@ -220,6 +246,10 @@ export function PersonaSamplingRail({
   onModeChange,
   selectedPersonaIds,
   onSelectedPersonaIdsChange,
+  selectedCount = 0,
+  onSelectedCountChange,
+  useEntirePool = false,
+  onUseEntirePoolChange,
   sampleSize,
   onSampleSizeChange,
   sampleSizePerValueGroup,
@@ -241,9 +271,9 @@ export function PersonaSamplingRail({
 }: PersonaSamplingRailProps) {
   const [filterOpen, setFilterOpen] = useState(false);
   const [detailPersona, setDetailPersona] = useState<PersonaPoolPersonaCard | null>(null);
-  const [generatedCards, setGeneratedCards] = useState<PersonaPoolPersonaCard[]>([]);
-  const [generateError, setGenerateError] = useState<string | null>(null);
-    const [generating, setGenerating] = useState(false);
+  const [previewCards, setPreviewCards] = useState<PersonaPoolPersonaCard[]>([]);
+  const [pullError, setPullError] = useState<string | null>(null);
+    const [pulling, setPulling] = useState(false);
   /** Local draft so users can clear/retype without clamp fighting every keystroke. */
   const [sampleSizeDraft, setSampleSizeDraft] = useState<string | null>(null);
   const [perCellDraft, setPerCellDraft] = useState<string | null>(null);
@@ -258,7 +288,8 @@ export function PersonaSamplingRail({
   const isBenchPool = sourcePool === PERSONA_BENCH_POOL;
   const isProduction1m = sourcePool === PERSONA_PRODUCTION_1M_POOL;
   const canSaveAsDataset =
-    isProduction1mCohortPool(activePool) && selectedPersonaIds.length > 0;
+    isMaterializedCohortPool(activePool) && (selectedCount > 0 || selectedPersonaIds.length > 0);
+  const cohortSize = Math.max(selectedCount, selectedPersonaIds.length);
   const sampleSizeMax = isProduction1m
     ? PERSONA_SAMPLE_SIZE_MAX_PRODUCTION
     : PERSONA_SAMPLE_SIZE_MAX_DEV;
@@ -338,10 +369,10 @@ export function PersonaSamplingRail({
         dimensions: {},
       }));
     }
-    return generatedCards;
+    return previewCards;
   }, [
     quickPickCards,
-    generatedCards,
+    previewCards,
     mode,
     disabled,
     selectedPersonaIds,
@@ -349,60 +380,83 @@ export function PersonaSamplingRail({
   ]);
 
   useEffect(() => {
-    if (mode === "single") setGeneratedCards([]);
+    if (mode === "single") setPreviewCards([]);
   }, [mode]);
 
   const togglePersona = useCallback(
     (personaId: string) => {
+      if (useEntirePool) {
+        // Cohort-ref selection is not per-card editable.
+        return;
+      }
       if (mode === "single") {
         onSelectedPersonaIdsChange(
           selectedPersonaIds.includes(personaId) ? [] : [personaId],
         );
+        onSelectedCountChange?.(
+          selectedPersonaIds.includes(personaId) ? 0 : 1,
+        );
         return;
       }
-      onSelectedPersonaIdsChange(
-        selectedPersonaIds.includes(personaId)
-          ? selectedPersonaIds.filter((id) => id !== personaId)
-          : [...selectedPersonaIds, personaId],
-      );
+      const next = selectedPersonaIds.includes(personaId)
+        ? selectedPersonaIds.filter((id) => id !== personaId)
+        : [...selectedPersonaIds, personaId];
+      onSelectedPersonaIdsChange(next);
+      onSelectedCountChange?.(next.length);
     },
-    [mode, onSelectedPersonaIdsChange, selectedPersonaIds],
+    [
+      mode,
+      onSelectedCountChange,
+      onSelectedPersonaIdsChange,
+      selectedPersonaIds,
+      useEntirePool,
+    ],
   );
 
   const handleSelectAll = useCallback(async () => {
-    setGenerating(true);
-    setGenerateError(null);
+    setPulling(true);
+    setPullError(null);
     try {
       const pool = activePool;
       const idsResult = await api.listPersonaPoolIds(pool);
-      const personaIds = idsResult.personaIds;
-      if (personaIds.length === 0) {
+      const count = idsResult.count || idsResult.personaIds.length;
+      if (count === 0) {
         throw new ApiError(404, "This dataset has no persona YAML files.");
       }
+      const previewIds = idsResult.personaIds.slice(0, PERSONA_CARD_PREVIEW_LIMIT);
       const preview = await api.getPersonaPoolCards({
         pool,
-        limit: Math.min(PERSONA_CARD_PREVIEW_LIMIT, personaIds.length),
-        personaIds: personaIds.slice(0, PERSONA_CARD_PREVIEW_LIMIT),
+        limit: Math.min(PERSONA_CARD_PREVIEW_LIMIT, count),
+        personaIds: previewIds.length ? previewIds : undefined,
       });
-      setGeneratedCards(preview.personas);
-      onSelectedPersonaIdsChange(personaIds);
+      setPreviewCards(preview.personas);
+      const truncated = Boolean(idsResult.idsTruncated) || count > PERSONA_UI_ID_LIST_MAX;
+      onSelectedCountChange?.(count);
+      onUseEntirePoolChange?.(truncated);
+      onSelectedPersonaIdsChange(truncated ? preview.personas.map((p) => p.personaId) : idsResult.personaIds);
       onPersonaPoolChange?.(pool);
     } catch (err) {
       const raw =
         err instanceof ApiError ? err.message : "Could not load the full dataset cohort.";
-      setGenerateError(raw);
+      setPullError(raw);
       } finally {
-      setGenerating(false);
+      setPulling(false);
     }
-  }, [activePool, onPersonaPoolChange, onSelectedPersonaIdsChange]);
+  }, [
+    activePool,
+    onPersonaPoolChange,
+    onSelectedCountChange,
+    onSelectedPersonaIdsChange,
+    onUseEntirePoolChange,
+  ]);
 
-  const handleGenerate = useCallback(async () => {
+  const handlePull = useCallback(async () => {
     if (mode === "all") {
       await handleSelectAll();
       return;
     }
-    setGenerating(true);
-    setGenerateError(null);
+    setPulling(true);
+    setPullError(null);
     try {
       const dimensionFilters = filtersForSampleApi(filters);
       // Only send per-cell when explicitly set. Omitting it makes the backend
@@ -422,7 +476,6 @@ export function PersonaSamplingRail({
         sampleSizePerValueGroup: perCell,
         taskPath: taskPath?.trim() || undefined,
       });
-      // Select the full cohort immediately; only keep a small card preview for the rail.
       const cards = result.personas.slice(0, PERSONA_CARD_PREVIEW_LIMIT).map((row) => ({
         personaId: row.personaId,
         name: row.name ?? `persona-${row.personaId}`,
@@ -430,25 +483,31 @@ export function PersonaSamplingRail({
         path: row.path,
         dimensions: row.dimensions ?? {},
       }));
-      setGeneratedCards(cards);
+      setPreviewCards(cards);
+      const count = result.selectedCount ?? result.sampleSize ?? result.personaIds.length;
+      const truncated = Boolean(result.idsTruncated) || count > PERSONA_UI_ID_LIST_MAX;
+      onSelectedCountChange?.(count);
+      onUseEntirePoolChange?.(truncated);
       onSelectedPersonaIdsChange(result.personaIds);
       if (result.pool) {
         // Launch needs the materialized YAML dir; Dataset UI still shows sourcePool.
         onPersonaPoolChange?.(result.pool);
       }
     } catch (err) {
-      const raw = err instanceof ApiError ? err.message : "Could not generate sample.";
+      const raw = err instanceof ApiError ? err.message : "Could not pull cohort from this dataset.";
       const formatted = formatPersonaSampleError(raw, taskPath);
-      setGenerateError(formatted);
+      setPullError(formatted);
     } finally {
-      setGenerating(false);
+      setPulling(false);
     }
   }, [
     filters,
     handleSelectAll,
     mode,
     onPersonaPoolChange,
+    onSelectedCountChange,
     onSelectedPersonaIdsChange,
+    onUseEntirePoolChange,
     sampleSize,
     sampleSizePerValueGroup,
     seed,
@@ -489,8 +548,10 @@ export function PersonaSamplingRail({
       if (pool === sourcePool) return;
       onPersonaPoolChange?.(pool);
       onSelectedPersonaIdsChange([]);
-      setGeneratedCards([]);
-      setGenerateError(null);
+      onSelectedCountChange?.(0);
+      onUseEntirePoolChange?.(false);
+      setPreviewCards([]);
+      setPullError(null);
         setDetailPersona(null);
       setSaveOpen(false);
       setSaveDatasetError(null);
@@ -498,11 +559,11 @@ export function PersonaSamplingRail({
         onModeChange("random");
       }
     },
-    [mode, onModeChange, onPersonaPoolChange, onSelectedPersonaIdsChange, sourcePool],
+    [mode, onModeChange, onPersonaPoolChange, onSelectedCountChange, onSelectedPersonaIdsChange, onUseEntirePoolChange, sourcePool],
   );
 
   const handleSaveAsDataset = useCallback(async () => {
-    const name = saveNameDraft.trim() || `cohort-${selectedPersonaIds.length}`;
+    const name = saveNameDraft.trim() || `cohort-${cohortSize}`;
     const slug = slugifyDatasetName(name);
     if (!slug) {
       setSaveDatasetError("Enter a name with letters or numbers.");
@@ -531,7 +592,7 @@ export function PersonaSamplingRail({
     onPersonaPoolChange,
     queryClient,
     saveNameDraft,
-    selectedPersonaIds.length,
+    cohortSize,
   ]);
 
   const filterCount = activeFilterCount(filters);
@@ -540,8 +601,8 @@ export function PersonaSamplingRail({
     taskType === "survey" || taskType === "chatbot" || taskType === "web" || taskType === "os-app";
   const strategyLocked = hasTaskStrategy && useTaskDefaultStrategy;
   const customSamplingUnlocked = !strategyLocked;
-  const poolFooterLabel = isProduction1mCohortPool(activePool)
-    ? `${poolSlugLabel(sourcePool)} · sample ready`
+  const poolFooterLabel = isMaterializedCohortPool(activePool)
+    ? `${poolSlugLabel(sourcePool)} · cohort ready`
     : poolSlugLabel(sourcePool);
 
   return (
@@ -649,24 +710,24 @@ export function PersonaSamplingRail({
             </p>
             <button
               type="button"
-              disabled={disabled || generating}
+              disabled={disabled || pulling}
               onClick={() => void handleSelectAll()}
               className={`flex h-9 w-full items-center justify-center gap-1.5 rounded-lg bg-surface-high/90 text-[13px] font-medium text-text-main hover:bg-surface-high disabled:opacity-50 ${FOCUS_RING}`}
             >
               <Sym
-                name={generating ? "autorenew" : "done_all"}
+                name={pulling ? "autorenew" : "done_all"}
                 size={15}
-                className={generating ? "animate-rb-spin text-primary" : "text-primary"}
+                className={pulling ? "animate-rb-spin text-primary" : "text-primary"}
               />
-              {generating
+              {pulling
                 ? "Loading cohort…"
                 : typeof poolCount === "number"
                   ? `Select all · ${poolCount}`
                   : "Select all"}
             </button>
-            {generateError ? (
+            {pullError ? (
               <div className="space-y-1.5 rounded-lg border border-danger/30 bg-danger/5 px-2.5 py-2">
-                <p className="text-[12px] leading-snug text-danger">{generateError}</p>
+                <p className="text-[12px] leading-snug text-danger">{pullError}</p>
               </div>
             ) : null}
           </div>
@@ -775,21 +836,21 @@ export function PersonaSamplingRail({
               ) : null}
               <button
                 type="button"
-                disabled={disabled || generating}
-                onClick={() => void handleGenerate()}
+                disabled={disabled || pulling}
+                onClick={() => void handlePull()}
                 className={`flex h-9 min-w-0 flex-1 items-center justify-center gap-1.5 rounded-lg bg-surface-high/90 text-[13px] font-medium text-text-main hover:bg-surface-high disabled:opacity-50 ${FOCUS_RING}`}
               >
                 <Sym
-                  name={generating ? "autorenew" : "auto_awesome"}
+                  name={pulling ? "autorenew" : "download"}
                   size={15}
-                  className={generating ? "animate-rb-spin text-primary" : "text-primary"}
+                  className={pulling ? "animate-rb-spin text-primary" : "text-primary"}
                 />
-                {generating ? "Generating…" : "Generate preview"}
+                {pulling ? "Pulling…" : "Pull cohort"}
               </button>
             </div>
-            {generateError ? (
+            {pullError ? (
               <div className="space-y-1.5 rounded-lg border border-danger/30 bg-danger/5 px-2.5 py-2">
-                <p className="whitespace-pre-wrap text-[12px] leading-snug text-danger">{generateError}</p>
+                <p className="whitespace-pre-wrap text-[12px] leading-snug text-danger">{pullError}</p>
               </div>
             ) : null}
             {canSaveAsDataset && !disabled ? (
@@ -803,7 +864,7 @@ export function PersonaSamplingRail({
                       setSaveDatasetError(null);
                       if (!saveNameDraft.trim()) {
                         const stamp = new Date().toISOString().slice(0, 10);
-                        setSaveNameDraft(`sample-${selectedPersonaIds.length}-${stamp}`);
+                        setSaveNameDraft(`sample-${cohortSize}-${stamp}`);
                       }
                     }}
                     className={`flex w-full items-center justify-center gap-1.5 rounded-md py-1.5 text-[12px] font-medium text-primary hover:bg-primary/5 disabled:opacity-50 ${FOCUS_RING}`}
@@ -900,11 +961,11 @@ export function PersonaSamplingRail({
               />
             ))}
             {mode !== "single" &&
-              selectedPersonaIds.length > displayCards.length &&
+              cohortSize > displayCards.length &&
               displayCards.length > 0 && (
                 <p className="rounded-lg border border-dashed border-outline/40 px-3 py-2 text-center text-[12px] text-text-dim">
-                  Previewing {displayCards.length} of {selectedPersonaIds.length} selected — full
-                  cohort is ready to launch.
+                  Previewing {displayCards.length} of {cohortSize.toLocaleString()} selected
+                  {useEntirePool ? " — launching by cohort ref" : " — full cohort is ready to launch"}.
                 </p>
               )}
             {mode === "single" && !defaultCardsQuery.isLoading && displayCards.length === 0 && (
@@ -915,10 +976,10 @@ export function PersonaSamplingRail({
             {mode !== "single" && displayCards.length === 0 && !disabled && (
               <p className="rounded-lg border border-dashed border-outline/40 p-4 text-center text-[13px] text-text-dim">
                 {strategyLocked
-                  ? "Generate a preview cohort from the task default strategy."
+                  ? "Pull the cohort this task recommends."
                   : mode === "all"
-                    ? "Select all to load every persona from the chosen dataset."
-                    : "Set filters and generate a preview cohort."}
+                    ? "Select all to use everyone in this dataset."
+                    : "Choose a sample size and Pull a cohort from this dataset."}
               </p>
             )}
             {mode !== "single" &&
@@ -931,7 +992,7 @@ export function PersonaSamplingRail({
       </div>
 
       <p className="mt-2 shrink-0 truncate text-center font-mono text-[12px] tracking-wide text-text-dim">
-        <span className="font-semibold text-primary">{selectedPersonaIds.length}</span> selected ·{" "}
+        <span className="font-semibold text-primary">{cohortSize.toLocaleString()}</span> selected ·{" "}
         {poolFooterLabel}
       </p>
       </>

--- a/application/playground/frontend/src/components/cockpit/setup/cockpitBatchStorage.ts
+++ b/application/playground/frontend/src/components/cockpit/setup/cockpitBatchStorage.ts
@@ -3,6 +3,8 @@ import type { HarborCockpitTaskKind } from "@/lib/harborCockpitMappers";
 export interface CockpitBatchRecord {
   jobName: string;
   personaIds: string[];
+  /** Full cohort size — may exceed personaIds when launching by pool ref. */
+  selectedCount?: number;
   taskId?: string;
 }
 
@@ -86,11 +88,17 @@ migrateLegacyBatchStore();
 export function readCockpitBatch(taskKind: HarborCockpitTaskKind): CockpitBatchRecord | null {
   const record = readStore()[taskKind];
   if (!record?.jobName) return null;
+  const personaIds = Array.isArray(record.personaIds)
+    ? record.personaIds.filter((id): id is string => typeof id === "string")
+    : [];
+  const selectedCount =
+    typeof record.selectedCount === "number" && record.selectedCount > 0
+      ? Math.round(record.selectedCount)
+      : personaIds.length;
   return {
     jobName: record.jobName,
-    personaIds: Array.isArray(record.personaIds)
-      ? record.personaIds.filter((id): id is string => typeof id === "string")
-      : [],
+    personaIds,
+    selectedCount,
     taskId: typeof record.taskId === "string" ? record.taskId : undefined,
   };
 }
@@ -104,6 +112,7 @@ export function writeCockpitBatch(
     store[taskKind] = {
       jobName: record.jobName,
       personaIds: record.personaIds,
+      selectedCount: record.selectedCount,
       taskId: record.taskId,
     };
   } else {

--- a/application/playground/frontend/src/components/cockpit/setup/cockpitPersonaSetupStorage.ts
+++ b/application/playground/frontend/src/components/cockpit/setup/cockpitPersonaSetupStorage.ts
@@ -1,6 +1,6 @@
 import type { HarborCockpitTaskKind } from "@/lib/harborCockpitMappers";
 import type { TaskPersonaStrategy } from "@/lib/types";
-import { PERSONA_BENCH_POOL } from "@/lib/types";
+import { PERSONA_BENCH_POOL, PERSONA_CARD_PREVIEW_LIMIT, PERSONA_UI_ID_LIST_MAX } from "@/lib/types";
 
 import { readCockpitBatch } from "./cockpitBatchStorage";
 import {
@@ -15,7 +15,14 @@ const LEGACY_BENCH_DEV_SAMPLE = "persona/datasets/bench-dev-sample";
 /** Drop legacy synthetic strategy pools from restored setup. */
 export function sanitizePersonaPool(pool: string | null | undefined): string {
   const text = (pool ?? "").trim();
-  if (!text || text.includes("/_generated/")) return PERSONA_BENCH_POOL;
+  if (!text) return PERSONA_BENCH_POOL;
+  // Allow launch caches next to their source dataset; drop leftover synthetic pools.
+  if (/persona\/datasets\/[^/]+\/cohorts\/cohort-/.test(text)) {
+    return text;
+  }
+  if (text.includes("/_generated/")) {
+    return PERSONA_BENCH_POOL;
+  }
   // Old cockpit / task setups still point at the removed bench-dev-sample path.
   if (text === LEGACY_BENCH_DEV_SAMPLE || text.endsWith("/bench-dev-sample")) {
     return PERSONA_BENCH_POOL;
@@ -25,6 +32,10 @@ export function sanitizePersonaPool(pool: string | null | undefined): string {
 
 export interface CockpitPersonaSetupRecord {
   selectedPersonaIds: string[];
+  /** Full cohort size (may exceed selectedPersonaIds when launching by pool ref). */
+  selectedCount: number;
+  /** When true, launch uses the whole personaPool without echoing IDs. */
+  useEntirePool: boolean;
   samplingMode: PersonaSamplingMode;
   groupFilters: PersonaDimensionFilters;
   stratifyFields: string[];
@@ -37,7 +48,7 @@ export interface CockpitPersonaSetupRecord {
   sampleSizePerValueGroup: number | null;
   parallelTrials: number;
   personaModel: string;
-  /** Pool used for the current cohort (never restore legacy ``_generated`` paths). */
+  /** Pool used for the current cohort (never restore leftover synthetic paths). */
   personaPool: string;
   /** When true, sampling follows the task's persona_strategy.json and custom filters stay locked. */
   useTaskDefaultStrategy: boolean;
@@ -135,10 +146,23 @@ function normalizeRecord(
   fallbackPersonaModel: string,
 ): CockpitPersonaSetupRecord | null {
   if (!record) return null;
+  const selectedPersonaIds = Array.isArray(record.selectedPersonaIds)
+    ? record.selectedPersonaIds
+        .filter((id): id is string => typeof id === "string")
+        .slice(0, PERSONA_UI_ID_LIST_MAX)
+    : [];
+  const selectedCount =
+    typeof record.selectedCount === "number" && record.selectedCount > 0
+      ? Math.round(record.selectedCount)
+      : selectedPersonaIds.length;
+  const useEntirePool =
+    record.useEntirePool === true || selectedCount > PERSONA_UI_ID_LIST_MAX;
   return {
-    selectedPersonaIds: Array.isArray(record.selectedPersonaIds)
-      ? record.selectedPersonaIds.filter((id): id is string => typeof id === "string")
-      : [],
+    selectedPersonaIds: useEntirePool
+      ? selectedPersonaIds.slice(0, PERSONA_CARD_PREVIEW_LIMIT)
+      : selectedPersonaIds,
+    selectedCount,
+    useEntirePool,
     samplingMode:
       record.samplingMode === "random" ||
       record.samplingMode === "stratified" ||
@@ -175,6 +199,8 @@ function normalizeRecord(
 export function defaultPersonaSetup(fallbackPersonaModel: string): CockpitPersonaSetupRecord {
   return {
     selectedPersonaIds: [],
+    selectedCount: 0,
+    useEntirePool: false,
     samplingMode: "single",
     groupFilters: emptyPersonaDimensionFilters(),
     stratifyFields: ["age_bracket", "region"],
@@ -255,6 +281,8 @@ export function setupFromPersonaStrategy(
 
   // Fresh strategy apply clears prior preview selection and locks custom filters.
   next.selectedPersonaIds = [];
+  next.selectedCount = 0;
+  next.useEntirePool = false;
   next.useTaskDefaultStrategy = true;
   next.taskDefaultStrategyDismissed = false;
   return next;

--- a/application/playground/frontend/src/components/cockpit/setup/personaLaunchFields.ts
+++ b/application/playground/frontend/src/components/cockpit/setup/personaLaunchFields.ts
@@ -1,0 +1,63 @@
+import { PERSONA_UI_ID_LIST_MAX } from "@/lib/types";
+
+/** Shared fields for POST /api/harbor/jobs persona selection. */
+export type PersonaLaunchFields = {
+  personaPool: string;
+  sampleSize: number;
+  personaIds?: string[];
+  useEntirePool?: boolean;
+  nConcurrentTrials: number;
+};
+
+export function resolveCohortSize(input: {
+  selectedCount?: number;
+  selectedPersonaIds: string[];
+}): number {
+  return Math.max(input.selectedCount ?? 0, input.selectedPersonaIds.length);
+}
+
+export function shouldLaunchEntirePool(input: {
+  useEntirePool?: boolean;
+  selectedCount?: number;
+  selectedPersonaIds: string[];
+}): boolean {
+  if (input.useEntirePool) return true;
+  const size = resolveCohortSize(input);
+  if (size <= 0) return false;
+  if (size > PERSONA_UI_ID_LIST_MAX) return true;
+  return input.selectedPersonaIds.length > 0 && input.selectedPersonaIds.length < size;
+}
+
+export function buildPersonaLaunchFields(input: {
+  personaPool: string;
+  selectedPersonaIds: string[];
+  selectedCount?: number;
+  useEntirePool?: boolean;
+  parallelTrials: number;
+}): PersonaLaunchFields {
+  const sampleSize = resolveCohortSize(input);
+  const entire = shouldLaunchEntirePool(input);
+  const nConcurrentTrials = Math.max(1, Math.min(input.parallelTrials, Math.max(sampleSize, 1)));
+  if (entire) {
+    return {
+      personaPool: input.personaPool,
+      sampleSize,
+      useEntirePool: true,
+      nConcurrentTrials,
+    };
+  }
+  return {
+    personaPool: input.personaPool,
+    sampleSize: input.selectedPersonaIds.length || sampleSize,
+    personaIds: input.selectedPersonaIds,
+    nConcurrentTrials,
+  };
+}
+
+export function hasLaunchableCohort(input: {
+  selectedCount?: number;
+  selectedPersonaIds: string[];
+  useEntirePool?: boolean;
+}): boolean {
+  return resolveCohortSize(input) > 0 || Boolean(input.useEntirePool);
+}

--- a/application/playground/frontend/src/components/cockpit/setup/useCockpitBatchJob.ts
+++ b/application/playground/frontend/src/components/cockpit/setup/useCockpitBatchJob.ts
@@ -18,12 +18,18 @@ import type { RunLaunchPhase } from "./RunLaunchBar";
 
 function initialBatchState(taskKind?: HarborCockpitTaskKind) {
   if (!taskKind) {
-    return { jobName: null as string | null, personaIds: [] as string[], taskId: null as string | null };
+    return {
+      jobName: null as string | null,
+      personaIds: [] as string[],
+      selectedCount: 0,
+      taskId: null as string | null,
+    };
   }
   const saved = readCockpitBatch(taskKind);
   return {
     jobName: saved?.jobName ?? null,
     personaIds: saved?.personaIds ?? [],
+    selectedCount: saved?.selectedCount ?? saved?.personaIds.length ?? 0,
     taskId: saved?.taskId ?? null,
   };
 }
@@ -32,11 +38,13 @@ export function useCockpitBatchJob(
   selectedPersonaIds: string[],
   parallelTrials = 1,
   taskKind?: HarborCockpitTaskKind,
+  selectedCount = 0,
 ) {
   const { state: urlState, setState: setUrlState } = useUrlState();
   const [initial] = useState(() => initialBatchState(taskKind));
   const [batchJobName, setBatchJobNameInternal] = useState<string | null>(initial.jobName);
   const [restoredPersonaIds, setRestoredPersonaIds] = useState<string[]>(initial.personaIds);
+  const [restoredSelectedCount, setRestoredSelectedCount] = useState(initial.selectedCount);
   const [restoredTaskId, setRestoredTaskId] = useState<string | null>(initial.taskId);
 
   // Freeze the cohort to the batch launch snapshot until the user resets.
@@ -61,11 +69,22 @@ export function useCockpitBatchJob(
 
       if (jobName) {
         const personaIds = selectedPersonaIds.length > 0 ? selectedPersonaIds : restoredPersonaIds;
+        const cohortSize = Math.max(
+          selectedCount,
+          personaIds.length,
+          restoredSelectedCount,
+        );
         const taskId = meta?.taskId ?? restoredTaskId ?? undefined;
-        writeCockpitBatch(taskKind, { jobName, personaIds, taskId });
+        writeCockpitBatch(taskKind, {
+          jobName,
+          personaIds,
+          selectedCount: cohortSize,
+          taskId,
+        });
         if (selectedPersonaIds.length > 0) {
           setRestoredPersonaIds(selectedPersonaIds);
         }
+        setRestoredSelectedCount(cohortSize);
         if (taskId) {
           setRestoredTaskId(taskId);
         }
@@ -80,13 +99,23 @@ export function useCockpitBatchJob(
       } else {
         writeCockpitBatch(taskKind, null);
         setRestoredPersonaIds([]);
+        setRestoredSelectedCount(0);
         setRestoredTaskId(null);
         if (urlState.pgTask === taskKind) {
           setUrlState({ cockpitBatch: null });
         }
       }
     },
-    [restoredPersonaIds, restoredTaskId, selectedPersonaIds, setUrlState, taskKind, urlState.pgTask],
+    [
+      restoredPersonaIds,
+      restoredSelectedCount,
+      restoredTaskId,
+      selectedCount,
+      selectedPersonaIds,
+      setUrlState,
+      taskKind,
+      urlState.pgTask,
+    ],
   );
 
   const clearBatch = useCallback(() => setBatchJobName(null), [setBatchJobName]);
@@ -144,12 +173,13 @@ export function useCockpitBatchJob(
   }, [personaCardsQuery.data?.personas]);
 
   const statusSnapshot = statusFeed.snapshot;
-  const expectedTrialCount =
-    effectivePersonaIds.length ||
-    statusSnapshot?.trialCount ||
-    batchLive.live?.trialCount ||
-    batchLive.live?.trials.length ||
-    0;
+  const expectedTrialCount = Math.max(
+    batchJobName ? restoredSelectedCount : selectedCount,
+    effectivePersonaIds.length,
+    statusSnapshot?.trialCount ?? 0,
+    batchLive.live?.trialCount ?? 0,
+    batchLive.live?.trials.length ?? 0,
+  );
 
   const completedTrials =
     aggregate && statusSnapshot
@@ -180,7 +210,7 @@ export function useCockpitBatchJob(
   const batchGridCells = useMemo(() => {
     if (aggregate && statusSnapshot) {
       return buildBatchCellsFromStatus(statusSnapshot, {
-        expectedTotal: effectivePersonaIds.length,
+        expectedTotal: expectedTrialCount,
         personaIds: effectivePersonaIds,
         personaById,
       });
@@ -189,11 +219,13 @@ export function useCockpitBatchJob(
       jobStarted: Boolean(batchJobName),
       parallelTrials,
       personaById,
+      expectedTotal: expectedTrialCount,
     });
   }, [
     aggregate,
     statusSnapshot,
     effectivePersonaIds,
+    expectedTrialCount,
     batchLive.live?.trials,
     batchJobName,
     parallelTrials,

--- a/application/playground/frontend/src/components/cockpit/setup/useSetupPersonaSampling.ts
+++ b/application/playground/frontend/src/components/cockpit/setup/useSetupPersonaSampling.ts
@@ -18,6 +18,7 @@ import {
   type CockpitPersonaSetupRecord,
 } from "./cockpitPersonaSetupStorage";
 import {
+  emptyPersonaDimensionFilters,
   type PersonaDimensionFilters,
   type PersonaSamplingMode,
 } from "./personaSamplingTypes";
@@ -30,6 +31,8 @@ function applyPersonaHandoffToSetup(
   return {
     ...base,
     selectedPersonaIds: ids,
+    selectedCount: ids.length,
+    useEntirePool: false,
     personaPool: sanitizePersonaPool(handoff.pool) || base.personaPool || PERSONA_BENCH_POOL,
     samplingMode: ids.length > 1 ? "random" : "single",
     useTaskDefaultStrategy: false,
@@ -55,6 +58,8 @@ export function useSetupPersonaSampling(
   );
   const [samplingMode, setSamplingMode] = useState<PersonaSamplingMode>(initial.samplingMode);
   const [selectedPersonaIds, setSelectedPersonaIds] = useState<string[]>(initial.selectedPersonaIds);
+  const [selectedCount, setSelectedCount] = useState(initial.selectedCount);
+  const [useEntirePool, setUseEntirePool] = useState(initial.useEntirePool);
   const [groupFilters, setGroupFilters] = useState<PersonaDimensionFilters>(initial.groupFilters);
   const [stratifyFields, setStratifyFields] = useState<string[]>(initial.stratifyFields);
   const [sampleSize, setSampleSize] = useState(initial.sampleSize);
@@ -94,6 +99,8 @@ export function useSetupPersonaSampling(
     skipNextPersistRef.current = true;
     setSamplingMode(record.samplingMode);
     setSelectedPersonaIds(record.selectedPersonaIds);
+    setSelectedCount(record.selectedCount);
+    setUseEntirePool(record.useEntirePool);
     setGroupFilters(record.groupFilters);
     setStratifyFields(record.stratifyFields);
     setSampleSize(record.sampleSize);
@@ -132,6 +139,8 @@ export function useSetupPersonaSampling(
       // Explicit operator opt-out — do not confuse with pre-hydrate false.
       setTaskDefaultStrategyDismissed(true);
       setUseTaskDefaultStrategyState(false);
+      // Drop strategy-owned filters so custom mode starts clean.
+      setGroupFilters(emptyPersonaDimensionFilters());
       // Custom stratified UI expects an editable per-cell; invent 1 only after unlock.
       setSampleSizePerValueGroup((prev) => (prev == null ? 1 : prev));
     },
@@ -170,8 +179,10 @@ export function useSetupPersonaSampling(
       // Keep last cohort selection across remount/navigation. Strategy apply
       // clears preview ids intentionally for explicit "Task default" toggles,
       // but hydrate must not wipe a selection the operator already made.
-      if (stored.selectedPersonaIds.length > 0) {
+      if (stored.selectedPersonaIds.length > 0 || stored.selectedCount > 0) {
         applied.selectedPersonaIds = stored.selectedPersonaIds;
+        applied.selectedCount = stored.selectedCount || stored.selectedPersonaIds.length;
+        applied.useEntirePool = stored.useEntirePool;
       }
     } else if (hasTaskSpecificStore) {
       applied = {
@@ -185,8 +196,10 @@ export function useSetupPersonaSampling(
         personaModel: effectiveModel,
         parallelTrials: stored.parallelTrials,
       });
-      if (stored.selectedPersonaIds.length > 0) {
+      if (stored.selectedPersonaIds.length > 0 || stored.selectedCount > 0) {
         applied.selectedPersonaIds = stored.selectedPersonaIds;
+        applied.selectedCount = stored.selectedCount || stored.selectedPersonaIds.length;
+        applied.useEntirePool = stored.useEntirePool;
       }
     }
 
@@ -261,6 +274,8 @@ export function useSetupPersonaSampling(
       taskKind,
       {
         selectedPersonaIds,
+        selectedCount,
+        useEntirePool,
         samplingMode,
         groupFilters,
         stratifyFields,
@@ -278,6 +293,8 @@ export function useSetupPersonaSampling(
     taskKind,
     normalizedPath,
     selectedPersonaIds,
+    selectedCount,
+    useEntirePool,
     samplingMode,
     groupFilters,
     stratifyFields,
@@ -303,7 +320,8 @@ export function useSetupPersonaSampling(
     });
   }, [selectedPersonaIds]);
 
-  const isBatchRun = samplingMode !== "single" || selectedPersonaIds.length > 1;
+  const isBatchRun =
+    samplingMode !== "single" || selectedCount > 1 || selectedPersonaIds.length > 1;
 
   const personaModelKnob = options?.knobs.find((k) => k.key === "personaModel");
   const personaModelOptions =
@@ -314,15 +332,27 @@ export function useSetupPersonaSampling(
 
   const togglePersona = useCallback(
     (personaId: string) => {
-      if (samplingMode === "single") {
-        setSelectedPersonaIds((prev) => (prev.includes(personaId) ? [] : [personaId]));
+      if (useEntirePool) {
+        // Ref-based cohorts are not individually toggled; keep preview selection cosmetic.
         return;
       }
-      setSelectedPersonaIds((prev) =>
-        prev.includes(personaId) ? prev.filter((id) => id !== personaId) : [...prev, personaId],
-      );
+      if (samplingMode === "single") {
+        setSelectedPersonaIds((prev) => {
+          const next = prev.includes(personaId) ? [] : [personaId];
+          setSelectedCount(next.length);
+          return next;
+        });
+        return;
+      }
+      setSelectedPersonaIds((prev) => {
+        const next = prev.includes(personaId)
+          ? prev.filter((id) => id !== personaId)
+          : [...prev, personaId];
+        setSelectedCount(next.length);
+        return next;
+      });
     },
-    [samplingMode],
+    [samplingMode, useEntirePool],
   );
 
   const hasTaskStrategy = Boolean(taskPersonaStrategy);
@@ -336,6 +366,10 @@ export function useSetupPersonaSampling(
     setSamplingMode,
     selectedPersonaIds,
     setSelectedPersonaIds,
+    selectedCount,
+    setSelectedCount,
+    useEntirePool,
+    setUseEntirePool,
     togglePersona,
     groupFilters,
     setGroupFilters,

--- a/application/playground/frontend/src/lib/api.ts
+++ b/application/playground/frontend/src/lib/api.ts
@@ -207,6 +207,7 @@ export const api = {
     personaSources?: string[] | null;
     personaFilters?: Record<string, string> | null;
     cohortId?: string | null;
+    useEntirePool?: boolean;
     osAppSubmissionProfile?: string | null;
     osAppBackend?: string | null;
   }) =>

--- a/application/playground/frontend/src/lib/personaPoolCopy.ts
+++ b/application/playground/frontend/src/lib/personaPoolCopy.ts
@@ -20,15 +20,17 @@ export function isPersonaPoolCoverageError(message: string | null | undefined): 
     text.includes("No personas with stratify fields") ||
     text.includes("sample_size_per_value_group=") ||
     text.includes("Incomplete stratify coverage") ||
-    text.includes("matraix-persona-1m")
+    text.includes("matraix-persona-1m") ||
+    text.includes("matraix-persona-dev-sample")
   );
 }
 
 export function personaPoolCoverageHint(_taskPath?: string | null): string {
   return (
-    "Pool coverage is too thin for these filters. Sample from " +
-    "persona/datasets/matraix-persona-1m, widen dimensionFilters / sources, " +
-    "or use a saved cohort with enough matches."
+    "Not enough matching personas in this dataset for the current filters. " +
+    "Widen filters / sources, switch dataset (dev sample vs matraix-persona-1m), " +
+    "or use a saved cohort that already has enough matches. " +
+    "Playground does not synthesize missing personas."
   );
 }
 
@@ -40,7 +42,9 @@ export function formatPersonaSampleError(
   const trimmed = message.trim();
   if (isPersonaPoolCoverageError(trimmed)) {
     const first = trimmed.split("\n").find((line) => line.trim()) || trimmed;
-    const alreadyHinted = trimmed.includes("matraix-persona-1m");
+    const alreadyHinted =
+      trimmed.includes("matraix-persona-1m") ||
+      trimmed.includes("does not synthesize");
     return alreadyHinted ? trimmed : `${first}\n\n${personaPoolCoverageHint(taskPath)}`;
   }
   return trimmed;

--- a/application/playground/frontend/src/lib/types.ts
+++ b/application/playground/frontend/src/lib/types.ts
@@ -987,6 +987,7 @@ export interface PersonaPoolIdsResponse {
   pool: string;
   personaIds: string[];
   count: number;
+  idsTruncated?: boolean;
 }
 
 export interface PersonaPoolSampleResult {
@@ -1003,6 +1004,9 @@ export interface PersonaPoolSampleResult {
     dimensions?: Record<string, string>;
   }>;
   stratifyFields?: string[];
+  /** Full cohort size (may exceed personaIds when idsTruncated). */
+  selectedCount?: number;
+  idsTruncated?: boolean;
 }
 
 export interface PersonaPoolPersonaCard {
@@ -1090,10 +1094,12 @@ export const PERSONA_SAMPLE_SIZE_MAX_DEV = 500;
 export const PERSONA_SAMPLE_SIZE_MAX_PRODUCTION = 10_000;
 
 /**
- * Large stratified cohorts keep the full personaId list for launch, but only
- * hydrate/render this many cards in the UI (async preview — nobody scrolls 1k).
+ * Large cohorts keep a pool ref for launch; only this many cards hydrate in the UI.
+ * At or below PERSONA_UI_ID_LIST_MAX the full ID list may still be held for toggles.
  */
 export const PERSONA_CARD_PREVIEW_LIMIT = 32;
+/** Max persona IDs kept in browser state; larger cohorts launch by pool ref. */
+export const PERSONA_UI_ID_LIST_MAX = 100;
 
 export interface PersonaCohortSummary {
   cohortId: string;

--- a/docs/application/playground-api.md
+++ b/docs/application/playground-api.md
@@ -178,12 +178,15 @@ Common optional fields:
 | `agentName` | Override resolved Matraix Playground agent |
 | `jobName` | Explicit job basename; if omitted, defaults to `pg-{task_slug}-{8 hex chars}` |
 | `cohortId` | Launch from a saved persona cohort |
+| `useEntirePool` | Launch every persona in `personaPool` without listing IDs |
 | `personaSources` / `personaFilters` | Pool sampling filters |
 | `chatDomain`, `chatApplicationId`, `chatApplicationContext`, `chatMaxTurns` | Chatbot / user-sim tasks |
 | `osAppSubmissionProfile`, `osAppBackend` | os-app / CUA tasks |
 
 `mode` must be one of `auto`, `force_docker`, or `smoke`.
 `plane` must be `harbor` or `remote`.
+Large cohorts should set `useEntirePool` and point `personaPool` at the
+cohort directory. See [large-scale-runs.md](../environment/large-scale-runs.md).
 
 Response:
 
@@ -242,6 +245,9 @@ Returns dimension metadata for one persona pool.
 ### `POST /api/persona-pool/sample`
 
 Samples personas from a pool with optional filters and stratification.
+Optional `previewLimit` (default 32) and `includePersonaIds`. Cohorts larger
+than 100 IDs return a truncated `personaIds` list plus `selectedCount` /
+`idsTruncated`.
 
 ### `GET /api/persona-pool/personas`
 

--- a/docs/environment/README.md
+++ b/docs/environment/README.md
@@ -256,6 +256,7 @@ In `task.toml`, set `[environment].docker_image` to a Docker image name (convert
 | [Handbook](../README.md) | Docs home |
 | [Agents](agents.md) | Agent ↔ API key matrix |
 | [Runtime](runtime.md) | Matraix Playground vs remote plane |
+| [Large-scale runs](large-scale-runs.md) | Bigger cohorts, one job |
 | [Web interaction](web-interaction.md) | Playwright / browser-use / Cocoa / CUA |
 | [Application](../application/README.md) | Tasks and Playground |
 | [Playground API](../application/playground-api.md) | HTTP API reference |

--- a/docs/environment/large-scale-runs.md
+++ b/docs/environment/large-scale-runs.md
@@ -1,147 +1,76 @@
 # Large-scale runs
 
-How to scale a Matraix Playground job from a single smoke persona to hundreds or thousands
-of trials — using public persona sources and local artifacts only.
+Run a Playground evaluation over many personas. The result is still **one job**:
+one name in Runs, one folder `jobs/<job_name>/`.
 
-For a first end-to-end run, start with [quickstart.md](../quickstart.md). This
-page assumes you already have API keys, Docker (when needed), and a working
-single-persona job.
+First single-persona walkthrough: [quickstart](../quickstart.md).
 
 ---
 
-## What “large-scale” means here
+## Launch
 
-| Piece | Small / smoke | Large-scale |
-|-------|---------------|-------------|
-| Personas | One YAML (e.g. `persona_0042`) | Stratified sample or imported 1M subset |
-| Launch | One `harbor run` or Playground trial | Job recipe with many trials + concurrency |
-| Outputs | One trial under `jobs/<job>/` | Full job tree + optional batch PDF |
+Use one of:
 
-Tasks live under [`application/tasks/`](../../application/tasks/). Pick any
-checked-in task that matches your surface (survey, chat, web, OS app).
+- Playground
+- `POST /api/harbor/jobs`
+- `harbor run -c <job.yaml>`
 
----
-
-## Persona cohorts
-
-Use one of these sources — do **not** invent a private upload destination for
-personas unless you manage that storage yourself.
-
-### 1. Task strategy (recommended starting point)
-
-Most tasks ship a `persona_strategy.json`. Generate a cohort with the Playground
-or `generate_application_job.py` so filters, stratification, and `sampleSize`
-come from the task:
-
-```bash
-# Example: build a job that samples from the task strategy
-uv run python application/scripts/generate_application_job.py \
-  --task application/tasks/<task-name> \
-  --help
-```
-
-When using stratified sampling, set `sampleSize` to the **exact total** you
-want. Do not also set `sampleSizePerValueGroup`: the two fields are mutually
-exclusive, and `sampleSizePerValueGroup` sets a quota per stratum rather than
-an exact total.
-
-### 2. Public Persona 1M coreset
-
-For population-scale studies, import
-[`MatrAIx2026/MatrAIx_Persona_1M_Public_Release`](https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release)
-and point jobs at the local mirror. See
-[Persona setup](../persona/README.md#setup-and-usage) and
-[configuration.md](../configuration.md#persona-profile-and-default-sample).
-
-### 3. In-repo sample dataset
-
-For development and CI-sized batches:
-
-```text
-persona/datasets/matraix-persona-dev-sample/
-```
-
-Record the persona source (path, revision if Hugging Face, count) in your job
-README or recipe comments so runs stay reproducible.
+One launch covers the whole cohort. Do not start a separate job per persona.
 
 ---
 
-## Running the job
+## Personas
 
-1. Choose agent and model for the task surface — see [agents.md](agents.md) and
-   [web-interaction.md](web-interaction.md).
-2. Launch via a recipe under `configs/jobs/` or generate one from Playground /
-   `generate_application_job.py`.
-3. Raise concurrency only as far as your machine, Docker, and API quotas allow.
-4. Keep the job on a stable git revision of this repo so task + verifier match
-   the artifacts you archive.
+A **cohort** is a directory of persona YAML files.
 
-Example shape (paths and flags vary by task):
+| Batch size | How to pass them |
+|------------|------------------|
+| Small (about ≤100) | Optional `personaIds` |
+| Large | `personaPool` = that directory, plus `useEntirePool` |
 
-```bash
-uv run harbor run -c configs/jobs/<your-recipe>.yaml
-```
+Sources:
 
-Remote or multi-machine dispatch: [runtime.md](runtime.md).
+1. **Task strategy** — most tasks ship `persona_strategy.json`. Sample in
+   Playground, or run
+   `generate_application_job.py --task application/tasks/<name>`.
+   For a stratified sample, set `sampleSize` to the **total** you want.
+   `sampleSizePerValueGroup` is a per-group quota, not a second total.
+2. **Public Persona 1M** —
+   [`MatrAIx2026/MatrAIx_Persona_1M_Public_Release`](https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release).
+   Import it locally, then point the job at that path. See
+   [Persona setup](../persona/README.md#setup-and-usage).
+3. **Dev sample** — `persona/datasets/matraix-persona-dev-sample/` for small
+   local batches.
+
+Playground / API fields: `personaPool`, `useEntirePool`, `sampleSize`,
+`nConcurrentTrials`. Reference: [playground-api.md](../application/playground-api.md).
+
+Record the persona path (and the Hugging Face revision, if you used one) so the
+batch is reproducible.
 
 ---
 
-## Where artifacts land
-
-Matraix Playground writes under the repo-local `jobs/` tree (gitignored):
+## Outputs
 
 ```text
 jobs/<job_name>/
+├── result.json
 ├── <task>__<trial>/
-│   ├── agent/          trajectory, screenshots, …
-│   ├── verifier/       scores / reports
+│   ├── agent/
+│   ├── verifier/
 │   └── result.json
-├── job.log
-└── result.json         job-level rollup when present
+└── job.log
 ```
 
-Generated persona YAMLs used for a run often sit under a task or job
-`_generated/` (or Playground materialization) directory — package or copy them
-**before** cleaning the workspace if you need to reproduce the cohort later.
-
-You own archival: copy `jobs/<job_name>/` (and any persona cohort you generated)
-to whatever storage your org uses. This handbook does not prescribe a shared
-external dataset for uploads.
-
----
-
-## Batch PDF report (optional but useful)
-
-For multi-persona jobs, Playground can export a **Persona-Task Batch Report**
-PDF via **Download PDF** on the run detail view. That export is produced by
-`application/playground/frontend/src/lib/exportBatchReportPdf.ts` (frontend
-`jspdf` + `html-to-image`), not the compact server-side `report_pdf` helper.
-
-```bash
-cd application/playground/frontend
-npm install
-npm run build
-```
-
-After trials finish:
-
-1. Confirm the job has the expected number of completed trials (no pending /
-   running / errored trials you still care about).
-2. Build or refresh aggregation with `application/scripts/report_job.py`
-   (`--no-llm` when you only need deterministic rollups).
-3. Open the job in Playground **Runs**, wait for the batch report UI to load,
-   then **Download PDF**.
-4. Keep the PDF next to `aggregation.json` in your own archive layout if you
-   want a shareable deliverable.
-
-Expected filename pattern: `<job_name>-persona-task-batch-report.pdf`.
+Keep `jobs/<job_name>/` and any sampled cohort directory if you need to
+reproduce the run. Pulled copies sit next to the source dataset, for example
+`persona/datasets/matraix-persona-dev-sample/cohorts/`.
 
 ---
 
 ## Related
 
-- [Environment overview](README.md)
+- [Runtime](runtime.md)
 - [Quickstart](../quickstart.md)
 - [Persona 1M](../persona/README.md#public-coreset-matraix-persona-1m)
-- [Configuration](../configuration.md)
 - [Playground API](../application/playground-api.md)

--- a/src/matraix/application_job.py
+++ b/src/matraix/application_job.py
@@ -191,6 +191,7 @@ def build_application_job_config(
         )
 
     pool = load_manifest(pool_dir, repo_root=repo_root)
+    use_entire_pool = bool(spec.get("use_entire_pool"))
     if persona_ids:
         matched = pool
         chosen = resolve_persona_entries(
@@ -198,6 +199,15 @@ def build_application_job_config(
             persona_pool=spec["persona_pool"],
             repo_root=repo_root,
         )
+    elif use_entire_pool:
+        matched = pool
+        chosen = list(pool)
+        if not chosen:
+            raise ValueError(
+                "use_entire_pool=True but persona pool is empty: {}".format(
+                    spec["persona_pool"]
+                )
+            )
     else:
         matched, chosen = select_personas(
             pool,
@@ -251,6 +261,7 @@ def build_application_job_config(
             "matched_pool_size": len(matched),
             "selected_persona_ids": [entry["persona_id"] for entry in chosen],
             "persona_ids": persona_ids,
+            "use_entire_pool": use_entire_pool,
             "execution_mode": execution_mode,
             "trial_profile": trial_profile,
         },

--- a/tests/unit/playground_core/test_application_job.py
+++ b/tests/unit/playground_core/test_application_job.py
@@ -177,6 +177,36 @@ def test_build_application_job_config_auto_survey_uses_host_environment(tmp_path
     ) == "application/tasks/example-survey_product-feedback"
 
 
+def test_build_application_job_config_use_entire_pool(tmp_path: Path) -> None:
+    repo = tmp_path
+    pool = repo / "persona" / "datasets" / "matraix-persona-dev-sample"
+    pool.mkdir(parents=True)
+    for pid in ("0001", "0002", "0003"):
+        (pool / f"persona_{pid}.yaml").write_text(
+            f"persona_id: '{pid}'\nversion: '1.0'\nsource: Nemotron\ndimensions: {{}}\n",
+            encoding="utf-8",
+        )
+
+    job = build_application_job_config(
+        {
+            "name": "entire-pool-job",
+            "task": "application/tasks/example-survey_product-feedback",
+            "persona_pool": "persona/datasets/matraix-persona-dev-sample",
+            "use_entire_pool": True,
+            "sample_size": 1,
+            "execution_mode": "auto",
+            "trial_profile": "json_survey",
+            "agent": {"name": "persona-claude-code", "model_name": "anthropic/claude-haiku-4-5"},
+            "job": {"job_name": "entire-pool-job", "jobs_dir": "jobs"},
+        },
+        repo_root=repo,
+    )
+    meta = job.pop("_job_meta")
+    assert meta["use_entire_pool"] is True
+    assert sorted(meta["selected_persona_ids"]) == ["0001", "0002", "0003"]
+    assert len(job["agents"]) == 3
+
+
 def test_build_application_job_config_rejects_unknown_mode(tmp_path: Path) -> None:
     repo = tmp_path
     pool = repo / "persona" / "datasets" / "matraix-persona-dev-sample"


### PR DESCRIPTION
## Summary
- Sample and launch large cohorts with `personaPool` + `useEntirePool` instead of shipping every persona ID through the browser.
- Materialized pulls land at `<source-dataset>/cohorts/cohort-<digest>/` and can be saved as a reusable dataset. Playground shows a 32-card preview; turning off the task default strategy clears its filters.
- Launch caches under `persona/datasets/*/cohorts/` stay gitignored.

## Test plan
- [ ] Sample more than 100 personas from the dev dataset; UI shows 32 cards and the full count, launch writes one job with that many trials
- [ ] Turn Task default persona strategy off and confirm filters reset
- [ ] Save a pulled cohort as a named dataset and relaunch from it
- [ ] Confirm `persona/datasets/<source>/cohorts/` is gitignored and checked-in fixtures are not


Made with [Cursor](https://cursor.com)