### PR TITLE
fix(chat): reference task reporting + Acme session isolation (#37)

### DIFF
--- a/application/tasks/example-chat-api_support_chatbot/input/chatbot.yaml
+++ b/application/tasks/example-chat-api_support_chatbot/input/chatbot.yaml
@@ -12,13 +12,13 @@ protocol:
   sendMessage:
     method: POST
     path: /v1/messages
-    sessionIdField: ""
+    sessionIdField: sessionId
     messageField: message
     titleField: ""
     botTypeField: ""
     staticBody: {}
   response:
-    sessionIdField: ""
+    sessionIdField: sessionId
     replyField: reply
 artifacts:
   transcript: transcript.json

--- a/application/tasks/example-chat-api_support_chatbot/tests/test.sh
+++ b/application/tasks/example-chat-api_support_chatbot/tests/test.sh
@@ -1,22 +1,14 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # shellcheck disable=SC1091
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/verifier_env.sh"
 
-apt-get update
-apt-get install -y curl
-
-curl -LsSf https://astral.sh/uv/0.9.7/install.sh | sh
-source "$HOME/.local/bin/env"
-
-uvx \
-  --with pytest==8.4.1 \
-  --with pytest-json-ctrf==0.3.5 \
-  pytest --ctrf "${VERIFIER_DIR}/ctrf.json" "${TESTS_DIR}/test_state.py" -rA
-
-if [ $? -eq 0 ]; then
+# Run the module (not pytest) so main() writes structured_output.json for
+# batch reporting. Keep test_* helpers for manual pytest debugging.
+if python3 "${TESTS_DIR}/test_state.py"; then
   echo 1 > "${VERIFIER_DIR}/reward.txt"
 else
   echo 0 > "${VERIFIER_DIR}/reward.txt"
+  exit 1
 fi

--- a/environment/task-environments/application/chatbot-api-sidecar_acme-support-api/README.md
+++ b/environment/task-environments/application/chatbot-api-sidecar_acme-support-api/README.md
@@ -2,3 +2,6 @@
 
 Local Acme support REST endpoint for chat tasks.
 Persona agent runtime: `application/shared-chat-persona`.
+
+Conversation state is scoped by `sessionId` so shared-sidecar multi-persona
+batches do not merge transcripts across trials.

--- a/environment/task-environments/application/chatbot-api-sidecar_acme-support-api/support-api/server.py
+++ b/environment/task-environments/application/chatbot-api-sidecar_acme-support-api/support-api/server.py
@@ -1,14 +1,18 @@
-"""Acme customer support REST API with in-memory conversation state."""
+"""Acme customer support REST API with per-session conversation state."""
 
 from __future__ import annotations
 
 import re
+import threading
+import uuid
 
 from flask import Flask, jsonify, request
 
 app = Flask(__name__)
 
-_messages: list[dict[str, str]] = []
+_sessions_lock = threading.Lock()
+# session_id → ordered chat turns for that trial / browser session
+_sessions: dict[str, list[dict[str, str]]] = {}
 
 _ORDER_ID = "4521"
 _ORDER_STATUS = (
@@ -57,6 +61,20 @@ def _bot_reply(customer_message: str) -> str:
     )
 
 
+def _resolve_session_id(raw: object) -> str:
+    text = str(raw or "").strip()
+    return text or str(uuid.uuid4())
+
+
+def _session_messages(session_id: str) -> list[dict[str, str]]:
+    with _sessions_lock:
+        bucket = _sessions.get(session_id)
+        if bucket is None:
+            bucket = []
+            _sessions[session_id] = bucket
+        return bucket
+
+
 @app.get("/health")
 @app.get("/v1/health")
 def health():
@@ -85,15 +103,38 @@ def post_message():
     if not customer_message:
         return jsonify({"error": "message must not be empty"}), 400
 
-    _messages.append({"role": "customer", "content": customer_message})
-    reply = _bot_reply(customer_message)
-    _messages.append({"role": "support", "content": reply})
-    return jsonify({"reply": reply})
+    session_id = _resolve_session_id(payload.get("sessionId"))
+    messages = _session_messages(session_id)
+    with _sessions_lock:
+        messages.append({"role": "customer", "content": customer_message})
+        reply = _bot_reply(customer_message)
+        messages.append({"role": "support", "content": reply})
+        snapshot = list(messages)
+
+    return jsonify({"sessionId": session_id, "reply": reply, "turn": len(snapshot) // 2})
 
 
 @app.get("/v1/conversation")
 def get_conversation():
-    return jsonify({"messages": _messages})
+    session_id = str(request.args.get("sessionId") or "").strip()
+    with _sessions_lock:
+        if session_id:
+            messages = list(_sessions.get(session_id, []))
+            return jsonify({"sessionId": session_id, "messages": messages})
+
+        if len(_sessions) > 1:
+            return jsonify(
+                {
+                    "error": "sessionId is required when multiple conversations exist",
+                    "sessionCount": len(_sessions),
+                }
+            ), 400
+
+        if len(_sessions) == 1:
+            only_id, only_messages = next(iter(_sessions.items()))
+            return jsonify({"sessionId": only_id, "messages": list(only_messages)})
+
+    return jsonify({"sessionId": "", "messages": []})
 
 
 if __name__ == "__main__":

--- a/tests/environment/test_acme_support_api_sessions.py
+++ b/tests/environment/test_acme_support_api_sessions.py
@@ -1,0 +1,72 @@
+"""Session isolation for the Acme support HTTP sidecar (#37)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("flask")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SERVER_PATH = (
+    REPO_ROOT
+    / "environment"
+    / "task-environments"
+    / "application"
+    / "chatbot-api-sidecar_acme-support-api"
+    / "support-api"
+    / "server.py"
+)
+
+
+def _load_server():
+    spec = importlib.util.spec_from_file_location("acme_support_api_server", SERVER_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_acme_support_api_scopes_conversation_by_session() -> None:
+    server = _load_server()
+    # Fresh module state between pytest invocations of this file.
+    server._sessions.clear()
+    client = server.app.test_client()
+
+    first = client.post("/v1/messages", json={"message": "Where is order 4521?"})
+    assert first.status_code == 200
+    first_body = first.get_json()
+    session_a = first_body["sessionId"]
+    assert session_a
+    assert "4521" in first_body["reply"]
+
+    second = client.post(
+        "/v1/messages",
+        json={"sessionId": session_a, "message": "Thanks"},
+    )
+    assert second.status_code == 200
+    assert second.get_json()["sessionId"] == session_a
+
+    other = client.post("/v1/messages", json={"message": "I want a refund"})
+    assert other.status_code == 200
+    session_b = other.get_json()["sessionId"]
+    assert session_b != session_a
+
+    convo_a = client.get(f"/v1/conversation?sessionId={session_a}")
+    assert convo_a.status_code == 200
+    messages_a = convo_a.get_json()["messages"]
+    assert any("4521" in m.get("content", "") for m in messages_a)
+    assert not any("refund" in m.get("content", "").lower() for m in messages_a)
+
+    convo_b = client.get(f"/v1/conversation?sessionId={session_b}")
+    assert convo_b.status_code == 200
+    messages_b = convo_b.get_json()["messages"]
+    assert any("refund" in m.get("content", "").lower() for m in messages_b)
+    assert not any("4521" in m.get("content", "") for m in messages_b)
+
+    bare = client.get("/v1/conversation")
+    assert bare.status_code == 400

--- a/tests/environment/test_application_tasks.py
+++ b/tests/environment/test_application_tasks.py
@@ -156,6 +156,18 @@ def test_example_chat_sidecar_contract() -> None:
     assert '@app.post("/v1/messages")' in server_source
     assert '@app.get("/v1/conversation")' in server_source
     assert "def _bot_reply" in server_source
+    # Shared-sidecar batches must scope transcript state by session (#37).
+    assert "_sessions" in server_source
+    assert "sessionId" in server_source
+
+    chatbot_yaml = (EXAMPLE_CHAT / "input" / "chatbot.yaml").read_text(encoding="utf-8")
+    assert "sessionIdField: sessionId" in chatbot_yaml
+
+    test_sh = (EXAMPLE_CHAT / "tests" / "test.sh").read_text(encoding="utf-8")
+    # Production verifier must invoke main() so structured_output.json is written.
+    assert 'python3 "${TESTS_DIR}/test_state.py"' in test_sh
+    assert "pytest --ctrf" not in test_sh
+    assert "uvx" not in test_sh
 
 
 def test_application_task_spec_manifest_uses_clean_task_paths() -> None:


### PR DESCRIPTION
## Summary
Fixes both findings in #37:

1. **`example-chat-api_support_chatbot` verifier** now runs `python3 test_state.py` (not pytest), so `main()` writes `structured_output.json` for batch reporting, and failure still writes `reward.txt`.
2. **Acme support sidecar** stores conversations per `sessionId` (with a lock), returns `sessionId` from `POST /v1/messages`, and requires `sessionId` on `GET /v1/conversation` when multiple sessions exist. Task `chatbot.yaml` sets `sessionIdField: sessionId`.

## Test plan
- [x] `pytest tests/environment/test_acme_support_api_sessions.py tests/environment/test_application_tasks.py::test_example_chat_sidecar_contract`
- [ ] Optional: multi-persona Acme batch — agent `turnCount` vs `transcript.json` message count should stay aligned across trials

Closes #37

Made with [Cursor](https://cursor.com)