### PR TITLE
feat: add OpenRouter as a persona model provider

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -75,6 +75,7 @@ jobs:
             application/playground/backend/tests/test_trial_events.py \
             packages/playground/src/playground/tests/test_chatbot_sidecar_compose.py \
             packages/playground/src/playground/tests/test_model_client.py \
+            packages/playground/src/playground/tests/test_model_client_openrouter.py \
             tests/environment/test_application_task_contracts.py \
             tests/environment/test_application_tasks.py \
             tests/environment/test_harbor_runtime_foundation.py \

--- a/application/playground/backend/api/app.py
+++ b/application/playground/backend/api/app.py
@@ -176,6 +176,7 @@ def preflight_checks() -> List[Dict[str, Any]]:
     **Required** (block platform ready)
 
     * Model credentials — at least one of OpenAI / Anthropic / DashScope
+      / OpenRouter
       (every survey / chat / web / os-app run needs a persona or agent model).
     * Survey forms / Web tasks — surfaces are always available in-process.
 
@@ -198,12 +199,14 @@ def preflight_checks() -> List[Dict[str, Any]]:
         os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("CLAUDE_API_KEY")
     )
     dashscope_key = bool(os.environ.get("DASHSCOPE_API_KEY"))
+    openrouter_key = bool(os.environ.get("OPENROUTER_API_KEY"))
     configured = [
         label
         for label, present in (
             ("OpenAI", openai_key),
             ("Anthropic", anthropic_key),
             ("DashScope", dashscope_key),
+            ("OpenRouter", openrouter_key),
         )
         if present
     ]
@@ -215,8 +218,8 @@ def preflight_checks() -> List[Dict[str, Any]]:
             "detail": (
                 "Configured: {}.".format(", ".join(configured))
                 if configured
-                else "Not configured. Set OpenAI, Anthropic, or DashScope credentials "
-                "to run application tasks."
+                else "Not configured. Set OpenAI, Anthropic, DashScope, or "
+                "OpenRouter credentials to run application tasks."
             ),
         }
     )
@@ -257,6 +260,19 @@ def preflight_checks() -> List[Dict[str, Any]]:
                 if dashscope_key
                 else "Not configured. Needed only for DashScope persona models "
                 "(Qwen, DeepSeek)."
+            ),
+        }
+    )
+    checks.append(
+        {
+            "group": "Core",
+            "name": "OpenRouter",
+            "ok": openrouter_key,
+            "optional": True,
+            "detail": (
+                "Configured."
+                if openrouter_key
+                else "Not configured. Needed only for OpenRouter persona models."
             ),
         }
     )

--- a/application/playground/backend/service/config.py
+++ b/application/playground/backend/service/config.py
@@ -28,8 +28,8 @@ REMOTE_RUNNER_API_URL_ENV = "REMOTE_RUNNER_API_URL"
 DEFAULT_PERSONA_MODEL = "anthropic/claude-haiku-4-5"
 
 # Persona-model IDs use LiteLLM provider prefixes (``anthropic/``, ``openai/``,
