### PR TITLE
feat(playground): survey/chat Harness selector (CLI subscription support) + preflight check

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -50,6 +50,7 @@ jobs:
           uv run pytest tests/ \
             packages/harbor-langsmith/tests/ \
             packages/rewardkit/tests/ \
+            application/playground/backend/tests/test_api.py \
             application/playground/backend/tests/test_api_schemas.py \
             application/playground/backend/tests/test_application_types.py \
             application/playground/backend/tests/test_application_task_spec.py \

--- a/application/playground/backend/api/app.py
+++ b/application/playground/backend/api/app.py
@@ -41,6 +41,7 @@ import os
 import subprocess
 import urllib.request
 from contextlib import asynccontextmanager
+from pathlib import Path
 from typing import Any, AsyncIterator, Dict, List, Optional
 
 from fastapi import Depends, FastAPI, HTTPException, Query, Request
@@ -273,6 +274,51 @@ def preflight_checks() -> List[Dict[str, Any]]:
                 "Configured."
                 if openrouter_key
                 else "Not configured. Needed only for OpenRouter persona models."
+            ),
+        }
+    )
+
+    # ---- Core — CLI harness subscriptions (optional) ------------------- #
+    # Vendor-CLI subscription credentials are an alternative to API keys, but
+    # only for the Docker CLI harnesses (persona-claude-code / persona-codex /
+    # persona-gemini-cli): web "CLI family" runs and force_docker survey/chat.
+    # API-direct persona models (json-survey / user-sim via litellm) still
+    # need the provider API keys above.
+    def _path_from(env_name: str, default: Path) -> Path:
+        override = (os.environ.get(env_name) or "").strip()
+        return Path(override).expanduser() if override else default
+
+    home = Path.home()
+    claude_subscription = bool((os.environ.get("CLAUDE_CODE_OAUTH_TOKEN") or "").strip())
+    codex_subscription = _path_from(
+        "CODEX_AUTH_JSON_PATH", home / ".codex" / "auth.json"
+    ).is_file()
+    gemini_subscription = _path_from(
+        "GEMINI_OAUTH_CREDS_PATH", home / ".gemini" / "oauth_creds.json"
+    ).is_file()
+    subscriptions = [
+        label
+        for label, present in (
+            ("Claude Code", claude_subscription),
+            ("Codex", codex_subscription),
+            ("Gemini CLI", gemini_subscription),
+        )
+        if present
+    ]
+    checks.append(
+        {
+            "group": "Core",
+            "name": "CLI subscriptions",
+            "ok": bool(subscriptions),
+            "optional": True,
+            "detail": (
+                "Configured: {}. Used by the Docker CLI harnesses "
+                "(web CLI family, force-docker survey/chat) instead of an API "
+                "key.".format(", ".join(subscriptions))
+                if subscriptions
+                else "Not configured. Optional — lets the Docker CLI harnesses "
+                "(Claude Code, Codex, Gemini CLI) bill a vendor subscription "
+                "instead of an API key. See agents.md § CLI subscription auth."
             ),
         }
     )

--- a/application/playground/backend/tests/test_api.py
+++ b/application/playground/backend/tests/test_api.py
@@ -41,6 +41,7 @@ def test_preflight_shape(client):
         "Web tasks",
         "Docker",
         "use.computer API",
+        "CLI subscriptions",
     } <= names
     # Not part of the shipped application task set — keep out of readiness.
     assert "Recommendation engine" not in names
@@ -68,6 +69,7 @@ def test_preflight_required_vs_optional_contract(client):
         "Acme MCP support",
         "Docker",
         "use.computer API",
+        "CLI subscriptions",
     } <= optional
     assert body["ready"] == all(c["ok"] for c in body["checks"] if not c.get("optional"))
 
@@ -150,6 +152,44 @@ def test_preflight_anthropic_check_optional(client, monkeypatch):
     body = client.get("/api/preflight").json()
     anthropic = next(c for c in body["checks"] if c["name"] == "Anthropic credentials")
     assert anthropic["ok"] is True
