### PR TITLE
fix(playground): batch grid persona cards for 1M cohorts (id resolution + human display names)

### DIFF
--- a/application/playground/backend/service/persona_1m_pool.py
+++ b/application/playground/backend/service/persona_1m_pool.py
@@ -18,6 +18,8 @@ from typing import Any, Iterator
 
 import yaml
 
+from matraix.persona_display_name import assign_cohort_display_names, synthetic_display_name
+
 PRODUCTION_1M_POOL = "persona/datasets/matraix-persona-1m"
 PRODUCTION_1M_LABEL = "matraix-persona-1m"
 PRODUCTION_1M_KIND = "production"
@@ -688,6 +690,10 @@ def materialize_cohort(
     out_dir = repo_root / rel_pool
     out_dir.mkdir(parents=True, exist_ok=True)
 
+    display_names = assign_cohort_display_names(
+        [(str(row["persona_id"]), dict(row.get("dimensions") or {})) for row in rows]
+    )
+
     manifest_personas: list[dict[str, Any]] = []
     source_counts: dict[str, int] = {}
     for row in rows:
@@ -703,6 +709,7 @@ def materialize_cohort(
             "persona_id": persona_id,
             "version": "1.0",
             "source": source,
+            "display_name": display_names.get(persona_id),
             "dimensions": dimensions,
         }
         (repo_root / rel_yaml).write_text(
@@ -717,6 +724,7 @@ def materialize_cohort(
         manifest_personas.append(
             {
                 "persona_id": persona_id,
+                "display_name": display_names.get(persona_id),
                 "path": rel_yaml,
                 "source": source,
                 "dimensions": card_dims,
@@ -746,7 +754,7 @@ def materialize_cohort(
     cards = [
         {
             "personaId": item["persona_id"],
-            "name": f"persona-{item['persona_id']}",
+            "name": item.get("display_name") or f"persona-{item['persona_id']}",
             "source": item.get("source"),
             "path": item.get("path"),
             "dimensions": dict(item.get("dimensions") or {}),
@@ -831,7 +839,7 @@ def preview_production_1m(
         }
         persona_id = str(row["persona_id"])
         source = str(row.get("source") or "")
-        name = f"persona-{persona_id}"
+        name = synthetic_display_name(persona_id, dims_full)
         search_parts = [persona_id, name, source]
         for key, value in dims_full.items():
             search_parts.append(str(key))
@@ -900,9 +908,12 @@ def _detail_payload_from_row(
         profile_markdown_lines.append(f"**Path:** `{path}`")
     if yaml_text.strip():
         profile_markdown_lines.extend(["", "```yaml", yaml_text.rstrip(), "```"])
+    display_name = str(row.get("display_name") or "").strip() or synthetic_display_name(
+        persona_id, dimensions
+    )
     return {
         "personaId": persona_id,
-        "name": f"persona-{persona_id}",
+        "name": display_name,
         "source": source,
         "path": path or None,
         "dimensions": dimensions,
@@ -1082,6 +1093,7 @@ def get_production_1m_persona_detail(
                 row={
                     "persona_id": str(payload.get("persona_id") or pid),
                     "source": payload.get("source") or "unknown",
+                    "display_name": payload.get("display_name") or "",
                     "dimensions": payload.get("dimensions") or {},
                 },
                 pool=f"{PRODUCTION_1M_POOL}/cohorts/{cohort_dir.name}",

--- a/application/playground/frontend/src/components/cockpit/SurveyEvalCockpit.tsx
+++ b/application/playground/frontend/src/components/cockpit/SurveyEvalCockpit.tsx
@@ -239,6 +239,7 @@ export function SurveyEvalCockpit({
     batchJobName,
     batchTaskId,
     batchPersonaIds,
+    batchPersonaPool,
     setBatchJobName,
     clearBatch,
     cancelBatch,
@@ -253,9 +254,12 @@ export function SurveyEvalCockpit({
     expectedTrialCount,
     completedTrials: batchCompletedTrials,
     batchError,
-  } = useCockpitBatchJob(selectedPersonaIds, parallelTrials, "survey", selectedCount);
+  } = useCockpitBatchJob(selectedPersonaIds, parallelTrials, "survey", selectedCount, personaPool);
   const setupLocked = phase !== "idle" || Boolean(batchJobName);
   const visiblePersonaIds = setupLocked && batchPersonaIds.length > 0 ? batchPersonaIds : selectedPersonaIds;
+  // Locked batches must read cards from the launch-time pool (cohort path);
+  // the live setup pool may have reverted to the raw dataset on reload.
+  const visiblePersonaPool = batchJobName ? batchPersonaPool ?? personaPool : personaPool;
   const activeTaskId = batchJobName && batchTaskId ? batchTaskId : selectedTaskId;
   const selectedCard =
     taskCards.find((item) => item.id === activeTaskId) ?? null;
@@ -401,7 +405,7 @@ export function SurveyEvalCockpit({
           ...personaFields,
           mode: "auto",
         });
-        setBatchJobName(launched.jobName, { taskId: selectedCard.id });
+        setBatchJobName(launched.jobName, { taskId: selectedCard.id, personaPool });
       } catch (exc) {
         const message = exc instanceof ApiError ? exc.message : exc instanceof Error ? exc.message : String(exc);
         setLaunchError(message);
@@ -581,7 +585,7 @@ export function SurveyEvalCockpit({
           useTaskDefaultStrategy={useTaskDefaultStrategy}
           onUseTaskDefaultStrategyChange={setUseTaskDefaultStrategy}
           onPersonaPoolChange={setPersonaPool}
-          personaPool={personaPool}
+          personaPool={visiblePersonaPool}
           disabled={setupLocked}
         />
       }

--- a/application/playground/frontend/src/components/cockpit/setup/BatchTrialGrid.tsx
+++ b/application/playground/frontend/src/components/cockpit/setup/BatchTrialGrid.tsx
@@ -1,7 +1,7 @@
 import { useVirtualizer } from "@tanstack/react-virtual";
 
 import { formatBatchCellStatusLabel } from "@/lib/trialStatus";
-import { personaDisplayId, personaPrimaryName } from "@/lib/personaDisplay";
+import { isMachinePersonaName, personaDisplayId, personaPrimaryName } from "@/lib/personaDisplay";
 import type { PersonaPoolPersonaCard } from "@/lib/types";
 
 import { BatchMosaicCanvas, MOSAIC_STATUS_COLORS } from "./BatchMosaicCanvas";
@@ -395,6 +395,17 @@ function personaMetaFromCard(card: PersonaPoolPersonaCard | undefined): BatchTri
   };
 }
 
+// Status feeds carry bare ids ("wiki-ebc…") while cohort cards key the
+// prefixed form ("persona-wiki-ebc…") — accept either.
+function lookupPersonaCard(
+  personaById: Record<string, PersonaPoolPersonaCard>,
+  personaId: string | null | undefined,
+): PersonaPoolPersonaCard | undefined {
+  const raw = (personaId ?? "").trim();
+  if (!raw) return undefined;
+  return personaById[raw] ?? personaById[personaDisplayId(raw)] ?? personaById[raw.replace(/^persona[-_]/i, "")];
+}
+
 function resolveBatchGridSlots(
   personaIds: string[],
   harborTrials: HarborTrialRow[] | undefined,
@@ -480,7 +491,7 @@ export function buildBatchGridCells(
       status = "running";
     }
 
-    const card = personaById[slot.personaId];
+    const card = lookupPersonaCard(personaById, slot.personaId);
     const persona = personaMetaFromCard(card);
 
     return {
@@ -530,15 +541,23 @@ export function buildBatchCellsFromStatus(
   for (let i = 0; i < snapshot.codes.length; i += 1) {
     const status = STATUS_CODE_TO_STATUS[snapshot.codes[i]] ?? "pending";
     const personaId = snapshot.personaIds[i] ?? undefined;
-    const card = personaId ? personaById[personaId] : undefined;
-    const name = snapshot.personaNames[i] ?? card?.name ?? undefined;
+    const card = lookupPersonaCard(personaById, personaId);
+    // Feed names are machine ids ("persona-wiki-…") until real names land —
+    // never surface those; prefer the cohort card's display name.
+    const feedName = snapshot.personaNames[i] ?? undefined;
+    const name = card?.name ?? (feedName && !isMachinePersonaName(feedName) ? feedName : undefined);
     cells.push({
       id: snapshot.trialNames[i] ?? `trial-${i}`,
       label: name ?? personaId ?? `#${i + 1}`,
       status,
       persona:
         personaId || card
-          ? { personaId: personaId ?? "", name, dimensions: card?.dimensions ?? {} }
+          ? {
+              personaId: card?.personaId ?? personaId ?? "",
+              name,
+              source: card?.source,
+              dimensions: card?.dimensions ?? {},
+            }
           : undefined,
     });
   }
@@ -546,13 +565,18 @@ export function buildBatchCellsFromStatus(
   const total = Math.max(expectedTotal, cells.length);
   for (let i = cells.length; i < total; i += 1) {
     const personaId = personaIds[i];
-    const card = personaId ? personaById[personaId] : undefined;
+    const card = lookupPersonaCard(personaById, personaId);
     cells.push({
       id: personaId ? `persona-${personaId}` : `pending-${i}`,
       label: card?.name ?? personaId ?? `#${i + 1}`,
       status: "pending",
       persona: personaId
-        ? { personaId, name: card?.name, dimensions: card?.dimensions ?? {} }
+        ? {
+            personaId: card?.personaId ?? personaId,
+            name: card?.name,
+            source: card?.source,
+            dimensions: card?.dimensions ?? {},
+          }
         : undefined,
     });
   }

--- a/application/playground/frontend/src/components/cockpit/setup/cockpitBatchStorage.ts
+++ b/application/playground/frontend/src/components/cockpit/setup/cockpitBatchStorage.ts
@@ -6,6 +6,9 @@ export interface CockpitBatchRecord {
   /** Full cohort size — may exceed personaIds when launching by pool ref. */
   selectedCount?: number;
   taskId?: string;
+  /** Pool the launch resolved (cohort path for 1M samples) — needed to re-fetch
+   * cards after reload; the setup store may have reverted to the raw dataset. */
+  personaPool?: string;
 }
 
 type CockpitBatchStore = Partial<Record<HarborCockpitTaskKind, CockpitBatchRecord | null>>;
@@ -100,6 +103,10 @@ export function readCockpitBatch(taskKind: HarborCockpitTaskKind): CockpitBatchR
     personaIds,
     selectedCount,
     taskId: typeof record.taskId === "string" ? record.taskId : undefined,
+    personaPool:
+      typeof record.personaPool === "string" && record.personaPool.trim()
+        ? record.personaPool.trim()
+        : undefined,
   };
 }
 

--- a/application/playground/frontend/src/components/cockpit/setup/useCockpitBatchJob.ts
+++ b/application/playground/frontend/src/components/cockpit/setup/useCockpitBatchJob.ts
@@ -23,6 +23,7 @@ function initialBatchState(taskKind?: HarborCockpitTaskKind) {
       personaIds: [] as string[],
       selectedCount: 0,
       taskId: null as string | null,
+      personaPool: null as string | null,
     };
   }
   const saved = readCockpitBatch(taskKind);
@@ -31,6 +32,7 @@ function initialBatchState(taskKind?: HarborCockpitTaskKind) {
     personaIds: saved?.personaIds ?? [],
     selectedCount: saved?.selectedCount ?? saved?.personaIds.length ?? 0,
     taskId: saved?.taskId ?? null,
+    personaPool: saved?.personaPool ?? null,
   };
 }
 
@@ -39,6 +41,7 @@ export function useCockpitBatchJob(
   parallelTrials = 1,
   taskKind?: HarborCockpitTaskKind,
   selectedCount = 0,
+  personaPool: string | null = null,
 ) {
   const { state: urlState, setState: setUrlState } = useUrlState();
   const [initial] = useState(() => initialBatchState(taskKind));
@@ -46,6 +49,9 @@ export function useCockpitBatchJob(
   const [restoredPersonaIds, setRestoredPersonaIds] = useState<string[]>(initial.personaIds);
   const [restoredSelectedCount, setRestoredSelectedCount] = useState(initial.selectedCount);
   const [restoredTaskId, setRestoredTaskId] = useState<string | null>(initial.taskId);
+  const [restoredPersonaPool, setRestoredPersonaPool] = useState<string | null>(
+    initial.personaPool,
+  );
 
   // Freeze the cohort to the batch launch snapshot until the user resets.
   const effectivePersonaIds = batchJobName
@@ -63,7 +69,7 @@ export function useCockpitBatchJob(
   const statusFeed = useHarborBatchStatus(batchJobName, aggregate);
 
   const setBatchJobName = useCallback(
-    (jobName: string | null, meta?: { taskId?: string }) => {
+    (jobName: string | null, meta?: { taskId?: string; personaPool?: string }) => {
       setBatchJobNameInternal(jobName);
       if (!taskKind) return;
 
@@ -75,11 +81,14 @@ export function useCockpitBatchJob(
           restoredSelectedCount,
         );
         const taskId = meta?.taskId ?? restoredTaskId ?? undefined;
+        const launchPool =
+          meta?.personaPool?.trim() || personaPool?.trim() || restoredPersonaPool || undefined;
         writeCockpitBatch(taskKind, {
           jobName,
           personaIds,
           selectedCount: cohortSize,
           taskId,
+          personaPool: launchPool,
         });
         if (selectedPersonaIds.length > 0) {
           setRestoredPersonaIds(selectedPersonaIds);
@@ -88,6 +97,7 @@ export function useCockpitBatchJob(
         if (taskId) {
           setRestoredTaskId(taskId);
         }
+        setRestoredPersonaPool(launchPool ?? null);
         if (urlState.pgTask === taskKind) {
           setUrlState({
             cockpitBatch: jobName,
@@ -101,13 +111,16 @@ export function useCockpitBatchJob(
         setRestoredPersonaIds([]);
         setRestoredSelectedCount(0);
         setRestoredTaskId(null);
+        setRestoredPersonaPool(null);
         if (urlState.pgTask === taskKind) {
           setUrlState({ cockpitBatch: null });
         }
       }
     },
     [
+      personaPool,
       restoredPersonaIds,
+      restoredPersonaPool,
       restoredSelectedCount,
       restoredTaskId,
       selectedCount,
@@ -153,10 +166,39 @@ export function useCockpitBatchJob(
     [effectivePersonaIds],
   );
 
+  // Launches that predate pool persistence: recover the resolved pool from the
+  // job config's persona_path (…/cohorts/cohort-x/persona_y.yaml → cohort dir).
+  const jobPoolQuery = useQuery({
+    queryKey: ["batch-job-persona-pool", batchJobName],
+    queryFn: () => api.getHarborJob(batchJobName as string),
+    enabled: Boolean(batchJobName) && !restoredPersonaPool,
+    staleTime: Infinity,
+  });
+  const derivedJobPool = useMemo(() => {
+    const agents = (jobPoolQuery.data?.config as { agents?: unknown } | null | undefined)?.agents;
+    if (!Array.isArray(agents)) return null;
+    for (const agent of agents) {
+      const path = (agent as { kwargs?: { persona_path?: unknown } } | null)?.kwargs
+        ?.persona_path;
+      if (typeof path === "string" && path.includes("/")) {
+        return path.slice(0, path.lastIndexOf("/"));
+      }
+    }
+    return null;
+  }, [jobPoolQuery.data?.config]);
+
+  const batchPersonaPool = restoredPersonaPool ?? derivedJobPool;
+
+  // While a batch is locked, the launch-time pool wins: after a reload the
+  // setup store may have reverted to the raw dataset (e.g. matraix-persona-1m),
+  // which rejects id lookups — only the resolved cohort path serves cards.
+  const cardsPool = (batchJobName ? batchPersonaPool ?? personaPool : personaPool) ?? undefined;
+
   const personaCardsQuery = useQuery({
-    queryKey: ["batch-cohort-personas", previewPersonaIds.join(",")],
+    queryKey: ["batch-cohort-personas", cardsPool ?? "", previewPersonaIds.join(",")],
     queryFn: () =>
       api.getPersonaPoolCards({
+        pool: cardsPool,
         personaIds: previewPersonaIds,
         limit: previewPersonaIds.length,
       }),
@@ -236,6 +278,7 @@ export function useCockpitBatchJob(
     batchJobName,
     batchTaskId: restoredTaskId,
     batchPersonaIds: effectivePersonaIds,
+    batchPersonaPool,
     setBatchJobName,
     batchLive,
     clearBatch,

--- a/src/matraix/persona_display_name.py
+++ b/src/matraix/persona_display_name.py
@@ -56,7 +56,7 @@ _REGION_POOLS: dict[str, list[tuple[str, str]]] = {
         ("Noah", "Williams"),
         ("Ava", "Martinez"),
     ],
-    "LATAM": [
+    "Latin America": [
         ("Camila", "Rojas"),
         ("Diego", "Fernandez"),
         ("Lucia", "Santos"),
@@ -110,12 +110,37 @@ def _hash_index(seed: str, modulo: int) -> int:
 def synthetic_display_name(
     persona_id: str,
     dimensions: dict[str, Any] | None = None,
+    *,
+    salt: str = "",
 ) -> str:
-    """Return a stable human-readable name for a bench persona."""
+    """Return a stable human-readable name for a bench persona.
+
+    First and last names are drawn independently (cross-product of the region
+    pool) so cohorts of 10+ personas rarely collide; `salt` lets callers probe
+    for an unused name deterministically.
+    """
     pid = str(persona_id or "").strip()
     dims = dimensions if isinstance(dimensions, dict) else {}
     region = str(dims.get("region") or "").strip()
     pool = _REGION_POOLS.get(region) or _DEFAULT_POOL
-    idx = _hash_index(f"{pid}:{region}", len(pool))
-    first, last = pool[idx]
+    seed = f"{pid}:{region}" if not salt else f"{pid}:{region}:{salt}"
+    first = pool[_hash_index(f"{seed}:f", len(pool))][0]
+    last = pool[_hash_index(f"{seed}:l", len(pool))][1]
     return f"{first} {last}"
+
+
+def assign_cohort_display_names(
+    entries: list[tuple[str, dict[str, Any] | None]],
+) -> dict[str, str]:
+    """Deterministic display names, unique within one cohort."""
+    used: set[str] = set()
+    named: dict[str, str] = {}
+    for persona_id, dimensions in entries:
+        name = synthetic_display_name(persona_id, dimensions)
+        probe = 0
+        while name in used and probe < 64:
+            probe += 1
+            name = synthetic_display_name(persona_id, dimensions, salt=str(probe))
+        used.add(name)
+        named[str(persona_id)] = name
+    return named


### PR DESCRIPTION
## What

Fixes 1M-cohort personas rendering as blank cards or machine ids in the Playground batch grid. Two halves of the same symptom:

**Batch grid card resolution**
- The status feed keys bare ids (`wiki-x`) while cohort cards key the prefixed form (`persona-wiki-x`); grid cell lookups now accept either.
- After a page reload the setup store reverts to the raw dataset (e.g. `matraix-persona-1m`), which rejects card lookups that only the launch-resolved cohort path can serve. The launch-time pool is now persisted with the batch record and used while the batch is locked; for launches that predate pool persistence, the pool is derived from the job config's `persona_path`.
- Machine-id feed names (`persona-wiki-…`) are never surfaced as display names; the cohort card's name wins, and the card's `source` is carried into the cell persona meta.

**Human display names for 1M cohorts**
- The synthetic-name helper's Latin America pool was dead code: keyed `"LATAM"` while the schema value is `"Latin America"`.
- First and last names were drawn as fixed pairs, making collisions common in cohorts of 10+; they are now drawn independently (cross-product of the region pool) with a deterministic salt, and `assign_cohort_display_names` guarantees uniqueness within one cohort.
- Materialized cohort YAMLs, the manifest, persona cards, and the 1M preview/detail payloads now carry the display name instead of the `persona-<id>` fallback.

## Verified

- `pytest backend/tests/test_persona_1m_pool.py backend/tests/test_persona_1m_index.py`: 10/10 on this branch.
- Frontend `tsc`: no new errors vs `main`.
- Developed against live 1M cohort batches in the Playground GUI (the card-resolution half was reproduced and fixed with a running batch).
