### PR TITLE
chore: use area: labels instead of team: in PR labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,11 +1,11 @@
-# Auto-label PRs by team area
+# Auto-label PRs by code area
 
-"team: persona":
+"area: persona":
   - changed-files:
       - any-glob-to-any-file:
           - persona/**
 
-"team: application":
+"area: application":
   - changed-files:
       - any-glob-to-any-file:
           - application/**
@@ -23,7 +23,7 @@
           - docs/migration/**
           - migration/matraix/**
 
-"team: environment":
+"area: environment":
   - changed-files:
       - any-glob-to-any-file:
           - environment/**


### PR DESCRIPTION
## Summary
- Rename auto-labeler keys from `team: persona|application|environment` to `area: persona|application|environment` in `.github/labeler.yml`.
- Update the labeler comment to “Auto-label PRs by code area”.
- Rename existing GitHub labels `team: application` / `team: environment` → `area: application` / `area: environment`, and create `area: persona` (no prior `team: persona` label).

## Test plan
- [ ] Confirm `.github/labeler.yml` keys are `area:*` and globs for persona / application / environment / documentation / migration are unchanged.
- [ ] Confirm repo labels list shows `area: application`, `area: environment`, `area: persona` (no remaining `team:*` area labels).
- [ ] Next PR that touches those paths should receive `area:*` labels from the labeler (or open a trivial path-touching PR to verify).


Made with [Cursor](https://cursor.com)