### PR TITLE
fix: always write reward.txt on verifier failure (#35)

### DIFF
--- a/application/tasks/example-chat-api_support_chatbot/tests/test.sh
+++ b/application/tasks/example-chat-api_support_chatbot/tests/test.sh
@@ -1,22 +1,14 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # shellcheck disable=SC1091
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/verifier_env.sh"
 
-apt-get update
-apt-get install -y curl
-
-curl -LsSf https://astral.sh/uv/0.9.7/install.sh | sh
-source "$HOME/.local/bin/env"
-
-uvx \
-  --with pytest==8.4.1 \
-  --with pytest-json-ctrf==0.3.5 \
-  pytest --ctrf "${VERIFIER_DIR}/ctrf.json" "${TESTS_DIR}/test_state.py" -rA
-
-if [ $? -eq 0 ]; then
+# Run the module (not pytest) so main() writes structured_output.json for
+# batch reporting. Keep test_* helpers for manual pytest debugging.
+if python3 "${TESTS_DIR}/test_state.py"; then
   echo 1 > "${VERIFIER_DIR}/reward.txt"
 else
   echo 0 > "${VERIFIER_DIR}/reward.txt"
+  exit 1
 fi

--- a/application/tasks/example-computer-use-ios_photo-access-review/tests/test.sh
+++ b/application/tasks/example-computer-use-ios_photo-access-review/tests/test.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/verifier_env.sh"
 export VERIFIER_DIR
 
-python3 <<'PY'
+if python3 <<'PY'
 from __future__ import annotations
 
 import json
@@ -610,8 +610,7 @@ if feedback is not None:
     encoding="utf-8",
 )
 PY
-
-if [ $? -eq 0 ]; then
+then
   printf '1\n' > "${VERIFIER_DIR}/reward.txt"
 else
   printf '0\n' > "${VERIFIER_DIR}/reward.txt"

--- a/application/tasks/example-computer-use-linux_note-to-csv/tests/test.sh
+++ b/application/tasks/example-computer-use-linux_note-to-csv/tests/test.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/verifier_env.sh"
 export VERIFIER_DIR
 
-python3 <<'PY'
+if python3 <<'PY'
 from __future__ import annotations
 
 import json
@@ -402,8 +402,7 @@ if feedback is not None:
     encoding="utf-8",
 )
 PY
-
-if [ $? -eq 0 ]; then
+then
   printf '1\n' > "${VERIFIER_DIR}/reward.txt"
 else
   printf '0\n' > "${VERIFIER_DIR}/reward.txt"

--- a/application/tasks/example-computer-use-macos_calendar-reminder-handoff/tests/test.sh
+++ b/application/tasks/example-computer-use-macos_calendar-reminder-handoff/tests/test.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/verifier_env.sh"
 export VERIFIER_DIR
 
-python3 <<'PY'
+if python3 <<'PY'
 from __future__ import annotations
 
 import json
@@ -550,8 +550,7 @@ if feedback is not None:
     encoding="utf-8",
 )
 PY
-
-if [ $? -eq 0 ]; then
+then
   printf '1\n' > "${VERIFIER_DIR}/reward.txt"
 else
   printf '0\n' > "${VERIFIER_DIR}/reward.txt"

--- a/application/tasks/os-app-ios_news-subscription-decision/tests/test.sh
+++ b/application/tasks/os-app-ios_news-subscription-decision/tests/test.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/verifier_env.sh"
 export VERIFIER_DIR
 
-python3 <<'PY'
+if python3 <<'PY'
 from __future__ import annotations
 
 import json
@@ -802,8 +802,7 @@ if _decision_signals:
     encoding="utf-8",
 )
 PY
-
-if [ $? -eq 0 ]; then
+then
   printf '1\n' > "${VERIFIER_DIR}/reward.txt"
 else
   printf '0\n' > "${VERIFIER_DIR}/reward.txt"


### PR DESCRIPTION
## Summary
- Fix the five `tests/test.sh` scripts from #35 that used `set -e` + `$?`, so a failing verifier never reaches the reward write and Harbor raises `RewardFileNotFoundError` instead of scoring `0`.
- Match the existing good pattern: put the verifier in an `if` condition, then write `reward.txt` on both paths.
- `example-chat-api_support_chatbot` also switches to `python3 test_state.py` (same as the other chat tasks / overlapping with #41) so batch reporting still gets `structured_output.json`.

Closes #35

## Test plan
- [x] `bash -n` on all five scripts
- [x] Confirm no remaining `if [ $? -eq 0 ]` under `application/tasks/**/test.sh`
- [ ] Optional: `harbor run -a oracle` on one computer-use example and confirm a failing check yields `reward.txt` with `0` rather than `RewardFileNotFoundError`


Made with [Cursor](https://cursor.com)