### PR TITLE
fix(playground): stratified 1M sampling silently mis-sizes explicit per-cell strata

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -63,6 +63,8 @@ jobs:
             application/playground/backend/tests/test_harbor_survey_eval.py \
             application/playground/backend/tests/test_harbor_web_trace.py \
             application/playground/backend/tests/test_job_aggregation.py \
+            application/playground/backend/tests/test_persona_1m_index.py \
+            application/playground/backend/tests/test_persona_1m_pool.py \
             application/playground/backend/tests/test_persona_pool_service.py \
             application/playground/backend/tests/test_post_run_feedback.py \
             application/playground/backend/tests/test_remote_runner_client.py \

--- a/application/playground/backend/service/persona_1m_index.py
+++ b/application/playground/backend/service/persona_1m_index.py
@@ -495,8 +495,11 @@ def sample_row_ids_with_index(
 
         cells = list(product(*field_values))
         rng.shuffle(cells)
+        # Explicit per-cell quota is primary: take N per cell across ALL cells;
+        # sample_size is not a clip (mirrors PersonaPoolService contract).
+        target = per_cell * len(cells) if per_cell is not None else sample_size
         for cell in cells:
-            if len(chosen) >= sample_size:
+            if len(chosen) >= target:
                 break
             parts = []
             if base is not None:
@@ -507,12 +510,12 @@ def sample_row_ids_with_index(
             if cell_ids.size == 0:
                 continue
             take = per_cell if per_cell is not None else 1
-            take = min(take, int(cell_ids.size), sample_size - len(chosen))
+            take = min(take, int(cell_ids.size), target - len(chosen))
             if take <= 0:
                 continue
             pick = rng.choice(cell_ids, size=take, replace=False)
             chosen.extend(int(x) for x in np.atleast_1d(pick))
-        return np.asarray(chosen[:sample_size], dtype=np.uint32)
+        return np.asarray(chosen[:target], dtype=np.uint32)
 
     # Random (optionally filtered).
     pool = base if base is not None else np.arange(index.rows, dtype=np.uint32)

--- a/application/playground/backend/service/persona_1m_pool.py
+++ b/application/playground/backend/service/persona_1m_pool.py
@@ -468,11 +468,9 @@ def _flatten_stratum_buckets(
         else:
             chosen.extend(bucket)
 
+    # Explicit per-cell quota is primary: N per cell across all cells,
+    # sample_size is not a clip (mirrors PersonaPoolService contract).
     if per_cell is None and len(chosen) > sample_size:
-        rng.shuffle(chosen)
-        chosen = chosen[:sample_size]
-    elif per_cell is not None and len(chosen) > sample_size:
-        # Prefer covering more cells: keep at most sample_size after shuffle.
         rng.shuffle(chosen)
         chosen = chosen[:sample_size]
     return chosen
@@ -535,8 +533,23 @@ def _stratified_sample_production(
         seen_ids.add(persona_id)
         return True
 
+    # Explicit per-cell: early-exit only when the expected cell count is known
+    # (every stratify field constrained by filters) — otherwise a full pass is
+    # required, since new cells may appear anywhere in the stream.
+    expected_cells: int | None = None
+    if per_cell is not None and dimension_filters:
+        if all(dimension_filters.get(field) for field in bare):
+            expected_cells = 1
+            for field in bare:
+                expected_cells *= len(dimension_filters[field])
+
     def done() -> bool:
-        return sum(len(bucket) for bucket in buckets.values()) >= sample_size
+        total = sum(len(bucket) for bucket in buckets.values())
+        if per_cell is None:
+            return total >= sample_size
+        if expected_cells is None:
+            return False
+        return total >= per_cell * expected_cells
 
     # Single forward pass; stop once the cohort is full.
     for row in _iter_decoded_rows(paths, codec):


### PR DESCRIPTION
## What

Fixes Persona 1M stratified sampling silently mis-sizing cohorts when an explicit per-cell quota is set.

Both 1M sampling paths clipped explicit per-cell quotas to `sample_size`, contradicting the documented contract (an explicit per-cell number is primary and skips the `sample_size` ceiling, as `PersonaPoolService` already behaves). Worse, the streaming path's early exit stopped the single forward pass once `sample_size` rows were collected, so strata appearing later in the stream were never sampled at all, biasing stratified cohorts toward early rows.

- Index path: with an explicit `per_cell`, target `per_cell * cells` instead of clipping at `sample_size`.
- Streaming path: drop the per-cell `sample_size` clip; early-exit only when the expected cell count is derivable (every stratify field fully constrained by filters), otherwise complete the full pass.

## Why it matters

Any stratified study run on the 1M pool with an explicit per-cell quota got a silently different cohort composition than requested: under-filled and biased toward strata that appear early in the parquet stream.

Note this intentionally changes behavior: per-cell stratified cohorts on the 1M pool are no longer capped by `sample_size`, so `per_cell * cells` rows can exceed it by design.

## Verified

`pytest backend/tests/test_persona_1m_pool.py backend/tests/test_persona_1m_index.py`: 10/10 on this branch.
