### PR TITLE
docs: add multilingual README translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@
     and interactive products with heterogeneous simulated users.
   </p>
   <p>
+    <strong>English</strong> |
+    <a href="docs/i18n/README.ko.md">한국어</a> |
+    <a href="docs/i18n/README.zh-CN.md">简体中文</a> |
+    <a href="docs/i18n/README.zh-TW.md">繁體中文</a> |
+    <a href="docs/i18n/README.ja.md">日本語</a> |
+    <a href="docs/i18n/README.pt-BR.md">Português</a> |
+    <a href="docs/i18n/README.es.md">Español</a>
+  </p>
+  <p>
     <a href="https://matraix.ai/"><img alt="Website" src="https://img.shields.io/badge/Website-matraix.ai-4f7cff?style=for-the-badge"></a>
     <a href="https://discord.gg/knVyQQnRFa"><img alt="Discord" src="https://img.shields.io/badge/Discord-join%20MatrAIx-5865F2?style=for-the-badge&logo=discord&logoColor=white"></a>
     <a href="https://x.com/MatrAIx2026"><img alt="X" src="https://img.shields.io/badge/X-%40MatrAIx2026-000000?style=for-the-badge&logo=x&logoColor=white"></a>

--- a/docs/i18n/README.es.md
+++ b/docs/i18n/README.es.md
@@ -1,0 +1,222 @@
+<div align="center">
+  <h1>MatrAIx</h1>
+  <p><strong>Simulate before reality.</strong></p>
+  <p>
+    Infraestructura a escala poblacional y orientada a personas para evaluar
+    sistemas de IA y productos interactivos con usuarios simulados heterogéneos.
+  </p>
+  <p>
+    <a href="../../README.md">English</a> |
+    <a href="README.ko.md">한국어</a> |
+    <a href="README.zh-CN.md">简体中文</a> |
+    <a href="README.zh-TW.md">繁體中文</a> |
+    <a href="README.ja.md">日本語</a> |
+    <a href="README.pt-BR.md">Português</a> |
+    <strong>Español</strong>
+  </p>
+  <p>
+    <a href="https://matraix.ai/"><img alt="Website" src="https://img.shields.io/badge/Website-matraix.ai-4f7cff?style=for-the-badge"></a>
+    <a href="https://discord.gg/knVyQQnRFa"><img alt="Discord" src="https://img.shields.io/badge/Discord-join%20MatrAIx-5865F2?style=for-the-badge&logo=discord&logoColor=white"></a>
+    <a href="https://x.com/MatrAIx2026"><img alt="X" src="https://img.shields.io/badge/X-%40MatrAIx2026-000000?style=for-the-badge&logo=x&logoColor=white"></a>
+    <a href="https://www.linkedin.com/company/matraix"><img alt="LinkedIn" src="https://img.shields.io/badge/LinkedIn-MatrAIx-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white"></a>
+    <a href="https://forms.gle/hwEHng5HGWRqcJue9"><img alt="Google Form" src="https://img.shields.io/badge/Google%20Form-join%20MatrAIx-4285F4?style=for-the-badge&logo=googleforms&logoColor=white"></a>
+    <a href="../README.md"><img alt="Docs" src="https://img.shields.io/badge/Docs-Handbook-5b5b5b?style=for-the-badge"></a>
+    <a href="https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release"><img alt="Hugging Face" src="https://img.shields.io/badge/Hugging%20Face-Persona%201M-ffcc4d?style=for-the-badge"></a>
+    <a href="../../LICENSE"><img alt="License" src="https://img.shields.io/badge/License-MIT-c33b32?style=for-the-badge"></a>
+    <a href="../quickstart.md#10-playground--play-tasks-visually"><img alt="Playground" src="https://img.shields.io/badge/Playground-Visual%20Runner-56b879?style=for-the-badge"></a>
+  </p>
+</div>
+
+<div align="center">
+  <a href="https://www.youtube.com/watch?v=cNFkz9Wo1y4&t=15s">
+    <img src="https://img.youtube.com/vi/cNFkz9Wo1y4/maxresdefault.jpg" alt="Ver la demo de MatrAIx en YouTube" width="900">
+  </a>
+  <p>
+    <a href="https://www.youtube.com/watch?v=cNFkz9Wo1y4&t=15s"><img alt="Ver la demo de MatrAIx en YouTube" src="https://img.shields.io/badge/%E2%96%B6%20Watch%20the%20demo-on%20YouTube-FF0000?style=for-the-badge&logo=youtube&logoColor=white"></a>
+  </p>
+</div>
+
+---
+
+**MatrAIx** es una infraestructura a escala poblacional y orientada a personas
+para evaluar sistemas de IA y productos interactivos con usuarios simulados
+heterogéneos. En lugar de probar contra un usuario genérico o intercambiable,
+MatrAIx instancia registros de persona muestreados como agentes LLM y los
+ejecuta en tareas reproducibles en cuatro entornos — **Survey**, **AI Chatbot**,
+**Web** y **App** (escritorio y móvil nativos, incluidos macOS e iOS).
+
+En su base hay un esquema compartido de **1.290 dimensiones categóricas** que
+cubren trasfondo, psicología, capacidad y comportamiento. Las personas combinan
+generación sintética consciente de dependencias con grounding humano basado en
+evidencia; un coreset determinista y filtrado por calidad de **un millón de
+personas** se publica para investigación en
+[Hugging Face](https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release).
+La telemetría compartida, la verificación propia de cada tarea y los informes
+conectan respuestas y trayectorias individuales con hallazgos a nivel de
+subgrupo y población.
+
+El nombre alude a *The Matrix*: un mundo simulado útil para exploración,
+pruebas de estrés y generación de hipótesis — **no un sustituto de la evidencia
+de personas reales**.
+
+## Requisitos
+
+- [Docker](https://docs.docker.com/get-docker/)
+- [uv](https://docs.astral.sh/uv/) y Python 3.12
+- Node.js 20+ (solo frontends de Playground / viewer)
+- Claves de API de modelo para ejemplos de agentes de persona — ver [agents.md](../environment/agents.md)
+
+## Instalación
+
+```bash
+git clone <repo-url> && cd MatrAIx
+uv venv --python 3.12
+uv pip install -e .
+uv pip install pytest pytest-asyncio httpx
+uv pip install -e packages/playground
+uv pip install -e packages/harbor-langsmith
+uv pip install -e packages/rewardkit
+```
+
+Todos los comandos de Matraix Playground se ejecutan como **`uv run harbor …`**.
+
+Configura la clave de API del modelo correspondiente a tu proveedor antes de
+ejecutar tareas por GUI o CLI (el smoke test no la necesita):
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."   # modelos anthropic/claude-*
+# export OPENAI_API_KEY="sk-..."        # modelos openai/gpt-*
+```
+
+Consulta la matriz completa de claves en [agents.md](../environment/agents.md).
+Playground también puede cargar claves desde `application/playground/.env.local`.
+
+### Importar Persona 1M (opcional)
+
+```bash
+huggingface-cli download MatrAIx2026/MatrAIx_Persona_1M_Public_Release \
+  --repo-type dataset \
+  --local-dir persona/datasets/matraix-persona-1m/release
+```
+
+Playground: Dataset → **`matraix-persona-1m`**. CLI: `--dataset persona/datasets/matraix-persona-1m`.
+Detalles: [Handbook § Persona 1M](../README.md#3-persona-1m-optional).
+
+## Inicio rápido
+
+### Smoke test
+
+No se requiere clave de API. **Requiere Docker** (el smoke job usa
+`environment.type: docker`):
+
+```bash
+uv run harbor run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml
+```
+
+### Ejecuciones de tareas por GUI
+
+Playground elige tareas, muestrea personas y lanza los mismos jobs de
+Matraix Playground que el modo auto de la CLI.
+Inicia API + frontend (dos terminales):
+
+```bash
+# Terminal A — API
+VENV=.venv bash application/playground/backend/run_dev.sh
+
+# Terminal B — frontend
+cd application/playground/frontend && npm ci && npm run dev
+```
+
+Abre **http://localhost:5173** → Playground → elige una cohort de personas →
+elige tareas Survey / Chat / Web / OS app → **Lock pipeline** → **Run eval**.
+Detalles: [Playground §10](../quickstart.md#10-playground--play-tasks-visually).
+
+### Desarrollo / ejecución por CLI
+
+**Desarrollar** — copia una tarea de referencia en `application/tasks/`, edita
+`task.toml` / `instruction.md` / `input/` / verifier y regístrala en Playground
+([task-guide.md](../application/task-guide.md)):
+
+```bash
+cp -R application/tasks/example-survey_product-feedback \
+  application/tasks/<your-task-name>
+```
+
+| Tipo | Tarea de referencia |
+|------|---------------------|
+| Survey | `application/tasks/example-survey_product-feedback` |
+| Chat | `application/tasks/example-chat-api_support_chatbot` |
+| Web | `application/tasks/example-web-playwright_quote-choice` |
+| OS-app | `application/tasks/example-computer-use-linux_note-to-csv` |
+
+**Ejecutar** — genera un job de Matraix Playground (fija agent + model) y ejecútalo:
+
+```bash
+uv run python application/scripts/generate_application_job.py \
+  --task application/tasks/example-survey_product-feedback \
+  --execution-mode auto \
+  --persona-ids 0042 \
+  --model-name anthropic/claude-sonnet-4-6
+
+# Usa las líneas de export + la ruta del recipe que imprime el script, p. ej.:
+uv run harbor run -c configs/jobs/application-task-job-recipe/example-survey-product-feedback-auto-n1.yaml
+```
+
+Lotes (`--sample-size N`), filtros y ejemplos chat / web / os-app:
+[docs/quickstart.md](../quickstart.md).
+
+## Docs
+
+**[MatrAIx Handbook](../README.md)** — guías y docs de persona / application / environment.
+
+<p align="center">
+  <img src="../assets/matraix-architecture.png" alt="Arquitectura MatrAIx" width="900">
+</p>
+
+## Estructura del repositorio
+
+```text
+MatrAIx/
+├── persona/                 Schema, datasets, pipelines de síntesis/curación/validación
+│   ├── schema/              Schema de persona de 1.290 dimensiones
+│   ├── datasets/            Pool de muestras de desarrollo y YAMLs de persona
+│   ├── validation/          Suites de grounding / validación de calidad
+│   └── scripts/             Helpers de job y pipeline de persona
+├── application/
+│   ├── tasks/               Specs de tareas Survey · chat · web · os-app
+│   ├── task-spec/           Contratos compartidos de tarea
+│   ├── playground/          Runner visual (API backend + frontend)
+│   └── scripts/             generate_application_job.py y tooling de tareas
+├── environment/
+│   ├── runtime/             Runtime de Matraix Playground
+│   ├── agents/              Agentes condicionados a persona
+│   ├── task-environments/   Imágenes Docker / sidecars
+│   └── adapters/            Adaptadores externos (p. ej. SimpleQA)
+├── packages/                playground · rewardkit · harbor-langsmith
+├── apps/viewer/             Frontend emparejado con `harbor view`
+├── configs/jobs/            Recipes de job de Matraix Playground (curados y generados)
+├── docs/                    Handbook — persona/ · application/ · environment/
+├── examples/                Tareas de ejemplo mínimas
+├── src/matraix/             Entry points del paquete Python
+├── scripts/                 Helpers a nivel de repositorio
+├── tests/                   Tests unitarios / de entorno
+└── jobs/                    Salidas locales de Matraix Playground (gitignored)
+```
+
+Los datasets grandes generados quedan fuera de git (ver el release de Hugging Face arriba).
+
+## Únete a la comunidad
+
+[![Discord](https://img.shields.io/badge/Discord-join%20MatrAIx-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/knVyQQnRFa)
+[![X](https://img.shields.io/badge/X-follow%20%40MatrAIx2026-000000?style=for-the-badge&logo=x&logoColor=white)](https://x.com/MatrAIx2026)
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-follow%20MatrAIx-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/company/matraix)
+[![Google Form](https://img.shields.io/badge/Google%20Form-join%20MatrAIx-4285F4?style=for-the-badge&logo=googleforms&logoColor=white)](https://forms.gle/hwEHng5HGWRqcJue9)
+
+1. Únete a Discord — nickname **`Full Name - Affiliation`**. Completa el Google Form
+   (trasfondo, intereses, autoría / agradecimientos en papers).
+2. ¡Saluda! Nos gusta conectar a quienes comparten intereses o experiencia.
+3. Participa en la comunidad de investigación MatrAIx para colaborar o contribuir.
+
+## Licencia
+
+MIT — ver [LICENSE](../../LICENSE).

--- a/docs/i18n/README.ja.md
+++ b/docs/i18n/README.ja.md
@@ -1,0 +1,216 @@
+<div align="center">
+  <h1>MatrAIx</h1>
+  <p><strong>Simulate before reality.</strong></p>
+  <p>
+    異質なシミュレート・ユーザーで AI システムとインタラクティブ製品を評価するための、
+    人口規模・ペルソナ駆動のインフラストラクチャ。
+  </p>
+  <p>
+    <a href="../../README.md">English</a> |
+    <a href="README.ko.md">한국어</a> |
+    <a href="README.zh-CN.md">简体中文</a> |
+    <a href="README.zh-TW.md">繁體中文</a> |
+    <strong>日本語</strong> |
+    <a href="README.pt-BR.md">Português</a> |
+    <a href="README.es.md">Español</a>
+  </p>
+  <p>
+    <a href="https://matraix.ai/"><img alt="Website" src="https://img.shields.io/badge/Website-matraix.ai-4f7cff?style=for-the-badge"></a>
+    <a href="https://discord.gg/knVyQQnRFa"><img alt="Discord" src="https://img.shields.io/badge/Discord-join%20MatrAIx-5865F2?style=for-the-badge&logo=discord&logoColor=white"></a>
+    <a href="https://x.com/MatrAIx2026"><img alt="X" src="https://img.shields.io/badge/X-%40MatrAIx2026-000000?style=for-the-badge&logo=x&logoColor=white"></a>
+    <a href="https://www.linkedin.com/company/matraix"><img alt="LinkedIn" src="https://img.shields.io/badge/LinkedIn-MatrAIx-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white"></a>
+    <a href="https://forms.gle/hwEHng5HGWRqcJue9"><img alt="Google Form" src="https://img.shields.io/badge/Google%20Form-join%20MatrAIx-4285F4?style=for-the-badge&logo=googleforms&logoColor=white"></a>
+    <a href="../README.md"><img alt="Docs" src="https://img.shields.io/badge/Docs-Handbook-5b5b5b?style=for-the-badge"></a>
+    <a href="https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release"><img alt="Hugging Face" src="https://img.shields.io/badge/Hugging%20Face-Persona%201M-ffcc4d?style=for-the-badge"></a>
+    <a href="../../LICENSE"><img alt="License" src="https://img.shields.io/badge/License-MIT-c33b32?style=for-the-badge"></a>
+    <a href="../quickstart.md#10-playground--play-tasks-visually"><img alt="Playground" src="https://img.shields.io/badge/Playground-Visual%20Runner-56b879?style=for-the-badge"></a>
+  </p>
+</div>
+
+<div align="center">
+  <a href="https://www.youtube.com/watch?v=cNFkz9Wo1y4&t=15s">
+    <img src="https://img.youtube.com/vi/cNFkz9Wo1y4/maxresdefault.jpg" alt="YouTube で MatrAIx デモを見る" width="900">
+  </a>
+  <p>
+    <a href="https://www.youtube.com/watch?v=cNFkz9Wo1y4&t=15s"><img alt="YouTube で MatrAIx デモを見る" src="https://img.shields.io/badge/%E2%96%B6%20Watch%20the%20demo-on%20YouTube-FF0000?style=for-the-badge&logo=youtube&logoColor=white"></a>
+  </p>
+</div>
+
+---
+
+**MatrAIx** は、異質なシミュレート・ユーザーで AI システムとインタラクティブ製品を
+評価するための、人口規模・ペルソナ駆動のインフラストラクチャです。汎用的・交換可能な
+ユーザーに対してテストするのではなく、サンプリングしたペルソナ記録を LLM エージェントとして
+インスタンス化し、4 つの環境 — **Survey**、**AI Chatbot**、**Web**、**App**
+（macOS / iOS を含むネイティブのデスクトップおよびモバイル）— で再現可能なタスクを実行します。
+
+基盤は、背景・心理・能力・行動を覆う **1,290 のカテゴリ次元** からなる共有スキーマです。
+ペルソナは依存関係を考慮した合成生成と、証拠に基づく人間 grounding を組み合わせます。
+決定的で品質フィルタされた **100 万ペルソナ** のコリセットが研究用に
+[Hugging Face](https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release)
+で公開されています。共有テレメトリ、タスク所有の検証、レポートにより、個々の応答と軌跡を
+サブグループおよび人口レベルの知見につなぎます。
+
+名前は *The Matrix* に由来します。探索・ストレステスト・仮説生成に有用なシミュレート世界であり、
+**実在の人々からの証拠の代替ではありません**。
+
+## 要件
+
+- [Docker](https://docs.docker.com/get-docker/)
+- [uv](https://docs.astral.sh/uv/) と Python 3.12
+- Node.js 20+（Playground / viewer フロントエンドのみ）
+- ペルソナエージェント例用のモデル API キー — [agents.md](../environment/agents.md) を参照
+
+## インストール
+
+```bash
+git clone <repo-url> && cd MatrAIx
+uv venv --python 3.12
+uv pip install -e .
+uv pip install pytest pytest-asyncio httpx
+uv pip install -e packages/playground
+uv pip install -e packages/harbor-langsmith
+uv pip install -e packages/rewardkit
+```
+
+Matraix Playground のコマンドはすべて **`uv run harbor …`** として実行します。
+
+GUI / CLI タスク実行の前に、プロバイダに合わせたモデル API キーを設定してください
+（smoke test には不要です）：
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."   # anthropic/claude-* モデル
+# export OPENAI_API_KEY="sk-..."        # openai/gpt-* モデル
+```
+
+キーの全体表は [agents.md](../environment/agents.md) を参照。
+Playground は `application/playground/.env.local` からもキーを読み込めます。
+
+### Persona 1M のインポート（任意）
+
+```bash
+huggingface-cli download MatrAIx2026/MatrAIx_Persona_1M_Public_Release \
+  --repo-type dataset \
+  --local-dir persona/datasets/matraix-persona-1m/release
+```
+
+Playground: Dataset → **`matraix-persona-1m`**。CLI: `--dataset persona/datasets/matraix-persona-1m`。
+詳細: [Handbook § Persona 1M](../README.md#3-persona-1m-optional)。
+
+## クイックスタート
+
+### Smoke test
+
+API キー不要。**Docker が必要**（smoke job は `environment.type: docker` を使用）：
+
+```bash
+uv run harbor run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml
+```
+
+### GUI でのタスク実行
+
+Playground はタスク選択・ペルソナサンプリングを行い、CLI auto モードと同じ
+Matraix Playground job を起動します。
+API + フロントエンドを起動（2 つのターミナル）：
+
+```bash
+# ターミナル A — API
+VENV=.venv bash application/playground/backend/run_dev.sh
+
+# ターミナル B — フロントエンド
+cd application/playground/frontend && npm ci && npm run dev
+```
+
+**http://localhost:5173** を開く → Playground → ペルソナ cohort を選択 →
+Survey / Chat / Web / OS app タスクを選択 → **Lock pipeline** → **Run eval**。
+詳細: [Playground §10](../quickstart.md#10-playground--play-tasks-visually)。
+
+### CLI でのタスク開発 / 実行
+
+**開発** — `application/tasks/` 配下の参照タスクをコピーし、
+`task.toml` / `instruction.md` / `input/` / verifier を編集して Playground に登録
+（[task-guide.md](../application/task-guide.md)）：
+
+```bash
+cp -R application/tasks/example-survey_product-feedback \
+  application/tasks/<your-task-name>
+```
+
+| 種類 | 参照タスク |
+|------|------------|
+| Survey | `application/tasks/example-survey_product-feedback` |
+| Chat | `application/tasks/example-chat-api_support_chatbot` |
+| Web | `application/tasks/example-web-playwright_quote-choice` |
+| OS-app | `application/tasks/example-computer-use-linux_note-to-csv` |
+
+**実行** — Matraix Playground job を生成（agent + model を固定）して実行：
+
+```bash
+uv run python application/scripts/generate_application_job.py \
+  --task application/tasks/example-survey_product-feedback \
+  --execution-mode auto \
+  --persona-ids 0042 \
+  --model-name anthropic/claude-sonnet-4-6
+
+# スクリプトが出力する export 行と recipe パスを使用、例：
+uv run harbor run -c configs/jobs/application-task-job-recipe/example-survey-product-feedback-auto-n1.yaml
+```
+
+バッチ（`--sample-size N`）、フィルタ、chat / web / os-app の例：
+[docs/quickstart.md](../quickstart.md)。
+
+## ドキュメント
+
+**[MatrAIx Handbook](../README.md)** — ガイド、および persona / application / environment のドキュメント。
+
+<p align="center">
+  <img src="../assets/matraix-architecture.png" alt="MatrAIx アーキテクチャ" width="900">
+</p>
+
+## リポジトリ構成
+
+```text
+MatrAIx/
+├── persona/                 スキーマ、データセット、合成/キュレーション/検証パイプライン
+│   ├── schema/              1,290 次元ペルソナスキーマ
+│   ├── datasets/            開発サンプルプールとペルソナ YAML
+│   ├── validation/          Grounding / 品質検証スイート
+│   └── scripts/             ペルソナ job・パイプラインヘルパー
+├── application/
+│   ├── tasks/               Survey · chat · web · os-app タスク仕様
+│   ├── task-spec/           共有タスク契約
+│   ├── playground/          ビジュアルランナー（バックエンド API + フロントエンド）
+│   └── scripts/             generate_application_job.py とタスクツール
+├── environment/
+│   ├── runtime/             Matraix Playground runtime
+│   ├── agents/              ペルソナ条件付きエージェント
+│   ├── task-environments/   Docker イメージ / sidecar
+│   └── adapters/            外部アダプタ（例: SimpleQA）
+├── packages/                playground · rewardkit · harbor-langsmith
+├── apps/viewer/             `harbor view` と対になるフロントエンド
+├── configs/jobs/            キュレート / 生成された Matraix Playground job recipe
+├── docs/                    Handbook — persona/ · application/ · environment/
+├── examples/                最小のサンプルタスク
+├── src/matraix/             Python パッケージのエントリポイント
+├── scripts/                 リポジトリレベルのヘルパー
+├── tests/                   ユニット / 環境テスト
+└── jobs/                    ローカル Matraix Playground 実行出力（gitignore）
+```
+
+大規模な生成データセットは git 外に置きます（上記 Hugging Face リリースを参照）。
+
+## コミュニティに参加
+
+[![Discord](https://img.shields.io/badge/Discord-join%20MatrAIx-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/knVyQQnRFa)
+[![X](https://img.shields.io/badge/X-follow%20%40MatrAIx2026-000000?style=for-the-badge&logo=x&logoColor=white)](https://x.com/MatrAIx2026)
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-follow%20MatrAIx-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/company/matraix)
+[![Google Form](https://img.shields.io/badge/Google%20Form-join%20MatrAIx-4285F4?style=for-the-badge&logo=googleforms&logoColor=white)](https://forms.gle/hwEHng5HGWRqcJue9)
+
+1. Discord に参加 — ニックネームは **`Full Name - Affiliation`**。Google Form に記入
+   （背景、興味、論文の著者 / 謝辞）。
+2. あいさつしてください！共通の関心や経験でつなぎたいです。
+3. MatrAIx 研究コミュニティに参加して、コラボや貢献を！
+
+## ライセンス
+
+MIT — [LICENSE](../../LICENSE) を参照。

--- a/docs/i18n/README.ko.md
+++ b/docs/i18n/README.ko.md
@@ -1,0 +1,216 @@
+<div align="center">
+  <h1>MatrAIx</h1>
+  <p><strong>Simulate before reality.</strong></p>
+  <p>
+    이질적인 시뮬레이션 사용자로 AI 시스템과 인터랙티브 제품을 평가하기 위한
+    인구 규모·페르소나 기반 인프라.
+  </p>
+  <p>
+    <a href="../../README.md">English</a> |
+    <strong>한국어</strong> |
+    <a href="README.zh-CN.md">简体中文</a> |
+    <a href="README.zh-TW.md">繁體中文</a> |
+    <a href="README.ja.md">日本語</a> |
+    <a href="README.pt-BR.md">Português</a> |
+    <a href="README.es.md">Español</a>
+  </p>
+  <p>
+    <a href="https://matraix.ai/"><img alt="Website" src="https://img.shields.io/badge/Website-matraix.ai-4f7cff?style=for-the-badge"></a>
+    <a href="https://discord.gg/knVyQQnRFa"><img alt="Discord" src="https://img.shields.io/badge/Discord-join%20MatrAIx-5865F2?style=for-the-badge&logo=discord&logoColor=white"></a>
+    <a href="https://x.com/MatrAIx2026"><img alt="X" src="https://img.shields.io/badge/X-%40MatrAIx2026-000000?style=for-the-badge&logo=x&logoColor=white"></a>
+    <a href="https://www.linkedin.com/company/matraix"><img alt="LinkedIn" src="https://img.shields.io/badge/LinkedIn-MatrAIx-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white"></a>
+    <a href="https://forms.gle/hwEHng5HGWRqcJue9"><img alt="Google Form" src="https://img.shields.io/badge/Google%20Form-join%20MatrAIx-4285F4?style=for-the-badge&logo=googleforms&logoColor=white"></a>
+    <a href="../README.md"><img alt="Docs" src="https://img.shields.io/badge/Docs-Handbook-5b5b5b?style=for-the-badge"></a>
+    <a href="https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release"><img alt="Hugging Face" src="https://img.shields.io/badge/Hugging%20Face-Persona%201M-ffcc4d?style=for-the-badge"></a>
+    <a href="../../LICENSE"><img alt="License" src="https://img.shields.io/badge/License-MIT-c33b32?style=for-the-badge"></a>
+    <a href="../quickstart.md#10-playground--play-tasks-visually"><img alt="Playground" src="https://img.shields.io/badge/Playground-Visual%20Runner-56b879?style=for-the-badge"></a>
+  </p>
+</div>
+
+<div align="center">
+  <a href="https://www.youtube.com/watch?v=cNFkz9Wo1y4&t=15s">
+    <img src="https://img.youtube.com/vi/cNFkz9Wo1y4/maxresdefault.jpg" alt="YouTube에서 MatrAIx 데모 보기" width="900">
+  </a>
+  <p>
+    <a href="https://www.youtube.com/watch?v=cNFkz9Wo1y4&t=15s"><img alt="YouTube에서 MatrAIx 데모 보기" src="https://img.shields.io/badge/%E2%96%B6%20Watch%20the%20demo-on%20YouTube-FF0000?style=for-the-badge&logo=youtube&logoColor=white"></a>
+  </p>
+</div>
+
+---
+
+**MatrAIx**는 이질적인 시뮬레이션 사용자로 AI 시스템과 인터랙티브 제품을 평가하기 위한
+인구 규모·페르소나 기반 인프라입니다. 범용적이거나 서로 대체 가능한 사용자를 상대로
+테스트하는 대신, 샘플링된 페르소나 레코드를 LLM 에이전트로 인스턴스화하고 네 가지 환경 —
+**Survey**, **AI Chatbot**, **Web**, **App**(macOS·iOS를 포함한 네이티브 데스크톱·모바일) —
+에서 재현 가능한 태스크로 실행합니다.
+
+기반은 배경·심리·역량·행동을 아우르는 **1,290개의 범주형 차원** 공유 스키마입니다.
+페르소나는 의존성을 고려한 합성 생성과 증거 기반의 인간 grounding을 결합합니다.
+결정적이며 품질 필터링된 **백만 페르소나** 코어셋이 연구용으로
+[Hugging Face](https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release)
+에 공개되어 있습니다. 공유 텔레메트리, 태스크 소유 검증, 리포팅이 개별 응답·궤적을
+하위 집단 및 인구 수준의 발견으로 연결합니다.
+
+이름은 *The Matrix*를 가리킵니다. 탐색·스트레스 테스트·가설 생성에 유용한 시뮬레이션
+세계이며, **실제 사람으로부터의 증거를 대체하지 않습니다**.
+
+## 요구 사항
+
+- [Docker](https://docs.docker.com/get-docker/)
+- [uv](https://docs.astral.sh/uv/) 및 Python 3.12
+- Node.js 20+ (Playground / viewer 프론트엔드만)
+- 페르소나 에이전트 예제용 모델 API 키 — [agents.md](../environment/agents.md) 참고
+
+## 설치
+
+```bash
+git clone <repo-url> && cd MatrAIx
+uv venv --python 3.12
+uv pip install -e .
+uv pip install pytest pytest-asyncio httpx
+uv pip install -e packages/playground
+uv pip install -e packages/harbor-langsmith
+uv pip install -e packages/rewardkit
+```
+
+모든 Matraix Playground 명령은 **`uv run harbor …`** 형태로 실행합니다.
+
+GUI 또는 CLI 태스크 실행 전에 사용 중인 제공자에 맞는 모델 API 키를 설정하세요
+(smoke test에는 필요 없음):
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."   # anthropic/claude-* 모델
+# export OPENAI_API_KEY="sk-..."        # openai/gpt-* 모델
+```
+
+전체 키 매트릭스는 [agents.md](../environment/agents.md)를 참고하세요.
+Playground는 `application/playground/.env.local`에서도 키를 로드할 수 있습니다.
+
+### Persona 1M 가져오기 (선택)
+
+```bash
+huggingface-cli download MatrAIx2026/MatrAIx_Persona_1M_Public_Release \
+  --repo-type dataset \
+  --local-dir persona/datasets/matraix-persona-1m/release
+```
+
+Playground: Dataset → **`matraix-persona-1m`**. CLI: `--dataset persona/datasets/matraix-persona-1m`.
+자세한 내용: [Handbook § Persona 1M](../README.md#3-persona-1m-optional).
+
+## 빠른 시작
+
+### Smoke test
+
+API 키 불필요. **Docker 필요**(smoke job은 `environment.type: docker` 사용):
+
+```bash
+uv run harbor run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml
+```
+
+### GUI 태스크 실행
+
+Playground는 태스크를 고르고 페르소나를 샘플링한 뒤, CLI auto 모드와 동일한
+Matraix Playground job을 실행합니다.
+API + 프론트엔드 시작(터미널 두 개):
+
+```bash
+# 터미널 A — API
+VENV=.venv bash application/playground/backend/run_dev.sh
+
+# 터미널 B — 프론트엔드
+cd application/playground/frontend && npm ci && npm run dev
+```
+
+**http://localhost:5173** 열기 → Playground → 페르소나 cohort 선택 →
+Survey / Chat / Web / OS app 태스크 선택 → **Lock pipeline** → **Run eval**.
+자세한 내용: [Playground §10](../quickstart.md#10-playground--play-tasks-visually).
+
+### CLI 태스크 개발 / 실행
+
+**개발** — `application/tasks/` 아래 참고 태스크를 복사한 뒤
+`task.toml` / `instruction.md` / `input/` / verifier를 편집하고 Playground에 등록
+([task-guide.md](../application/task-guide.md)):
+
+```bash
+cp -R application/tasks/example-survey_product-feedback \
+  application/tasks/<your-task-name>
+```
+
+| 유형 | 참고 태스크 |
+|------|-------------|
+| Survey | `application/tasks/example-survey_product-feedback` |
+| Chat | `application/tasks/example-chat-api_support_chatbot` |
+| Web | `application/tasks/example-web-playwright_quote-choice` |
+| OS-app | `application/tasks/example-computer-use-linux_note-to-csv` |
+
+**실행** — Matraix Playground job을 생성(agent + model 고정)한 뒤 실행:
+
+```bash
+uv run python application/scripts/generate_application_job.py \
+  --task application/tasks/example-survey_product-feedback \
+  --execution-mode auto \
+  --persona-ids 0042 \
+  --model-name anthropic/claude-sonnet-4-6
+
+# 스크립트가 출력하는 export 줄과 recipe 경로를 사용, 예:
+uv run harbor run -c configs/jobs/application-task-job-recipe/example-survey-product-feedback-auto-n1.yaml
+```
+
+배치(`--sample-size N`), 필터, chat / web / os-app 예제:
+[docs/quickstart.md](../quickstart.md).
+
+## 문서
+
+**[MatrAIx Handbook](../README.md)** — 가이드 및 persona / application / environment 문서.
+
+<p align="center">
+  <img src="../assets/matraix-architecture.png" alt="MatrAIx 아키텍처" width="900">
+</p>
+
+## 저장소 구조
+
+```text
+MatrAIx/
+├── persona/                 스키마, 데이터셋, 합성/큐레이션/검증 파이프라인
+│   ├── schema/              1,290차원 페르소나 스키마
+│   ├── datasets/            개발 샘플 풀 및 페르소나 YAML
+│   ├── validation/          Grounding / 품질 검증 스위트
+│   └── scripts/             페르소나 job·파이프라인 헬퍼
+├── application/
+│   ├── tasks/               Survey · chat · web · os-app 태스크 스펙
+│   ├── task-spec/           공유 태스크 계약
+│   ├── playground/          비주얼 러너(백엔드 API + 프론트엔드)
+│   └── scripts/             generate_application_job.py 및 태스크 도구
+├── environment/
+│   ├── runtime/             Matraix Playground runtime
+│   ├── agents/              페르소나 조건 에이전트
+│   ├── task-environments/   Docker 이미지 / sidecar
+│   └── adapters/            외부 어댑터(예: SimpleQA)
+├── packages/                playground · rewardkit · harbor-langsmith
+├── apps/viewer/             `harbor view`와 짝을 이루는 프론트엔드
+├── configs/jobs/            큐레이션·생성된 Matraix Playground job recipe
+├── docs/                    Handbook — persona/ · application/ · environment/
+├── examples/                최소 예제 태스크
+├── src/matraix/             Python 패키지 엔트리포인트
+├── scripts/                 저장소 수준 헬퍼
+├── tests/                   유닛 / 환경 테스트
+└── jobs/                    로컬 Matraix Playground 실행 출력(gitignore)
+```
+
+대용량 생성 데이터셋은 git 밖에 둡니다(위 Hugging Face 릴리스 참고).
+
+## 커뮤니티 참여
+
+[![Discord](https://img.shields.io/badge/Discord-join%20MatrAIx-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/knVyQQnRFa)
+[![X](https://img.shields.io/badge/X-follow%20%40MatrAIx2026-000000?style=for-the-badge&logo=x&logoColor=white)](https://x.com/MatrAIx2026)
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-follow%20MatrAIx-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/company/matraix)
+[![Google Form](https://img.shields.io/badge/Google%20Form-join%20MatrAIx-4285F4?style=for-the-badge&logo=googleforms&logoColor=white)](https://forms.gle/hwEHng5HGWRqcJue9)
+
+1. Discord 가입 — 닉네임 **`Full Name - Affiliation`**. Google Form 작성
+   (배경, 관심사, 논문 저자 / 사사).
+2. 인사해 주세요! 공통 관심사나 경험으로 연결하고 싶습니다.
+3. MatrAIx 연구 커뮤니티에 참여해 협업하거나 기여하세요!
+
+## 라이선스
+
+MIT — [LICENSE](../../LICENSE) 참고.

--- a/docs/i18n/README.pt-BR.md
+++ b/docs/i18n/README.pt-BR.md
@@ -1,0 +1,221 @@
+<div align="center">
+  <h1>MatrAIx</h1>
+  <p><strong>Simulate before reality.</strong></p>
+  <p>
+    Infraestrutura em escala populacional e orientada a personas para avaliar
+    sistemas de IA e produtos interativos com usuários simulados heterogêneos.
+  </p>
+  <p>
+    <a href="../../README.md">English</a> |
+    <a href="README.ko.md">한국어</a> |
+    <a href="README.zh-CN.md">简体中文</a> |
+    <a href="README.zh-TW.md">繁體中文</a> |
+    <a href="README.ja.md">日本語</a> |
+    <strong>Português</strong> |
+    <a href="README.es.md">Español</a>
+  </p>
+  <p>
+    <a href="https://matraix.ai/"><img alt="Website" src="https://img.shields.io/badge/Website-matraix.ai-4f7cff?style=for-the-badge"></a>
+    <a href="https://discord.gg/knVyQQnRFa"><img alt="Discord" src="https://img.shields.io/badge/Discord-join%20MatrAIx-5865F2?style=for-the-badge&logo=discord&logoColor=white"></a>
+    <a href="https://x.com/MatrAIx2026"><img alt="X" src="https://img.shields.io/badge/X-%40MatrAIx2026-000000?style=for-the-badge&logo=x&logoColor=white"></a>
+    <a href="https://www.linkedin.com/company/matraix"><img alt="LinkedIn" src="https://img.shields.io/badge/LinkedIn-MatrAIx-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white"></a>
+    <a href="https://forms.gle/hwEHng5HGWRqcJue9"><img alt="Google Form" src="https://img.shields.io/badge/Google%20Form-join%20MatrAIx-4285F4?style=for-the-badge&logo=googleforms&logoColor=white"></a>
+    <a href="../README.md"><img alt="Docs" src="https://img.shields.io/badge/Docs-Handbook-5b5b5b?style=for-the-badge"></a>
+    <a href="https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release"><img alt="Hugging Face" src="https://img.shields.io/badge/Hugging%20Face-Persona%201M-ffcc4d?style=for-the-badge"></a>
+    <a href="../../LICENSE"><img alt="License" src="https://img.shields.io/badge/License-MIT-c33b32?style=for-the-badge"></a>
+    <a href="../quickstart.md#10-playground--play-tasks-visually"><img alt="Playground" src="https://img.shields.io/badge/Playground-Visual%20Runner-56b879?style=for-the-badge"></a>
+  </p>
+</div>
+
+<div align="center">
+  <a href="https://www.youtube.com/watch?v=cNFkz9Wo1y4&t=15s">
+    <img src="https://img.youtube.com/vi/cNFkz9Wo1y4/maxresdefault.jpg" alt="Assista à demo do MatrAIx no YouTube" width="900">
+  </a>
+  <p>
+    <a href="https://www.youtube.com/watch?v=cNFkz9Wo1y4&t=15s"><img alt="Assista à demo do MatrAIx no YouTube" src="https://img.shields.io/badge/%E2%96%B6%20Watch%20the%20demo-on%20YouTube-FF0000?style=for-the-badge&logo=youtube&logoColor=white"></a>
+  </p>
+</div>
+
+---
+
+**MatrAIx** é uma infraestrutura em escala populacional e orientada a personas
+para avaliar sistemas de IA e produtos interativos com usuários simulados
+heterogêneos. Em vez de testar contra um usuário genérico ou intercambiável, o
+MatrAIx instancia registros de persona amostrados como agentes LLM e os executa
+em tarefas reproduzíveis em quatro ambientes — **Survey**, **AI Chatbot**,
+**Web** e **App** (desktop e mobile nativos, incluindo macOS e iOS).
+
+Na base há um schema compartilhado de **1.290 dimensões categóricas** que
+cobrem background, psicologia, capacidade e comportamento. As personas combinam
+geração sintética sensível a dependências com grounding humano baseado em
+evidências; um coreset determinístico e filtrado por qualidade de **um milhão de
+personas** é publicado para pesquisa no
+[Hugging Face](https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release).
+Telemetria compartilhada, verificação pertencente à tarefa e relatórios conectam
+respostas e trajetórias individuais a achados em nível de subgrupo e população.
+
+O nome remete a *The Matrix*: um mundo simulado útil para exploração, testes de
+estresse e geração de hipóteses — **não um substituto para evidências de pessoas
+reais**.
+
+## Requisitos
+
+- [Docker](https://docs.docker.com/get-docker/)
+- [uv](https://docs.astral.sh/uv/) e Python 3.12
+- Node.js 20+ (apenas frontends do Playground / viewer)
+- Chaves de API de modelo para exemplos de agentes de persona — veja [agents.md](../environment/agents.md)
+
+## Instalação
+
+```bash
+git clone <repo-url> && cd MatrAIx
+uv venv --python 3.12
+uv pip install -e .
+uv pip install pytest pytest-asyncio httpx
+uv pip install -e packages/playground
+uv pip install -e packages/harbor-langsmith
+uv pip install -e packages/rewardkit
+```
+
+Todos os comandos do Matraix Playground rodam como **`uv run harbor …`**.
+
+Defina a chave de API do modelo correspondente ao seu provedor antes de executar
+tarefas via GUI ou CLI (o smoke test não precisa de chave):
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."   # modelos anthropic/claude-*
+# export OPENAI_API_KEY="sk-..."        # modelos openai/gpt-*
+```
+
+Veja a matriz completa de chaves em [agents.md](../environment/agents.md).
+O Playground também pode carregar chaves de `application/playground/.env.local`.
+
+### Importar Persona 1M (opcional)
+
+```bash
+huggingface-cli download MatrAIx2026/MatrAIx_Persona_1M_Public_Release \
+  --repo-type dataset \
+  --local-dir persona/datasets/matraix-persona-1m/release
+```
+
+Playground: Dataset → **`matraix-persona-1m`**. CLI: `--dataset persona/datasets/matraix-persona-1m`.
+Detalhes: [Handbook § Persona 1M](../README.md#3-persona-1m-optional).
+
+## Início rápido
+
+### Smoke test
+
+Nenhuma chave de API necessária. **Requer Docker** (o smoke job usa
+`environment.type: docker`):
+
+```bash
+uv run harbor run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml
+```
+
+### Execuções de tarefa via GUI
+
+O Playground escolhe tarefas, amostra personas e lança os mesmos jobs do
+Matraix Playground que o modo auto da CLI.
+Inicie API + frontend (dois terminais):
+
+```bash
+# Terminal A — API
+VENV=.venv bash application/playground/backend/run_dev.sh
+
+# Terminal B — frontend
+cd application/playground/frontend && npm ci && npm run dev
+```
+
+Abra **http://localhost:5173** → Playground → escolha uma cohort de personas →
+escolha tarefas Survey / Chat / Web / OS app → **Lock pipeline** → **Run eval**.
+Detalhes: [Playground §10](../quickstart.md#10-playground--play-tasks-visually).
+
+### Desenvolvimento / execução via CLI
+
+**Desenvolver** — copie uma tarefa de referência em `application/tasks/`, edite
+`task.toml` / `instruction.md` / `input/` / verifier e registre-a no Playground
+([task-guide.md](../application/task-guide.md)):
+
+```bash
+cp -R application/tasks/example-survey_product-feedback \
+  application/tasks/<your-task-name>
+```
+
+| Tipo | Tarefa de referência |
+|------|----------------------|
+| Survey | `application/tasks/example-survey_product-feedback` |
+| Chat | `application/tasks/example-chat-api_support_chatbot` |
+| Web | `application/tasks/example-web-playwright_quote-choice` |
+| OS-app | `application/tasks/example-computer-use-linux_note-to-csv` |
+
+**Executar** — gere um job do Matraix Playground (fixa agent + model) e execute-o:
+
+```bash
+uv run python application/scripts/generate_application_job.py \
+  --task application/tasks/example-survey_product-feedback \
+  --execution-mode auto \
+  --persona-ids 0042 \
+  --model-name anthropic/claude-sonnet-4-6
+
+# Use as linhas de export + o caminho do recipe impressos pelo script, p.ex.:
+uv run harbor run -c configs/jobs/application-task-job-recipe/example-survey-product-feedback-auto-n1.yaml
+```
+
+Lote (`--sample-size N`), filtros e exemplos chat / web / os-app:
+[docs/quickstart.md](../quickstart.md).
+
+## Docs
+
+**[MatrAIx Handbook](../README.md)** — guias e docs de persona / application / environment.
+
+<p align="center">
+  <img src="../assets/matraix-architecture.png" alt="Arquitetura MatrAIx" width="900">
+</p>
+
+## Estrutura do repositório
+
+```text
+MatrAIx/
+├── persona/                 Schema, datasets, pipelines de síntese/curadoria/validação
+│   ├── schema/              Schema de persona com 1.290 dimensões
+│   ├── datasets/            Pool de amostras de dev e YAMLs de persona
+│   ├── validation/          Suites de grounding / validação de qualidade
+│   └── scripts/             Helpers de job e pipeline de persona
+├── application/
+│   ├── tasks/               Specs de tarefas Survey · chat · web · os-app
+│   ├── task-spec/           Contratos compartilhados de tarefa
+│   ├── playground/          Runner visual (API backend + frontend)
+│   └── scripts/             generate_application_job.py e tooling de tarefas
+├── environment/
+│   ├── runtime/             Runtime do Matraix Playground
+│   ├── agents/              Agentes condicionados a persona
+│   ├── task-environments/   Imagens Docker / sidecars
+│   └── adapters/            Adaptadores externos (ex.: SimpleQA)
+├── packages/                playground · rewardkit · harbor-langsmith
+├── apps/viewer/             Frontend pareado com `harbor view`
+├── configs/jobs/            Recipes de job do Matraix Playground (curados e gerados)
+├── docs/                    Handbook — persona/ · application/ · environment/
+├── examples/                Tarefas de exemplo mínimas
+├── src/matraix/             Entry points do pacote Python
+├── scripts/                 Helpers no nível do repositório
+├── tests/                   Testes unitários / de ambiente
+└── jobs/                    Saídas locais do Matraix Playground (gitignored)
+```
+
+Datasets grandes gerados ficam fora do git (veja o release no Hugging Face acima).
+
+## Participe da comunidade
+
+[![Discord](https://img.shields.io/badge/Discord-join%20MatrAIx-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/knVyQQnRFa)
+[![X](https://img.shields.io/badge/X-follow%20%40MatrAIx2026-000000?style=for-the-badge&logo=x&logoColor=white)](https://x.com/MatrAIx2026)
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-follow%20MatrAIx-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/company/matraix)
+[![Google Form](https://img.shields.io/badge/Google%20Form-join%20MatrAIx-4285F4?style=for-the-badge&logo=googleforms&logoColor=white)](https://forms.gle/hwEHng5HGWRqcJue9)
+
+1. Entre no Discord — nickname **`Full Name - Affiliation`**. Preencha o Google Form
+   (background, interesses, autoria / agradecimentos em papers).
+2. Diga oi! Gostamos de conectar pessoas com interesses ou experiências em comum!
+3. Participe da comunidade de pesquisa MatrAIx para colaboração ou contribuição!
+
+## Licença
+
+MIT — veja [LICENSE](../../LICENSE).

--- a/docs/i18n/README.zh-CN.md
+++ b/docs/i18n/README.zh-CN.md
@@ -1,0 +1,205 @@
+<div align="center">
+  <h1>MatrAIx</h1>
+  <p><strong>Simulate before reality.</strong></p>
+  <p>
+    面向异构模拟用户的大规模、人格驱动基础设施，用于评估 AI 系统与交互式产品。
+  </p>
+  <p>
+    <a href="../../README.md">English</a> |
+    <a href="README.ko.md">한국어</a> |
+    <strong>简体中文</strong> |
+    <a href="README.zh-TW.md">繁體中文</a> |
+    <a href="README.ja.md">日本語</a> |
+    <a href="README.pt-BR.md">Português</a> |
+    <a href="README.es.md">Español</a>
+  </p>
+  <p>
+    <a href="https://matraix.ai/"><img alt="Website" src="https://img.shields.io/badge/Website-matraix.ai-4f7cff?style=for-the-badge"></a>
+    <a href="https://discord.gg/knVyQQnRFa"><img alt="Discord" src="https://img.shields.io/badge/Discord-join%20MatrAIx-5865F2?style=for-the-badge&logo=discord&logoColor=white"></a>
+    <a href="https://x.com/MatrAIx2026"><img alt="X" src="https://img.shields.io/badge/X-%40MatrAIx2026-000000?style=for-the-badge&logo=x&logoColor=white"></a>
+    <a href="https://www.linkedin.com/company/matraix"><img alt="LinkedIn" src="https://img.shields.io/badge/LinkedIn-MatrAIx-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white"></a>
+    <a href="https://forms.gle/hwEHng5HGWRqcJue9"><img alt="Google Form" src="https://img.shields.io/badge/Google%20Form-join%20MatrAIx-4285F4?style=for-the-badge&logo=googleforms&logoColor=white"></a>
+    <a href="../README.md"><img alt="Docs" src="https://img.shields.io/badge/Docs-Handbook-5b5b5b?style=for-the-badge"></a>
+    <a href="https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release"><img alt="Hugging Face" src="https://img.shields.io/badge/Hugging%20Face-Persona%201M-ffcc4d?style=for-the-badge"></a>
+    <a href="../../LICENSE"><img alt="License" src="https://img.shields.io/badge/License-MIT-c33b32?style=for-the-badge"></a>
+    <a href="../quickstart.md#10-playground--play-tasks-visually"><img alt="Playground" src="https://img.shields.io/badge/Playground-Visual%20Runner-56b879?style=for-the-badge"></a>
+  </p>
+</div>
+
+<div align="center">
+  <a href="https://www.youtube.com/watch?v=cNFkz9Wo1y4&t=15s">
+    <img src="https://img.youtube.com/vi/cNFkz9Wo1y4/maxresdefault.jpg" alt="在 YouTube 上观看 MatrAIx 演示" width="900">
+  </a>
+  <p>
+    <a href="https://www.youtube.com/watch?v=cNFkz9Wo1y4&t=15s"><img alt="在 YouTube 上观看 MatrAIx 演示" src="https://img.shields.io/badge/%E2%96%B6%20Watch%20the%20demo-on%20YouTube-FF0000?style=for-the-badge&logo=youtube&logoColor=white"></a>
+  </p>
+</div>
+
+---
+
+**MatrAIx** 是一套面向异构模拟用户的大规模、人格驱动基础设施，用于评估 AI 系统与交互式产品。它不依赖「通用」或可互换的用户假设，而是将抽样得到的人格记录实例化为 LLM Agent，并在四类环境中以可复现任务驱动运行 —— **Survey（问卷）**、**AI Chatbot（对话）**、**Web**，以及 **App**（原生桌面与移动端，含 macOS 与 iOS）。
+
+其基础是一套共享的 **1,290 个类别维度** 人格 Schema，覆盖背景、心理、能力与行为。人格结合依赖感知的合成生成与证据感知的人类 grounding；经确定性、质量过滤的 **百万人格** 共集（coreset）已在
+[Hugging Face](https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release)
+公开发布，供研究使用。共享遥测、任务自有验证与报告能力，将个体响应与轨迹连接到子群体与总体层面的发现。
+
+名称致敬 *The Matrix*：这是一个便于探索、压力测试与假设生成的模拟世界，**不能替代来自真实人群的证据**。
+
+## 环境要求
+
+- [Docker](https://docs.docker.com/get-docker/)
+- [uv](https://docs.astral.sh/uv/) 与 Python 3.12
+- Node.js 20+（仅 Playground / viewer 前端需要）
+- 人格 Agent 示例所需的模型 API Key —— 见 [agents.md](../environment/agents.md)
+
+## 安装
+
+```bash
+git clone <repo-url> && cd MatrAIx
+uv venv --python 3.12
+uv pip install -e .
+uv pip install pytest pytest-asyncio httpx
+uv pip install -e packages/playground
+uv pip install -e packages/harbor-langsmith
+uv pip install -e packages/rewardkit
+```
+
+所有 Matraix Playground 命令以 **`uv run harbor …`** 形式运行。
+
+在 GUI 或 CLI 任务运行前，设置与你的提供商匹配的模型 API Key（smoke test 不需要）：
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."   # anthropic/claude-* 模型
+# export OPENAI_API_KEY="sk-..."        # openai/gpt-* 模型
+```
+
+完整 Key 对照见 [agents.md](../environment/agents.md)。
+Playground 也可从 `application/playground/.env.local` 加载 Key。
+
+### 导入 Persona 1M（可选）
+
+```bash
+huggingface-cli download MatrAIx2026/MatrAIx_Persona_1M_Public_Release \
+  --repo-type dataset \
+  --local-dir persona/datasets/matraix-persona-1m/release
+```
+
+Playground：Dataset → **`matraix-persona-1m`**。CLI：`--dataset persona/datasets/matraix-persona-1m`。
+详情：[Handbook § Persona 1M](../README.md#3-persona-1m-optional)。
+
+## 快速开始
+
+### Smoke test
+
+无需 API Key。**需要 Docker**（smoke job 使用 `environment.type: docker`）：
+
+```bash
+uv run harbor run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml
+```
+
+### GUI 任务运行
+
+Playground 可选择任务、抽样人格，并启动与 CLI auto 模式相同的 Matraix Playground job。
+启动 API + 前端（两个终端）：
+
+```bash
+# 终端 A — API
+VENV=.venv bash application/playground/backend/run_dev.sh
+
+# 终端 B — 前端
+cd application/playground/frontend && npm ci && npm run dev
+```
+
+打开 **http://localhost:5173** → Playground → 选择人格 cohort →
+选择 Survey / Chat / Web / OS app 任务 → **Lock pipeline** → **Run eval**。
+详情：[Playground §10](../quickstart.md#10-playground--play-tasks-visually)。
+
+### CLI 任务开发 / 运行
+
+**开发** — 复制 `application/tasks/` 下的参考任务，编辑
+`task.toml` / `instruction.md` / `input/` / verifier，再注册到 Playground
+（[task-guide.md](../application/task-guide.md)）：
+
+```bash
+cp -R application/tasks/example-survey_product-feedback \
+  application/tasks/<your-task-name>
+```
+
+| 类型 | 参考任务 |
+|------|----------|
+| Survey | `application/tasks/example-survey_product-feedback` |
+| Chat | `application/tasks/example-chat-api_support_chatbot` |
+| Web | `application/tasks/example-web-playwright_quote-choice` |
+| OS-app | `application/tasks/example-computer-use-linux_note-to-csv` |
+
+**运行** — 生成 Matraix Playground job（固定 agent + model），再执行：
+
+```bash
+uv run python application/scripts/generate_application_job.py \
+  --task application/tasks/example-survey_product-feedback \
+  --execution-mode auto \
+  --persona-ids 0042 \
+  --model-name anthropic/claude-sonnet-4-6
+
+# 使用脚本打印的 export 行与 recipe 路径，例如：
+uv run harbor run -c configs/jobs/application-task-job-recipe/example-survey-product-feedback-auto-n1.yaml
+```
+
+批量（`--sample-size N`）、过滤条件，以及 chat / web / os-app 示例见：
+[docs/quickstart.md](../quickstart.md)。
+
+## 文档
+
+**[MatrAIx Handbook](../README.md)** — 指南，以及 persona / application / environment 文档。
+
+<p align="center">
+  <img src="../assets/matraix-architecture.png" alt="MatrAIx 架构" width="900">
+</p>
+
+## 仓库结构
+
+```text
+MatrAIx/
+├── persona/                 Schema、数据集、合成/策展/验证流水线
+│   ├── schema/              1,290 维人格 Schema
+│   ├── datasets/            开发样本池与人格 YAML
+│   ├── validation/          Grounding / 质量验证套件
+│   └── scripts/             人格 job 与流水线辅助脚本
+├── application/
+│   ├── tasks/               Survey · chat · web · os-app 任务规格
+│   ├── task-spec/           共享任务契约
+│   ├── playground/          可视化运行器（后端 API + 前端）
+│   └── scripts/             generate_application_job.py 与任务工具
+├── environment/
+│   ├── runtime/             Matraix Playground runtime
+│   ├── agents/              人格条件化 Agent
+│   ├── task-environments/   Docker 镜像 / sidecar
+│   └── adapters/            外部适配器（如 SimpleQA）
+├── packages/                playground · rewardkit · harbor-langsmith
+├── apps/viewer/             与 `harbor view` 配对的前端
+├── configs/jobs/            策展与生成的 Matraix Playground job recipe
+├── docs/                    Handbook — persona/ · application/ · environment/
+├── examples/                最小示例任务
+├── src/matraix/             Python 包入口
+├── scripts/                 仓库级辅助脚本
+├── tests/                   单元 / 环境测试
+└── jobs/                    本地 Matraix Playground 运行输出（gitignore）
+```
+
+大型生成数据集不纳入 git（见上方 Hugging Face 发布）。
+
+## 加入社区
+
+[![Discord](https://img.shields.io/badge/Discord-join%20MatrAIx-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/knVyQQnRFa)
+[![X](https://img.shields.io/badge/X-follow%20%40MatrAIx2026-000000?style=for-the-badge&logo=x&logoColor=white)](https://x.com/MatrAIx2026)
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-follow%20MatrAIx-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/company/matraix)
+[![Google Form](https://img.shields.io/badge/Google%20Form-join%20MatrAIx-4285F4?style=for-the-badge&logo=googleforms&logoColor=white)](https://forms.gle/hwEHng5HGWRqcJue9)
+
+1. 加入 Discord —— 昵称格式 **`Full Name - Affiliation`**。填写 Google Form
+   （背景、兴趣、论文署名 / 致谢意向）。
+2. 来打个招呼！我们很乐意按共同兴趣或经历帮你对接。
+3. 参与 MatrAIx 研究社区，一起协作或贡献！
+
+## 许可证
+
+MIT —— 见 [LICENSE](../../LICENSE)。

--- a/docs/i18n/README.zh-TW.md
+++ b/docs/i18n/README.zh-TW.md
@@ -1,0 +1,205 @@
+<div align="center">
+  <h1>MatrAIx</h1>
+  <p><strong>Simulate before reality.</strong></p>
+  <p>
+    面向異構模擬使用者的大規模、人格驅動基礎設施，用於評估 AI 系統與互動式產品。
+  </p>
+  <p>
+    <a href="../../README.md">English</a> |
+    <a href="README.ko.md">한국어</a> |
+    <a href="README.zh-CN.md">简体中文</a> |
+    <strong>繁體中文</strong> |
+    <a href="README.ja.md">日本語</a> |
+    <a href="README.pt-BR.md">Português</a> |
+    <a href="README.es.md">Español</a>
+  </p>
+  <p>
+    <a href="https://matraix.ai/"><img alt="Website" src="https://img.shields.io/badge/Website-matraix.ai-4f7cff?style=for-the-badge"></a>
+    <a href="https://discord.gg/knVyQQnRFa"><img alt="Discord" src="https://img.shields.io/badge/Discord-join%20MatrAIx-5865F2?style=for-the-badge&logo=discord&logoColor=white"></a>
+    <a href="https://x.com/MatrAIx2026"><img alt="X" src="https://img.shields.io/badge/X-%40MatrAIx2026-000000?style=for-the-badge&logo=x&logoColor=white"></a>
+    <a href="https://www.linkedin.com/company/matraix"><img alt="LinkedIn" src="https://img.shields.io/badge/LinkedIn-MatrAIx-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white"></a>
+    <a href="https://forms.gle/hwEHng5HGWRqcJue9"><img alt="Google Form" src="https://img.shields.io/badge/Google%20Form-join%20MatrAIx-4285F4?style=for-the-badge&logo=googleforms&logoColor=white"></a>
+    <a href="../README.md"><img alt="Docs" src="https://img.shields.io/badge/Docs-Handbook-5b5b5b?style=for-the-badge"></a>
+    <a href="https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release"><img alt="Hugging Face" src="https://img.shields.io/badge/Hugging%20Face-Persona%201M-ffcc4d?style=for-the-badge"></a>
+    <a href="../../LICENSE"><img alt="License" src="https://img.shields.io/badge/License-MIT-c33b32?style=for-the-badge"></a>
+    <a href="../quickstart.md#10-playground--play-tasks-visually"><img alt="Playground" src="https://img.shields.io/badge/Playground-Visual%20Runner-56b879?style=for-the-badge"></a>
+  </p>
+</div>
+
+<div align="center">
+  <a href="https://www.youtube.com/watch?v=cNFkz9Wo1y4&t=15s">
+    <img src="https://img.youtube.com/vi/cNFkz9Wo1y4/maxresdefault.jpg" alt="在 YouTube 上觀看 MatrAIx 示範" width="900">
+  </a>
+  <p>
+    <a href="https://www.youtube.com/watch?v=cNFkz9Wo1y4&t=15s"><img alt="在 YouTube 上觀看 MatrAIx 示範" src="https://img.shields.io/badge/%E2%96%B6%20Watch%20the%20demo-on%20YouTube-FF0000?style=for-the-badge&logo=youtube&logoColor=white"></a>
+  </p>
+</div>
+
+---
+
+**MatrAIx** 是一套面向異構模擬使用者的大規模、人格驅動基礎設施，用於評估 AI 系統與互動式產品。它不依賴「通用」或可互換的使用者假設，而是將抽樣得到的人格記錄實例化為 LLM Agent，並在四類環境中以可重現任務驅動執行 —— **Survey（問卷）**、**AI Chatbot（對話）**、**Web**，以及 **App**（原生桌面與行動裝置，含 macOS 與 iOS）。
+
+其基礎是一套共用的 **1,290 個類別維度** 人格 Schema，涵蓋背景、心理、能力與行為。人格結合依賴感知的合成生成與證據感知的人類 grounding；經確定性、品質過濾的 **百萬人格** 共集（coreset）已在
+[Hugging Face](https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release)
+公開發布，供研究使用。共用遙測、任務自有驗證與報告能力，將個體回應與軌跡連接到子群體與總體層面的發現。
+
+名稱致敬 *The Matrix*：這是一個便於探索、壓力測試與假設生成的模擬世界，**不能取代來自真實人群的證據**。
+
+## 環境需求
+
+- [Docker](https://docs.docker.com/get-docker/)
+- [uv](https://docs.astral.sh/uv/) 與 Python 3.12
+- Node.js 20+（僅 Playground / viewer 前端需要）
+- 人格 Agent 範例所需的模型 API Key —— 見 [agents.md](../environment/agents.md)
+
+## 安裝
+
+```bash
+git clone <repo-url> && cd MatrAIx
+uv venv --python 3.12
+uv pip install -e .
+uv pip install pytest pytest-asyncio httpx
+uv pip install -e packages/playground
+uv pip install -e packages/harbor-langsmith
+uv pip install -e packages/rewardkit
+```
+
+所有 Matraix Playground 指令以 **`uv run harbor …`** 形式執行。
+
+在 GUI 或 CLI 任務執行前，設定與你的提供者相符的模型 API Key（smoke test 不需要）：
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."   # anthropic/claude-* 模型
+# export OPENAI_API_KEY="sk-..."        # openai/gpt-* 模型
+```
+
+完整 Key 對照見 [agents.md](../environment/agents.md)。
+Playground 也可從 `application/playground/.env.local` 載入 Key。
+
+### 匯入 Persona 1M（可選）
+
+```bash
+huggingface-cli download MatrAIx2026/MatrAIx_Persona_1M_Public_Release \
+  --repo-type dataset \
+  --local-dir persona/datasets/matraix-persona-1m/release
+```
+
+Playground：Dataset → **`matraix-persona-1m`**。CLI：`--dataset persona/datasets/matraix-persona-1m`。
+詳情：[Handbook § Persona 1M](../README.md#3-persona-1m-optional)。
+
+## 快速開始
+
+### Smoke test
+
+無需 API Key。**需要 Docker**（smoke job 使用 `environment.type: docker`）：
+
+```bash
+uv run harbor run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml
+```
+
+### GUI 任務執行
+
+Playground 可選擇任務、抽樣人格，並啟動與 CLI auto 模式相同的 Matraix Playground job。
+啟動 API + 前端（兩個終端機）：
+
+```bash
+# 終端機 A — API
+VENV=.venv bash application/playground/backend/run_dev.sh
+
+# 終端機 B — 前端
+cd application/playground/frontend && npm ci && npm run dev
+```
+
+開啟 **http://localhost:5173** → Playground → 選擇人格 cohort →
+選擇 Survey / Chat / Web / OS app 任務 → **Lock pipeline** → **Run eval**。
+詳情：[Playground §10](../quickstart.md#10-playground--play-tasks-visually)。
+
+### CLI 任務開發 / 執行
+
+**開發** — 複製 `application/tasks/` 下的參考任務，編輯
+`task.toml` / `instruction.md` / `input/` / verifier，再註冊到 Playground
+（[task-guide.md](../application/task-guide.md)）：
+
+```bash
+cp -R application/tasks/example-survey_product-feedback \
+  application/tasks/<your-task-name>
+```
+
+| 類型 | 參考任務 |
+|------|----------|
+| Survey | `application/tasks/example-survey_product-feedback` |
+| Chat | `application/tasks/example-chat-api_support_chatbot` |
+| Web | `application/tasks/example-web-playwright_quote-choice` |
+| OS-app | `application/tasks/example-computer-use-linux_note-to-csv` |
+
+**執行** — 產生 Matraix Playground job（固定 agent + model），再執行：
+
+```bash
+uv run python application/scripts/generate_application_job.py \
+  --task application/tasks/example-survey_product-feedback \
+  --execution-mode auto \
+  --persona-ids 0042 \
+  --model-name anthropic/claude-sonnet-4-6
+
+# 使用腳本列印的 export 行與 recipe 路徑，例如：
+uv run harbor run -c configs/jobs/application-task-job-recipe/example-survey-product-feedback-auto-n1.yaml
+```
+
+批次（`--sample-size N`）、過濾條件，以及 chat / web / os-app 範例見：
+[docs/quickstart.md](../quickstart.md)。
+
+## 文件
+
+**[MatrAIx Handbook](../README.md)** — 指南，以及 persona / application / environment 文件。
+
+<p align="center">
+  <img src="../assets/matraix-architecture.png" alt="MatrAIx 架構" width="900">
+</p>
+
+## 儲存庫結構
+
+```text
+MatrAIx/
+├── persona/                 Schema、資料集、合成/策展/驗證流水線
+│   ├── schema/              1,290 維人格 Schema
+│   ├── datasets/            開發樣本池與人格 YAML
+│   ├── validation/          Grounding / 品質驗證套件
+│   └── scripts/             人格 job 與流水線輔助腳本
+├── application/
+│   ├── tasks/               Survey · chat · web · os-app 任務規格
+│   ├── task-spec/           共用任務契約
+│   ├── playground/          視覺化執行器（後端 API + 前端）
+│   └── scripts/             generate_application_job.py 與任務工具
+├── environment/
+│   ├── runtime/             Matraix Playground runtime
+│   ├── agents/              人格條件化 Agent
+│   ├── task-environments/   Docker 映像 / sidecar
+│   └── adapters/            外部適配器（如 SimpleQA）
+├── packages/                playground · rewardkit · harbor-langsmith
+├── apps/viewer/             與 `harbor view` 配對的前端
+├── configs/jobs/            策展與產生的 Matraix Playground job recipe
+├── docs/                    Handbook — persona/ · application/ · environment/
+├── examples/                最小範例任務
+├── src/matraix/             Python 套件入口
+├── scripts/                 儲存庫級輔助腳本
+├── tests/                   單元 / 環境測試
+└── jobs/                    本機 Matraix Playground 執行輸出（gitignore）
+```
+
+大型產生資料集不納入 git（見上方 Hugging Face 發布）。
+
+## 加入社群
+
+[![Discord](https://img.shields.io/badge/Discord-join%20MatrAIx-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/knVyQQnRFa)
+[![X](https://img.shields.io/badge/X-follow%20%40MatrAIx2026-000000?style=for-the-badge&logo=x&logoColor=white)](https://x.com/MatrAIx2026)
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-follow%20MatrAIx-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/company/matraix)
+[![Google Form](https://img.shields.io/badge/Google%20Form-join%20MatrAIx-4285F4?style=for-the-badge&logo=googleforms&logoColor=white)](https://forms.gle/hwEHng5HGWRqcJue9)
+
+1. 加入 Discord —— 暱稱格式 **`Full Name - Affiliation`**。填寫 Google Form
+   （背景、興趣、論文署名 / 致謝意向）。
+2. 來打個招呼！我們很樂意按共同興趣或經歷幫你對接。
+3. 參與 MatrAIx 研究社群，一起協作或貢獻！
+
+## 授權條款
+
+MIT —— 見 [LICENSE](../../LICENSE)。


### PR DESCRIPTION
## Summary
- Add README translations under `docs/i18n/` for 한국어, 简体中文, 繁體中文, 日本語, Português, and Español
- Link them from the root English `README.md` with a language switcher ordered by current GitHub audience signal

## Test plan
- [ ] Open root `README.md` on GitHub and confirm the language links resolve
- [ ] Spot-check each `docs/i18n/README.*.md` language bar and relative doc/image/LICENSE links
- [ ] Confirm current-language label is bold (not linked) on each page


Made with [Cursor](https://cursor.com)