-# ``dashscope/``). DashScope models route through Alibaba's OpenAI-compatible
-# endpoint when ``DASHSCOPE_API_KEY`` is set.
+# ``dashscope/``, ``openrouter/``). OpenAI-compatible providers use their own
+# credentials and endpoints.
 PERSONA_MODEL_KNOB_META: Dict[str, Dict[str, str]] = {
     "anthropic/claude-haiku-4-5": {
         "label": "Claude Haiku 4.5",
@@ -118,6 +118,14 @@ PERSONA_MODEL_KNOB_META: Dict[str, Dict[str, str]] = {
     "dashscope/deepseek-v3.2": {
         "label": "DeepSeek V3.2",
         "description": "DeepSeek V3.2 via DashScope compatible API.",
+    },
+    "openrouter/z-ai/glm-4.7": {
+        "label": "GLM 4.7",
+        "description": "Z.ai GLM 4.7 served through OpenRouter.",
+    },
+    "openrouter/anthropic/claude-haiku-4.5": {
+        "label": "Claude Haiku 4.5",
+        "description": "Anthropic Claude Haiku 4.5 served through OpenRouter.",
     },
 }
 
@@ -521,4 +529,3 @@ def _runtime_label(runtime: str) -> str:
     if runtime == "harbor":
         return "Harbor persona runner"
     return "In-process Harbor runner"
-

--- a/application/playground/backend/tests/test_api.py
+++ b/application/playground/backend/tests/test_api.py
@@ -32,6 +32,7 @@ def test_preflight_shape(client):
         "OpenAI credentials",
         "Anthropic credentials",
         "DashScope (Qwen / DeepSeek)",
+        "OpenRouter",
         "OpenBB (finance)",
         "Meal planning",
         "Acme support API",
@@ -60,6 +61,7 @@ def test_preflight_required_vs_optional_contract(client):
         "OpenAI credentials",
         "Anthropic credentials",
         "DashScope (Qwen / DeepSeek)",
+        "OpenRouter",
         "OpenBB (finance)",
         "Meal planning",
         "Acme support API",
@@ -77,6 +79,7 @@ def test_preflight_does_not_leak_env_var_names(client):
         "ANTHROPIC_API_KEY",
         "CLAUDE_API_KEY",
         "DASHSCOPE_API_KEY",
+        "OPENROUTER_API_KEY",
         "USE_COMPUTER_API_KEY",
         "INTERECAGENT_ROOT",
         "INTERECAGENT_CATALOG_PATH",
@@ -92,6 +95,7 @@ def test_preflight_model_credentials_any_provider(client, monkeypatch):
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     monkeypatch.delenv("CLAUDE_API_KEY", raising=False)
     monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
     body = client.get("/api/preflight").json()
     model = next(c for c in body["checks"] if c["name"] == "Model credentials")
     assert model["ok"] is False
@@ -117,6 +121,19 @@ def test_preflight_dashscope_check_optional(client, monkeypatch):
     body = client.get("/api/preflight").json()
     dashscope = next(c for c in body["checks"] if c["name"] == "DashScope (Qwen / DeepSeek)")
     assert dashscope["ok"] is True
+
+
+def test_preflight_openrouter_check_optional(client, monkeypatch):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    body = client.get("/api/preflight").json()
+    openrouter = next(c for c in body["checks"] if c["name"] == "OpenRouter")
+    assert openrouter["ok"] is False
+    assert openrouter.get("optional") is True
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
+    body = client.get("/api/preflight").json()
+    openrouter = next(c for c in body["checks"] if c["name"] == "OpenRouter")
+    assert openrouter["ok"] is True
 
 
 def test_preflight_anthropic_check_optional(client, monkeypatch):
@@ -250,6 +267,8 @@ def test_config_options(client):
     assert persona_model_values == set(PERSONA_MODEL_OPTIONS)
     assert "dashscope/qwen3.6-plus-2026-04-02" in persona_model_values
     assert "dashscope/deepseek-v4-pro" in persona_model_values
+    assert "openrouter/z-ai/glm-4.7" in persona_model_values
+    assert "openrouter/anthropic/claude-haiku-4.5" in persona_model_values
 
     assert body["defaults"]["engine"] == "gpt-4o-mini"
     assert body["defaults"]["rankerMode"] == "native"

--- a/application/playground/backend/tests/test_config.py
+++ b/application/playground/backend/tests/test_config.py
@@ -67,8 +67,31 @@ def test_options_knob_values_match_allowed(config_manager):
     assert "anthropic/claude-opus-4-8" in PERSONA_MODEL_OPTIONS
     assert "dashscope/qwen3.7-max" in PERSONA_MODEL_OPTIONS
     assert "dashscope/deepseek-v4-pro" in PERSONA_MODEL_OPTIONS
+    assert "openrouter/z-ai/glm-4.7" in PERSONA_MODEL_OPTIONS
+    assert "openrouter/anthropic/claude-haiku-4.5" in PERSONA_MODEL_OPTIONS
     assert "openai/gpt-5.4" in PERSONA_MODEL_OPTIONS
     assert "openai/gpt-5.5" in PERSONA_MODEL_OPTIONS
+
+
+def test_preflight_recognizes_openrouter_credentials(client, monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("CLAUDE_API_KEY", raising=False)
+    monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    body = client.get("/api/preflight").json()
+    model = next(c for c in body["checks"] if c["name"] == "Model credentials")
+    assert model["ok"] is False
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
+    body = client.get("/api/preflight").json()
+    model = next(c for c in body["checks"] if c["name"] == "Model credentials")
+    openrouter = next(c for c in body["checks"] if c["name"] == "OpenRouter")
+    assert model["ok"] is True
+    assert "OpenRouter" in model["detail"]
+    assert openrouter["ok"] is True
+    assert openrouter.get("optional") is True
 
 
 def test_options_rebuilds_agent_flag(config_manager):

--- a/application/playground/frontend/src/components/cockpit/setup/useSetupPersonaSampling.ts
+++ b/application/playground/frontend/src/components/cockpit/setup/useSetupPersonaSampling.ts
@@ -41,6 +41,17 @@ function applyPersonaHandoffToSetup(
   };
 }
 
+const PERSONA_MODEL_PROVIDER_LABELS: Record<string, string> = {
+  anthropic: "Anthropic",
+  dashscope: "DashScope",
+  openai: "OpenAI",
+  openrouter: "OpenRouter",
+};
+
+function personaModelProviderLabel(modelId: string): string | undefined {
+  return PERSONA_MODEL_PROVIDER_LABELS[modelId.split("/", 1)[0]];
+}
+
 export function useSetupPersonaSampling(
   options: ConfigOptionsResponse | null,
   taskKind: HarborCockpitTaskKind,
@@ -346,6 +357,8 @@ export function useSetupPersonaSampling(
     personaModelKnob?.options.map((o) => ({
       value: o.value,
       label: o.label,
+      meta: personaModelProviderLabel(o.value),
+      summary: o.description,
     })) ?? [{ value: personaModel, label: personaModel }];
 
   const togglePersona = useCallback(

--- a/docs/application/playground-api.md
+++ b/docs/application/playground-api.md
@@ -112,7 +112,7 @@ eval surfaces aligned to shipped `application/tasks`.
 `ready` ignores checks marked `optional`.
 
 **Required (blocks `ready`):** Model credentials (any of OpenAI / Anthropic /
-DashScope), plus always-available Survey / Web surface markers.
+DashScope / OpenRouter), plus always-available Survey / Web surface markers.
 
 **Optional (task-specific):** per-provider keys, Docker (survey / web / chat /
 Linux OS-app), use.computer (macOS / iOS), and chat sidecars (OpenBB, meal

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -95,12 +95,12 @@ Every run specifies a **persona agent** (the automation harness), a **persona LL
 
 | Agent | Application | Persona model | Example recipe | API key on host |
 |-------|-------------|---------------|-----------------|-----------------|
-| `persona-json-survey` | Survey (**auto**) | Any | generated `*-auto-n*.yaml` | `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `DASHSCOPE_API_KEY` |
+| `persona-json-survey` | Survey (**auto**) | Any | generated `*-auto-n*.yaml` | `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `DASHSCOPE_API_KEY`, or `OPENROUTER_API_KEY` |
 | `persona-user-sim` | Chatbot (**auto**) | Any | generated `*-auto-n*.yaml` | Persona key + often `OPENAI_API_KEY` for SUT |
 | `persona-claude-code` | Survey, Chatbot (`force_docker`) | `anthropic/claude-*` | `appSim-example-survey-local.yaml`, `appSim-example-chat-local.yaml` | `ANTHROPIC_API_KEY` |
 | `persona-gemini-cli` | Survey, Chatbot (`force_docker`) | `google/gemini-*` | `appSim-example-survey-local.yaml` | `GEMINI_API_KEY` |
 | `persona-codex` | Survey, Chatbot (`force_docker`) | `openai/gpt-*` | `appSim-example-survey-local.yaml` | `OPENAI_API_KEY` |
-| `persona-openhands-sdk` | Web (Playwright) | Any | `appSim-example-web-playwright-local.yaml` | `LLM_API_KEY` (or `DASHSCOPE_API_KEY` for DashScope models) |
+| `persona-openhands-sdk` | Web (Playwright) | Any | `appSim-example-web-playwright-local.yaml` | `LLM_API_KEY`, `DASHSCOPE_API_KEY`, or `OPENROUTER_API_KEY` (match the model provider) |
 | `persona-browser-use` | Web (browser automation) | Any | `appSim-example-web-browser-use-local.yaml` | `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `DASHSCOPE_API_KEY`, or `LLM_API_KEY` |
 | `persona-cocoa` | Web (browser + shell) | Any | `appSim-example-web-cocoa-local.yaml` | `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `DASHSCOPE_API_KEY`, or `LLM_API_KEY` |
 | `persona-computer-1` | Web / Computer-use (macOS, iOS, Linux) | `anthropic/claude-*` or `dashscope/*` | `appSim-example-computer-use-macos-local.yaml` | `ANTHROPIC_API_KEY`, `DASHSCOPE_API_KEY`, and optionally `USE_COMPUTER_API_KEY` (macOS/iOS) |
@@ -129,7 +129,9 @@ slashes: `openrouter/z-ai/glm-4.7` resolves to the model id `z-ai/glm-4.7`. Only
 the leading `openrouter/` is stripped.
 
 Set `OPENROUTER_API_KEY`. The endpoint defaults to `https://openrouter.ai/api/v1`
-and can be overridden with `OPENROUTER_API_BASE`.
+and can be overridden with `OPENROUTER_API_BASE`. The older
+`OPENROUTER_BASE_URL` name remains a compatibility alias and is used only when
+`OPENROUTER_API_BASE` is unset.
 
 The `openrouter/` prefix deliberately ignores `OPENAI_BASE_URL`. Routing an
 OpenAI-compatible client through OpenRouter by setting `OPENAI_BASE_URL` also
@@ -161,7 +163,7 @@ Set these in your shell before running a job. Each agent reads keys differently:
 
 | Agent | Required keys on host |
 |-------|----------------------|
-| `persona-openhands-sdk` | `LLM_API_KEY` (or `ANTHROPIC_API_KEY`/`OPENAI_API_KEY`/`DASHSCOPE_API_KEY`; map to `LLM_API_KEY` if needed) |
+| `persona-openhands-sdk` | `LLM_API_KEY` (or `ANTHROPIC_API_KEY`/`OPENAI_API_KEY`/`DASHSCOPE_API_KEY`/`OPENROUTER_API_KEY`; provider keys map automatically when supported) |
 | `persona-browser-use` | `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `DASHSCOPE_API_KEY`, or `LLM_API_KEY` |
 | `persona-cocoa` | `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `DASHSCOPE_API_KEY`, or `LLM_API_KEY` |
 | `persona-computer-1` | `ANTHROPIC_API_KEY` or `DASHSCOPE_API_KEY` (+ `USE_COMPUTER_API_KEY` for macOS/iOS via use.computer) |
@@ -175,6 +177,7 @@ export ANTHROPIC_API_KEY="sk-ant-..."
 export OPENAI_API_KEY="sk-..."
 export GEMINI_API_KEY="..."
 export DASHSCOPE_API_KEY="..."
+export OPENROUTER_API_KEY="..."
 
 # If using persona-openhands-sdk, map to LLM_API_KEY
 export LLM_API_KEY="${ANTHROPIC_API_KEY}"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,7 +77,7 @@ tasks:
 | Field | Type | Meaning |
 |-------|------|---------|
 | `agents[].name` | string | Persona agent name (e.g., `persona-claude-code`, `persona-browser-use`). |
-| `agents[].model_name` | string | Provider-prefixed model identifier (e.g., `anthropic/claude-sonnet-4-6`, `openai/gpt-4o-mini`, `dashscope/qwen3.7-max`). |
+| `agents[].model_name` | string | Provider-prefixed model identifier (e.g., `anthropic/claude-sonnet-4-6`, `openai/gpt-4o-mini`, `dashscope/qwen3.7-max`, `openrouter/z-ai/glm-4.7`). |
 | `agents[].kwargs.persona_path` | string | Path to persona YAML profile (e.g., `persona/datasets/matraix-persona-dev-sample/persona_0042.yaml`). |
 | `agents[].env` | object | Optional environment variable overrides (e.g., `agents[].env.ANTHROPIC_API_KEY`). |
 
@@ -120,6 +120,23 @@ The **persona LLM** is separate from the chat sidecar backend (e.g., `MATRIX_CHA
 - **OpenAI:** `openai/gpt-4o-mini`, `openai/gpt-4o`, etc.
 - **Google Gemini:** `google/gemini-2.5-pro` (with `persona-gemini-cli`)
 - **DashScope (Alibaba):** `dashscope/qwen3.7-max`, `dashscope/deepseek-v4-pro`, etc.
+- **OpenRouter:** `openrouter/z-ai/glm-4.7`, `openrouter/anthropic/claude-haiku-4.5`, etc.
+
+#### OpenRouter
+
+OpenRouter model ids carry their own vendor prefix, so the full string has two
+slashes: `openrouter/z-ai/glm-4.7` resolves to the model id `z-ai/glm-4.7`. Only
+the leading `openrouter/` is stripped.
+
+Set `OPENROUTER_API_KEY`. The endpoint defaults to `https://openrouter.ai/api/v1`
+and can be overridden with `OPENROUTER_API_BASE`.
+
+The `openrouter/` prefix deliberately ignores `OPENAI_BASE_URL`. Routing an
+OpenAI-compatible client through OpenRouter by setting `OPENAI_BASE_URL` also
+diverts the `anthropic/` prefix through that proxy, because a non-empty
+`OPENAI_BASE_URL` switches Anthropic models onto the proxy's OpenAI-compatible
+endpoint. Addressing OpenRouter explicitly keeps the two independent, so one
+process can send some models to OpenRouter and others direct to Anthropic.
 
 ### API keys and environment variables
 
@@ -129,8 +146,8 @@ Set these in your shell before running a job. Each agent reads keys differently:
 
 | Agent | Required keys on host |
 |-------|----------------------|
-| `persona-json-survey` | `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `DASHSCOPE_API_KEY` (match `-m`) |
-| `persona-user-sim` | Persona: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `DASHSCOPE_API_KEY`; chat sidecar: often `OPENAI_API_KEY` |
+| `persona-json-survey` | `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `DASHSCOPE_API_KEY`, or `OPENROUTER_API_KEY` (match `-m`) |
+| `persona-user-sim` | Persona: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `DASHSCOPE_API_KEY`, or `OPENROUTER_API_KEY`; chat sidecar: often `OPENAI_API_KEY` |
 
 #### CLI harness agents (vendor-locked)
 

--- a/docs/environment/agents.md
+++ b/docs/environment/agents.md
@@ -60,7 +60,12 @@ OpenAI (`openai/gpt-4o*`), and DashScope OpenAI-compatible models
 (`dashscope/qwen3.6-plus-2026-04-02`, `dashscope/qwen3.7-max`,
 `dashscope/deepseek-v4-pro`, …). Set `DASHSCOPE_API_KEY` (and optional
 `DASHSCOPE_API_BASE`) when using `dashscope/*` — the same `-m` value applies to
-auto survey/chat and Docker web/CUA agents. CLI harness agents
+auto survey/chat and Docker web/CUA agents. OpenRouter models include
+`openrouter/z-ai/glm-4.7` and `openrouter/anthropic/claude-haiku-4.5`. Set
+`OPENROUTER_API_KEY` (and optional `OPENROUTER_API_BASE`) for `openrouter/*`.
+`OPENROUTER_BASE_URL` remains a compatibility alias when
+`OPENROUTER_API_BASE` is unset.
+CLI harness agents
 (`persona-claude-code`, `persona-gemini-cli`, `persona-codex`) stay
 vendor-locked. Other LiteLLM-compatible ids may work if the matching API key is
 set.
@@ -104,12 +109,12 @@ differ by agent:
 
 | Agent | Required on host | Notes |
 |-------|------------------|-------|
-| `persona-json-survey` | `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `DASHSCOPE_API_KEY` | Match `-m` / YAML `model_name`. Auto host-native survey. |
-| `persona-user-sim` | Persona: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `DASHSCOPE_API_KEY`; often `OPENAI_API_KEY` for SUT | Persona model via `-m`; chat sidecar engine via `MATRIX_CHATBOT_ENGINE` (default `gpt-4o-mini`). |
+| `persona-json-survey` | `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `DASHSCOPE_API_KEY`, or `OPENROUTER_API_KEY` | Match `-m` / YAML `model_name`. Auto host-native survey. |
+| `persona-user-sim` | Persona: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `DASHSCOPE_API_KEY`, or `OPENROUTER_API_KEY`; often `OPENAI_API_KEY` for SUT | Persona model via `-m`; chat sidecar engine via `MATRIX_CHATBOT_ENGINE` (default `gpt-4o-mini`). |
 | `persona-claude-code` | `ANTHROPIC_API_KEY` (or subscription — see below) | Anthropic models |
 | `persona-gemini-cli` | `GEMINI_API_KEY` (or subscription — see below) | Google models, e.g. `google/gemini-2.5-pro` |
 | `persona-codex` | `OPENAI_API_KEY` (or subscription — see below) | OpenAI models, e.g. `openai/gpt-4o` |
-| `persona-openhands-sdk` | **`LLM_API_KEY`** (or `DASHSCOPE_API_KEY` when `-m` is `dashscope/*`) | Not the provider-native name for Anthropic/OpenAI. Map before run, e.g. `export LLM_API_KEY="$ANTHROPIC_API_KEY"` (match `-m`). DashScope models auto-map `DASHSCOPE_API_KEY` → `LLM_API_KEY`. |
+| `persona-openhands-sdk` | **`LLM_API_KEY`**, `DASHSCOPE_API_KEY`, or `OPENROUTER_API_KEY` (match `-m`) | Provider-specific DashScope and OpenRouter keys map automatically to `LLM_API_KEY`. For Anthropic/OpenAI, map explicitly, e.g. `export LLM_API_KEY="$ANTHROPIC_API_KEY"`. |
 | `persona-browser-use` | `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `DASHSCOPE_API_KEY`, or `LLM_API_KEY` | DashScope: set `DASHSCOPE_API_KEY` (+ optional `DASHSCOPE_API_BASE`). |
 | `persona-cocoa` | `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `DASHSCOPE_API_KEY`, or `LLM_API_KEY` | Task image must be AIO Sandbox-based. |
 | `persona-computer-1` | `ANTHROPIC_API_KEY` or `DASHSCOPE_API_KEY` | Docker Linux web CUA and linux computer-use. **use.computer** (macOS/iOS) also needs `USE_COMPUTER_API_KEY`. Install extras: `uv sync --extra use-computer --extra computer-1`. |
@@ -129,6 +134,7 @@ Export in your shell before running (e.g. in `~/.zshrc` or the current terminal)
 export ANTHROPIC_API_KEY=sk-...
 export GEMINI_API_KEY=...
 export OPENAI_API_KEY=sk-...
+export OPENROUTER_API_KEY=...
 
 # persona-openhands-sdk (pick one to match -m)
 export LLM_API_KEY="$ANTHROPIC_API_KEY"

--- a/packages/playground/src/playground/model_client.py
+++ b/packages/playground/src/playground/model_client.py
@@ -63,7 +63,9 @@ def openrouter_openai_client_kwargs(model: str) -> Dict[str, str]:
             "OPENROUTER_API_KEY is required for persona model {!r}".format(model)
         )
     base_url = (
-        os.environ.get("OPENROUTER_API_BASE") or OPENROUTER_DEFAULT_BASE_URL
+        os.environ.get("OPENROUTER_API_BASE")
+        or os.environ.get("OPENROUTER_BASE_URL")
+        or OPENROUTER_DEFAULT_BASE_URL
     ).strip()
     return {
         "model": openrouter_model_id(model),

--- a/packages/playground/src/playground/model_client.py
+++ b/packages/playground/src/playground/model_client.py
@@ -17,6 +17,7 @@ from playground.openai_client import (
 )
 
 DASHSCOPE_DEFAULT_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+OPENROUTER_DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
 
 
 def dashscope_model_id(model: str) -> str:
@@ -41,6 +42,31 @@ def dashscope_openai_client_kwargs(model: str) -> Dict[str, str]:
     ).strip()
     return {
         "model": dashscope_model_id(model),
+        "api_key": api_key,
+        "base_url": base_url,
+    }
+
+
+def openrouter_model_id(model: str) -> str:
+    """Return the bare OpenRouter model id from a Harbor persona model string."""
+    value = (model or "").strip()
+    if value.startswith("openrouter/"):
+        return value.split("/", 1)[1]
+    return value
+
+
+def openrouter_openai_client_kwargs(model: str) -> Dict[str, str]:
+    """OpenAI SDK kwargs for OpenRouter chat."""
+    api_key = (os.environ.get("OPENROUTER_API_KEY") or "").strip()
+    if not api_key:
+        raise RuntimeError(
+            "OPENROUTER_API_KEY is required for persona model {!r}".format(model)
+        )
+    base_url = (
+        os.environ.get("OPENROUTER_API_BASE") or OPENROUTER_DEFAULT_BASE_URL
+    ).strip()
+    return {
+        "model": openrouter_model_id(model),
         "api_key": api_key,
         "base_url": base_url,
     }
@@ -157,6 +183,14 @@ def build_json_client(model: str, *, temperature: float = 0.7) -> Any:
         return AnthropicJSONClient(value.split("/", 1)[1], temperature=temperature)
     if value.startswith("dashscope/"):
         kwargs = dashscope_openai_client_kwargs(value)
+        return OpenAIChatClient(
+            model=kwargs["model"],
+            api_key=kwargs["api_key"],
+            base_url=kwargs["base_url"],
+            temperature=temperature,
+        )
+    if value.startswith("openrouter/"):
+        kwargs = openrouter_openai_client_kwargs(value)
         return OpenAIChatClient(
             model=kwargs["model"],
             api_key=kwargs["api_key"],

--- a/packages/playground/src/playground/tests/test_model_client_openrouter.py
+++ b/packages/playground/src/playground/tests/test_model_client_openrouter.py
@@ -1,0 +1,95 @@
+import pytest
+
+from playground import model_client
+from playground.openai_client import OpenAIChatClient
+
+
+class _FakeOpenAI:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.chat = object()
+
+
+def test_openrouter_model_id_preserves_provider_model_path():
+    assert (
+        model_client.openrouter_model_id("openrouter/z-ai/glm-4.7")
+        == "z-ai/glm-4.7"
+    )
+
+
+def test_openrouter_model_id_preserves_anthropic_model_path():
+    assert (
+        model_client.openrouter_model_id(
+            "openrouter/anthropic/claude-haiku-4.5"
+        )
+        == "anthropic/claude-haiku-4.5"
+    )
+
+
+def test_openrouter_openai_client_kwargs_requires_api_key(monkeypatch):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    with pytest.raises(RuntimeError, match="OPENROUTER_API_KEY"):
+        model_client.openrouter_openai_client_kwargs(
+            "openrouter/z-ai/glm-4.7"
+        )
+
+
+def test_openrouter_api_base_overrides_default(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-openrouter-test")
+    monkeypatch.setenv("OPENROUTER_API_BASE", "https://openrouter.test/v1")
+
+    kwargs = model_client.openrouter_openai_client_kwargs(
+        "openrouter/z-ai/glm-4.7"
+    )
+    assert kwargs == {
+        "model": "z-ai/glm-4.7",
+        "api_key": "sk-openrouter-test",
+        "base_url": "https://openrouter.test/v1",
+    }
+
+
+def test_build_json_client_routes_openrouter_to_openai_compatible(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-openrouter-test")
+    monkeypatch.delenv("OPENROUTER_API_BASE", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    created: list[dict[str, str]] = []
+
+    def fake_openai(**kwargs):
+        created.append(kwargs)
+        return _FakeOpenAI(**kwargs)
+
+    monkeypatch.setattr("openai.OpenAI", fake_openai)
+
+    client = model_client.build_json_client("openrouter/z-ai/glm-4.7")
+    assert isinstance(client, OpenAIChatClient)
+    assert client.model == "z-ai/glm-4.7"
+    assert created == [
+        {
+            "api_key": "sk-openrouter-test",
+            "base_url": model_client.OPENROUTER_DEFAULT_BASE_URL,
+        }
+    ]
+
+
+def test_openai_base_url_does_not_change_openrouter_routing(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-openrouter-test")
+    monkeypatch.delenv("OPENROUTER_API_BASE", raising=False)
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://openai-proxy.test/v1")
+    created: list[dict[str, str]] = []
+
+    def fake_openai(**kwargs):
+        created.append(kwargs)
+        return _FakeOpenAI(**kwargs)
+
+    monkeypatch.setattr("openai.OpenAI", fake_openai)
+
+    client = model_client.build_json_client("openrouter/z-ai/glm-4.7")
+    assert isinstance(client, OpenAIChatClient)
+    assert client.model == "z-ai/glm-4.7"
+    assert created == [
+        {
+            "api_key": "sk-openrouter-test",
+            "base_url": model_client.OPENROUTER_DEFAULT_BASE_URL,
+        }
+    ]

--- a/packages/playground/src/playground/tests/test_model_client_openrouter.py
+++ b/packages/playground/src/playground/tests/test_model_client_openrouter.py
@@ -2,6 +2,7 @@ import pytest
 
 from playground import model_client
 from playground.openai_client import OpenAIChatClient
+from playground.user_sim.tool_client import OpenAIToolStepClient, build_tool_step_client
 
 
 class _FakeOpenAI:
@@ -52,6 +53,7 @@ def test_openrouter_api_base_overrides_default(monkeypatch):
 def test_build_json_client_routes_openrouter_to_openai_compatible(monkeypatch):
     monkeypatch.setenv("OPENROUTER_API_KEY", "sk-openrouter-test")
     monkeypatch.delenv("OPENROUTER_API_BASE", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
     monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
     created: list[dict[str, str]] = []
 
@@ -72,9 +74,79 @@ def test_build_json_client_routes_openrouter_to_openai_compatible(monkeypatch):
     ]
 
 
+def test_build_tool_step_client_routes_openrouter_to_openai_compatible(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-openrouter-test")
+    monkeypatch.delenv("OPENROUTER_API_BASE", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("CLAUDE_API_KEY", raising=False)
+    created: list[dict[str, str]] = []
+
+    def fake_openai(**kwargs):
+        created.append(kwargs)
+        return _FakeOpenAI(**kwargs)
+
+    monkeypatch.setattr("openai.OpenAI", fake_openai)
+
+    client = build_tool_step_client("openrouter/z-ai/glm-4.7")
+    assert isinstance(client, OpenAIToolStepClient)
+    assert client.model == "z-ai/glm-4.7"
+    assert created == [
+        {
+            "api_key": "sk-openrouter-test",
+            "base_url": model_client.OPENROUTER_DEFAULT_BASE_URL,
+        }
+    ]
+
+
+def test_openrouter_base_url_alias_configures_json_client(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-openrouter-test")
+    monkeypatch.delenv("OPENROUTER_API_BASE", raising=False)
+    monkeypatch.setenv("OPENROUTER_BASE_URL", "https://alias.openrouter.test/v1")
+    created: list[dict[str, str]] = []
+
+    def fake_openai(**kwargs):
+        created.append(kwargs)
+        return _FakeOpenAI(**kwargs)
+
+    monkeypatch.setattr("openai.OpenAI", fake_openai)
+
+    client = model_client.build_json_client("openrouter/z-ai/glm-4.7")
+    assert isinstance(client, OpenAIChatClient)
+    assert created == [
+        {
+            "api_key": "sk-openrouter-test",
+            "base_url": "https://alias.openrouter.test/v1",
+        }
+    ]
+
+
+def test_openrouter_api_base_wins_over_alias_for_tool_client(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-openrouter-test")
+    monkeypatch.setenv("OPENROUTER_API_BASE", "https://primary.openrouter.test/v1")
+    monkeypatch.setenv("OPENROUTER_BASE_URL", "https://alias.openrouter.test/v1")
+    created: list[dict[str, str]] = []
+
+    def fake_openai(**kwargs):
+        created.append(kwargs)
+        return _FakeOpenAI(**kwargs)
+
+    monkeypatch.setattr("openai.OpenAI", fake_openai)
+
+    client = build_tool_step_client("openrouter/z-ai/glm-4.7")
+    assert isinstance(client, OpenAIToolStepClient)
+    assert created == [
+        {
+            "api_key": "sk-openrouter-test",
+            "base_url": "https://primary.openrouter.test/v1",
+        }
+    ]
+
+
 def test_openai_base_url_does_not_change_openrouter_routing(monkeypatch):
     monkeypatch.setenv("OPENROUTER_API_KEY", "sk-openrouter-test")
     monkeypatch.delenv("OPENROUTER_API_BASE", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
     monkeypatch.setenv("OPENAI_BASE_URL", "https://openai-proxy.test/v1")
     created: list[dict[str, str]] = []
 

--- a/packages/playground/src/playground/user_sim/tool_client.py
+++ b/packages/playground/src/playground/user_sim/tool_client.py
@@ -189,7 +189,10 @@ def build_tool_step_client(
     temperature: float = 0.7,
     capabilities: Sequence[ChatbotCapability] | None = None,
 ) -> ToolStepClient:
-    from playground.model_client import dashscope_openai_client_kwargs
+    from playground.model_client import (
+        dashscope_openai_client_kwargs,
+        openrouter_openai_client_kwargs,
+    )
 
     value = (model or "openai/gpt-4o-mini").strip()
     if value.startswith("anthropic/"):
@@ -212,6 +215,15 @@ def build_tool_step_client(
         )
     if value.startswith("dashscope/"):
         kwargs = dashscope_openai_client_kwargs(value)
+        return OpenAIToolStepClient(
+            kwargs["model"],
+            api_key=kwargs["api_key"],
+            base_url=kwargs["base_url"],
+            temperature=temperature,
+            capabilities=capabilities,
+        )
+    if value.startswith("openrouter/"):
+        kwargs = openrouter_openai_client_kwargs(value)
         return OpenAIToolStepClient(
             kwargs["model"],
             api_key=kwargs["api_key"],


### PR DESCRIPTION
Adds an `openrouter/` model prefix alongside the existing `anthropic/`, `openai/`, and `dashscope/` prefixes, so persona LLMs can be served from OpenRouter without further configuration.

OpenRouter model ids carry their own vendor prefix, giving the full string two slashes. `openrouter_model_id()` therefore strips only the leading segment, mirroring `dashscope_model_id()`, so `openrouter/z-ai/glm-4.7` resolves to `z-ai/glm-4.7` rather than to `glm-4.7`.

The base URL resolves from `OPENROUTER_API_BASE`, then the OpenRouter default. It deliberately does not fall back to `OPENAI_BASE_URL`. Before this change the only way to reach OpenRouter was to set `OPENAI_BASE_URL`, which makes `_llm_proxy_base_url()` non-empty and consequently reroutes the `anthropic/` prefix through the same proxy. Addressing OpenRouter explicitly keeps the two independent, so a single process can send some models to OpenRouter and others direct to Anthropic.

No existing prefix changes behaviour.

The new test is added to the curated suite in the pytest workflow, since that workflow selects individual files under packages/playground/src rather than the whole directory.

Validation:
  uv run pytest packages/playground/src/playground/tests/test_model_client_openrouter.py
  uvx ruff@0.15.20 check .
  Live call: build_json_client("openrouter/z-ai/glm-4.7") returned valid JSON
  with OPENAI_BASE_URL set to an invalid host, confirming the isolation above.

## Module

Select the owning module:

- [ ] `persona/`
- [ ] `application/`
- [ ] `environment/`
- [ ] `packages/`
- [ ] `apps/`
- [ ] docs or migration metadata only

## Summary

What changed and why?

## Validation

Commands run:

```bash

```

### Application task PRs

When this PR adds or materially changes an `application/tasks/…` scenario:

- [ ] Attached the **Playground UI** batch report PDF (Runs → job → **Download PDF**
      on the persona-task batch report), not the server text `…/report.pdf` export.

## Data Policy

- [ ] No large generated outputs or raw dumps were added.
- [ ] Any fixtures are small and necessary for tests or docs.