+
+
+def test_preflight_cli_subscriptions_optional(client, monkeypatch, tmp_path):
+    # No token, no credential files anywhere under a scratch HOME.
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.delenv("CODEX_AUTH_JSON_PATH", raising=False)
+    monkeypatch.delenv("GEMINI_OAUTH_CREDS_PATH", raising=False)
+    monkeypatch.setattr("backend.api.app.Path.home", staticmethod(lambda: tmp_path))
+    body = client.get("/api/preflight").json()
+    check = next(c for c in body["checks"] if c["name"] == "CLI subscriptions")
+    assert check["ok"] is False
+    assert check.get("optional") is True
+    # Never gates readiness on its own.
+    assert "CLAUDE_CODE_OAUTH_TOKEN" not in check["detail"]
+
+    # Claude Code subscription token present.
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat-test")
+    body = client.get("/api/preflight").json()
+    check = next(c for c in body["checks"] if c["name"] == "CLI subscriptions")
+    assert check["ok"] is True
+    assert "Claude Code" in check["detail"]
+    assert "Codex" not in check["detail"]
+
+    # Codex auth.json via explicit path override.
+    auth_json = tmp_path / "auth.json"
+    auth_json.write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("CODEX_AUTH_JSON_PATH", str(auth_json))
+    body = client.get("/api/preflight").json()
+    check = next(c for c in body["checks"] if c["name"] == "CLI subscriptions")
+    assert "Codex" in check["detail"]
+
+    # Gemini CLI creds at the default location under HOME.
+    creds = tmp_path / ".gemini" / "oauth_creds.json"
+    creds.parent.mkdir(parents=True)
+    creds.write_text("{}", encoding="utf-8")
+    body = client.get("/api/preflight").json()
+    check = next(c for c in body["checks"] if c["name"] == "CLI subscriptions")
+    assert "Gemini CLI" in check["detail"]
 
 
 class _FakeOkResponse:

--- a/application/playground/frontend/src/components/cockpit/PlaygroundCockpit.tsx
+++ b/application/playground/frontend/src/components/cockpit/PlaygroundCockpit.tsx
@@ -318,6 +318,10 @@ function ChatbotEvalCockpit({
     personaModel,
     setPersonaModel,
     personaModelOptions,
+    harness,
+    setHarness,
+    launchMode,
+    launchAgentName,
     samplingMode,
     setSamplingMode,
     selectedPersonaIds,
@@ -528,7 +532,8 @@ function ChatbotEvalCockpit({
       taskPath: chatTaskPath,
       personaId: persona.id,
       personaModel,
-      mode: "auto",
+      mode: launchMode,
+      agentName: launchAgentName,
       chatDomain: requestDomain,
       chatApplicationId: knownLaunchApplicationId ?? undefined,
       chatApplicationContext: launchChatApplicationContext,
@@ -555,6 +560,8 @@ function ChatbotEvalCockpit({
     run,
     applicationId,
     personaModel,
+    launchMode,
+    launchAgentName,
     requestDomain,
     knownLaunchApplicationId,
     launchChatApplicationContext,
@@ -587,7 +594,8 @@ function ChatbotEvalCockpit({
           seed,
           personaModel,
           ...personaFields,
-          mode: "auto",
+          mode: launchMode,
+          agentName: launchAgentName,
           chatDomain: requestDomain,
           chatApplicationId: knownLaunchApplicationId ?? undefined,
           chatApplicationContext: launchChatApplicationContext,
@@ -610,6 +618,8 @@ function ChatbotEvalCockpit({
     applicationId,
     seed,
     personaModel,
+    launchMode,
+    launchAgentName,
     parallelTrials,
     personaPool,
     requestDomain,
@@ -857,6 +867,8 @@ function ChatbotEvalCockpit({
           personaModel={personaModel}
           onPersonaModelChange={setPersonaModel}
           personaModelOptions={personaModelOptions}
+          harness={harness}
+          onHarnessChange={setHarness}
           mode={samplingMode}
           onModeChange={setSamplingMode}
           selectedPersonaIds={visiblePersonaIds}

--- a/application/playground/frontend/src/components/cockpit/SurveyEvalCockpit.tsx
+++ b/application/playground/frontend/src/components/cockpit/SurveyEvalCockpit.tsx
@@ -208,6 +208,10 @@ export function SurveyEvalCockpit({
     personaModel,
     setPersonaModel,
     personaModelOptions,
+    harness,
+    setHarness,
+    launchMode,
+    launchAgentName,
     samplingMode,
     setSamplingMode,
     selectedPersonaIds,
@@ -358,7 +362,8 @@ export function SurveyEvalCockpit({
         taskPath,
         personaId: persona.id,
         personaModel,
-        mode: "auto",
+        mode: launchMode,
+        agentName: launchAgentName,
         mapDebrief: (debrief, ctx) =>
           mapSurveyDebriefToJobView(debrief, ctx, {
             personaId: persona.id,
@@ -375,7 +380,7 @@ export function SurveyEvalCockpit({
           }),
       });
     },
-    [persona, isRunning, run, personaModel, harborTasks],
+    [persona, isRunning, run, personaModel, launchMode, launchAgentName, harborTasks],
   );
 
   const handleRun = useCallback(() => {
@@ -406,7 +411,8 @@ export function SurveyEvalCockpit({
           seed,
           personaModel,
           ...personaFields,
-          mode: "auto",
+          mode: launchMode,
+          agentName: launchAgentName,
         });
         setBatchJobName(launched.jobName, { taskId: selectedCard.id, personaPool });
       } catch (exc) {
@@ -425,6 +431,8 @@ export function SurveyEvalCockpit({
     isBatchRun,
     seed,
     personaModel,
+    launchMode,
+    launchAgentName,
     parallelTrials,
     personaPool,
     handleRun,
@@ -571,6 +579,8 @@ export function SurveyEvalCockpit({
           personaModel={personaModel}
           onPersonaModelChange={setPersonaModel}
           personaModelOptions={personaModelOptions}
+          harness={harness}
+          onHarnessChange={setHarness}
           mode={samplingMode}
           onModeChange={setSamplingMode}
           selectedPersonaIds={visiblePersonaIds}

--- a/application/playground/frontend/src/components/cockpit/setup/PersonaSamplingRail.tsx
+++ b/application/playground/frontend/src/components/cockpit/setup/PersonaSamplingRail.tsx
@@ -23,6 +23,7 @@ import {
   type PersonaPoolPersonaCard,
   type TaskPersonaStrategy,
 } from "@/lib/types";
+import { runHarnessSelectOptions, type RunHarnessId } from "@/lib/personaAgentCatalog";
 import {
   formatPersonaSampleError,
   isPersonaPoolCoverageError,
@@ -499,6 +500,9 @@ export interface PersonaSamplingRailProps {
   personaModel: string;
   onPersonaModelChange: (model: string) => void;
   personaModelOptions: CockpitSelectOption[];
+  /** Run harness (survey / chatbot): API-direct or a Docker CLI agent. */
+  harness?: RunHarnessId;
+  onHarnessChange?: (harness: RunHarnessId) => void;
   mode: PersonaSamplingMode;
   onModeChange: (mode: PersonaSamplingMode) => void;
   selectedPersonaIds: string[];
@@ -538,6 +542,8 @@ export function PersonaSamplingRail({
   personaModel,
   onPersonaModelChange,
   personaModelOptions,
+  harness,
+  onHarnessChange,
   mode,
   onModeChange,
   selectedPersonaIds,
@@ -1142,6 +1148,18 @@ export function PersonaSamplingRail({
               onChange={onPersonaModelChange}
             />
           )}
+          {harness !== undefined && onHarnessChange && (
+            <CockpitSelect
+              label="Harness"
+              inlineLabel
+              labelClassName="w-[4.25rem]"
+              value={harness}
+              options={runHarnessSelectOptions()}
+              disabled={disabled}
+              showSelectedMeta={false}
+              onChange={(next) => onHarnessChange(next as RunHarnessId)}
+            />
+          )}
         </div>
 
         <div className="cockpit-segment cockpit-segment--grid mb-2 grid-cols-2">
@@ -1337,8 +1355,7 @@ export function PersonaSamplingRail({
         ) : (
         <>
         <div className="mb-2">
-        <CockpitSelect
-            label="Dataset"
+        <CockpitSelect            label="Dataset"
             inlineLabel
             labelClassName="w-[4.25rem]"
             value={sourcePool}

--- a/application/playground/frontend/src/components/cockpit/setup/useSetupPersonaSampling.ts
+++ b/application/playground/frontend/src/components/cockpit/setup/useSetupPersonaSampling.ts
@@ -2,6 +2,12 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
+import {
+  DEFAULT_RUN_HARNESS,
+  runHarnessLaunchFields,
+  runHarnessPersonaModelOptions,
+  type RunHarnessId,
+} from "@/lib/personaAgentCatalog";
 import { takePersonaHandoff, peekPersonaHandoff } from "@/lib/personaHandoffStorage";
 import { useUrlState } from "@/lib/useUrlState";
 import type { HarborCockpitTaskKind } from "@/lib/harborCockpitMappers";
@@ -424,15 +430,37 @@ export function useSetupPersonaSampling(
   const isBatchRun =
     samplingMode !== "single" || selectedCount > 1 || selectedPersonaIds.length > 1;
 
+  // Run harness (survey / chatbot only): API-direct auto mode, or a Docker CLI
+  // harness (force_docker) that can bill a vendor subscription instead of an
+  // API key. Session-local on purpose — subscription billing stays opt-in.
+  const harnessSelectable = taskKind === "survey" || taskKind === "chatbot";
+  const [harness, setHarness] = useState<RunHarnessId>(DEFAULT_RUN_HARNESS);
+  const effectiveHarness = harnessSelectable ? harness : DEFAULT_RUN_HARNESS;
+  const { mode: launchMode, agentName: launchAgentName } =
+    runHarnessLaunchFields(effectiveHarness);
+
   const personaModelKnob = options?.knobs.find((k) => k.key === "personaModel");
   // Provider meta only in the open menu (closed trigger stays label-only).
   // Omit summary — long descriptions clutter the compact Persona rail.
-  const personaModelOptions =
+  const allPersonaModelOptions =
     personaModelKnob?.options.map((o) => ({
       value: o.value,
       label: o.label,
       meta: personaModelProviderLabel(o.value),
     })) ?? [{ value: personaModel, label: personaModel }];
+  // CLI harnesses only speak their own vendor's models.
+  const personaModelOptions = runHarnessPersonaModelOptions(
+    effectiveHarness,
+    allPersonaModelOptions,
+  );
+
+  useEffect(() => {
+    if (!harnessSelectable) return;
+    if (personaModelOptions.length === 0) return;
+    if (personaModelOptions.some((opt) => opt.value === personaModel)) return;
+    setPersonaModel(personaModelOptions[0].value);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- options identity churns per render; keying on harness + model is enough
+  }, [effectiveHarness, harnessSelectable, personaModel]);
 
   const togglePersona = useCallback(
     (personaId: string) => {
@@ -466,6 +494,11 @@ export function useSetupPersonaSampling(
     personaModel,
     setPersonaModel,
     personaModelOptions,
+    harness: effectiveHarness,
+    setHarness,
+    harnessSelectable,
+    launchMode,
+    launchAgentName,
     samplingMode,
     setSamplingMode,
     selectedPersonaIds,

--- a/application/playground/frontend/src/lib/personaAgentCatalog.ts
+++ b/application/playground/frontend/src/lib/personaAgentCatalog.ts
@@ -229,6 +229,53 @@ export function webPersonaModelSelectOptions(
   return options;
 }
 
+/**
+ * Survey / chat run harness. "api" is the auto-mode default (persona-json-survey /
+ * persona-user-sim call the model API directly); a CLI id switches the launch to
+ * `mode: "force_docker"` with that Docker CLI harness, which can bill a vendor
+ * subscription (agents.md § CLI subscription auth) instead of an API key.
+ */
+export type RunHarnessId = "api" | "persona-claude-code" | "persona-codex" | "persona-gemini-cli";
+
+export const DEFAULT_RUN_HARNESS: RunHarnessId = "api";
+
+export function isCliRunHarness(harness: RunHarnessId): boolean {
+  return harness !== "api";
+}
+
+export function runHarnessSelectOptions(): CockpitSelectOption[] {
+  return [
+    {
+      value: "api",
+      label: "API (direct)",
+      meta: "auto · needs provider API key",
+    },
+    ...CLI_PERSONA_AGENTS.map((opt) => ({
+      value: opt.value,
+      label: opt.label.endsWith("CLI") ? opt.label : `${opt.label} CLI`,
+      meta: `${opt.badge ? `${opt.badge} · ` : ""}docker · subscription-capable`,
+    })),
+  ];
+}
+
+/** Launch fields for a run harness: auto/API vs force-docker CLI agent. */
+export function runHarnessLaunchFields(harness: RunHarnessId): {
+  mode: "auto" | "force_docker";
+  agentName?: string;
+} {
+  if (!isCliRunHarness(harness)) return { mode: "auto" };
+  return { mode: "force_docker", agentName: harness };
+}
+
+/** Vendor-matched persona models for a run harness (all options for "api"). */
+export function runHarnessPersonaModelOptions(
+  harness: RunHarnessId,
+  options: CockpitSelectOption[],
+): CockpitSelectOption[] {
+  if (!isCliRunHarness(harness)) return options;
+  return webPersonaModelSelectOptions(harness, options);
+}
+
 const CAPABILITY_TIER_LABELS: Record<AgentCapabilityTier, string> = {
   light: "Light",
   standard: "Standard",

--- a/application/tasks/example-survey_product-feedback/instruction.md
+++ b/application/tasks/example-survey_product-feedback/instruction.md
@@ -11,3 +11,34 @@ Read the product brief, then complete every question in the questionnaire. We wa
 - For multiple-choice, use the listed option ids.
 - For rating scales, use a whole number in the given range.
 - Give the answer alone unless a question also asks for a short reason or confidence.
+
+## Files (container runs)
+
+When you run inside the task container (working directory `/app`), the survey
+form is not delivered turn-by-turn — read and write it yourself:
+
+- Questionnaire (question ids, types, option ids, scale ranges): `/app/input/questionnaire.yaml`
+- Product brief: `/app/input/context.md`
+- Write your completed survey to `/app/output/survey_result.json`:
+
+```json
+{
+  "answers": [
+    {"questionId": "<id>", "prompt": "<question text>", "value": "<option id | number | text>", "rationale": "<short reason>"}
+  ],
+  "trajectory": [
+    {
+      "timestamp": "<ISO-8601>",
+      "actor": "persona",
+      "action": "ask_question",
+      "context": {"questionId": "<id>", "questionType": "<single_choice|multi_choice|likert|free_text>"},
+      "outcome": {"answered": true}
+    }
+  ]
+}
+```
+
+Add one `ask_question` trajectory event per answered question — every event
+needs all five keys (`timestamp`, `actor`, `action`, `context`, `outcome`;
+`context` and `outcome` are objects), with `questionType` copied from the
+questionnaire's `type` field.

--- a/docs/environment/agents.md
+++ b/docs/environment/agents.md
@@ -86,7 +86,10 @@ set.
 
 `generate_application_job.py --execution-mode auto` picks `persona-json-survey` or
 `persona-user-sim` from the task type. Use `--agent-name` to override, or
-`--execution-mode force_docker` for the CLI agents above.
+`--execution-mode force_docker` for the CLI agents above. In the Playground the
+survey / chatbot **Harness** selector does the same: "API (direct)" is auto
+mode, a CLI harness launches `force_docker` with that agent (and can bill a
+vendor subscription — see § CLI subscription auth).
 
 Live-web details: [web-interaction.md](web-interaction.md).
 


### PR DESCRIPTION
## What

Lets Playground survey/chat runs use a vendor **CLI subscription** (e.g. Claude Max via `claude setup-token`) instead of an API key, end to end:

1. **Preflight: "CLI subscriptions" check**: `/api/preflight` now reports whether CLI-harness subscription credentials are configured (Claude Code `CLAUDE_CODE_OAUTH_TOKEN`, Codex `auth.json`, Gemini CLI `oauth_creds.json`), with a detail explaining where they apply. Previously only API keys were surfaced, so a subscription-only setup looked unconfigured.
2. **GUI: Harness selector for survey/chat**: a new "Harness" select next to Model in the persona rail: "API (direct)" (existing auto mode, default) or Claude Code / Codex / Gemini CLI. Picking a CLI harness launches the job with `mode: "force_docker"` + that `agentName` (both already supported by the backend), and filters the model list to that vendor, mirroring the existing web "CLI family" picker. Session-local state, so subscription billing stays opt-in.
3. **Task fix: container file contract in `instruction.md`**: in the docker/CLI path the questionnaire is bind-mounted at `/app/input/questionnaire.yaml` but the instruction never mentioned it, so agents answered conversationally and scored 0. The example survey task now documents the input paths and the exact `survey_result.json` schema the verifier expects. (Auto mode is unaffected: `persona-json-survey` discards `instruction.md` and renders its own prompt.)
4. **Docs**: `agents.md` notes the Playground Harness selector as the GUI equivalent of `--execution-mode force_docker`.

## Why

The CLI subscription auth path (agents.md § CLI subscription auth) was only reachable from the Playground for web tasks. Survey/chat, the most common Playground flows, required an API key even when the operator had a working subscription.

## Verified

- `pytest backend/tests/test_api.py`: 14/14 (new preflight test included); full suite failure set unchanged vs `main`.
- Frontend `tsc`: no new errors vs `main`.
- Live end-to-end on macOS: Playground → Survey → Harness "Claude Code CLI" → force_docker trial ran `claude` with `apiKeySource: "none"` (subscription billing) and the verifier scored **reward 1.0** (9/9 answers valid). Before the instruction fix the same run scored 0 with "missing /app/output/survey_result.json".

> Split out the unrelated fixes hit while dogfooding this with the Persona 1M pool into #33 (stratified per-cell sampling) and #34 (batch grid persona cards + display names), to keep this PR reviewable as the feature alone.

## Note (not fixed here, tracked in #32)

The example survey task's oracle `solution/solve.sh` writes `/app/output/survey_responses.json`, but `tests/test_state.py` reads `/app/output/survey_result.json`, so the oracle itself scores 0. Filed as #32; happy to fix in a follow-up if the intended filename is confirmed.
