### PR TITLE
docs: add Citation section for MatrAIx paper

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,203 @@
+cff-version: 1.2.0
+message: If you use MatrAIx, please cite the paper below.
+type: software
+title: MatrAIx
+license: MIT
+repository-code: https://github.com/MatrAIx-ai/MatrAIx-Persona-8B
+url: https://matraix.ai
+preferred-citation:
+  type: article
+  title: "MatrAIx: Simulating the World with 8.3 Billion Persona Agents"
+  year: 2026
+  journal: arXiv
+  identifiers:
+    - type: arxiv
+      value: "2608.04205"
+  url: https://arxiv.org/abs/2608.04205
+  authors:
+    - family-names: Li
+      given-names: Xiaomin
+    - family-names: Hao
+      given-names: Yuexing
+    - family-names: Hou
+      given-names: Jianheng
+    - family-names: Huang
+      given-names: Jintao
+    - family-names: Wen
+      given-names: Qianfeng
+    - family-names: Huang
+      given-names: Shirley
+    - family-names: Liu
+      given-names: Yifan
+    - family-names: Liu
+      given-names: Xiaoyi
+    - family-names: Fan
+      given-names: Yilan
+    - family-names: Wang
+      given-names: Yijun
+    - family-names: Wu
+      given-names: Koutian
+    - family-names: Gao
+      given-names: Ruoqi
+    - family-names: Mohsin
+      given-names: Muhammad Ahmed
+    - family-names: Tang
+      given-names: Jing
+    - family-names: Joshi
+      given-names: Brihi
+    - family-names: Liu
+      given-names: Heming
+    - family-names: Deng
+      given-names: Zheyuan
+    - family-names: Di
+      given-names: Zonglin
+    - family-names: Jajee
+      given-names: Sankalp
+    - family-names: Lu
+      given-names: Jiuyao
+    - family-names: Zhang
+      given-names: Zhiwei
+    - family-names: Kapoor
+      given-names: Saksham
+    - family-names: Gupta
+      given-names: Ishan
+    - family-names: Zhao
+      given-names: Yunhan
+    - family-names: Park
+      given-names: Chanwoo
+    - family-names: Lu
+      given-names: Yucheng
+    - family-names: Hu
+      given-names: Bing
+    - family-names: Xiao
+      given-names: Weihang
+    - family-names: Mohan
+      given-names: Aravind
+    - family-names: Xing
+      given-names: Hanwen
+    - family-names: Zhang
+      given-names: Runyu
+    - family-names: Kulshreshtha
+      given-names: Mihir
+    - family-names: Xu
+      given-names: Yuanda
+    - family-names: Zhu
+      given-names: Qianyu
+    - family-names: Wang
+      given-names: Dianzhuo
+    - family-names: Xiao
+      given-names: Yuxin
+    - family-names: Jiang
+      given-names: Bowen
+    - family-names: Su
+      given-names: Yongye
+    - family-names: Chai
+      given-names: Wenhao
+    - family-names: Liu
+      given-names: Zuxin
+    - family-names: Chen
+      given-names: Lawrence Yunliang
+    - family-names: Zhao
+      given-names: Xuandong
+    - family-names: Ye
+      given-names: Ethan
+    - family-names: Patel
+      given-names: Shivam
+    - family-names: Xie
+      given-names: Jason
+    - family-names: Richmond
+      given-names: Alex Martin
+    - family-names: Ding
+      given-names: Weixiang
+    - family-names: Okcular
+      given-names: Emre
+    - family-names: Mathew
+      given-names: Diya
+    - family-names: Wang
+      given-names: Ziheng
+    - family-names: Khan
+      given-names: Rana M. Shahroz
+    - family-names: Peng
+      given-names: Zhejian
+    - family-names: Wu
+      given-names: Fang
+    - family-names: Nie
+      given-names: Fan
+    - family-names: Han
+      given-names: Xinyang
+    - family-names: Kim
+      given-names: Yubin
+    - family-names: Zhang
+      given-names: Jiawei
+    - family-names: Qi
+      given-names: Zhenting
+    - family-names: Su
+      given-names: Huangyuan
+    - family-names: Pan
+      given-names: Xu
+    - family-names: Gourabathina
+      given-names: Abinitha
+    - family-names: Jeong
+      given-names: Hyewon
+    - family-names: Ramesh
+      given-names: Hemanth Neelgund
+    - family-names: Alhamoud
+      given-names: Kumail
+    - family-names: Hamidieh
+      given-names: Kimia
+    - family-names: Xiong
+      given-names: Zidi
+    - family-names: Schmidgall
+      given-names: Samuel
+    - family-names: Han
+      given-names: Pengrui
+    - family-names: Huang
+      given-names: Yepeng
+    - family-names: Wang
+      given-names: Yongheng
+    - family-names: Yang
+      given-names: Bowen
+    - family-names: Gu
+      given-names: Alex
+    - family-names: Wang
+      given-names: Yuchu
+    - family-names: Paruchuri
+      given-names: Akshay
+    - family-names: Li
+      given-names: Brenna
+    - family-names: Cui
+      given-names: Hejie
+    - family-names: Ding
+      given-names: Jiayuan
+    - family-names: Dong
+      given-names: Chaosheng
+    - family-names: Wang
+      given-names: Jiahao
+    - family-names: He
+      given-names: Yixuan
+    - family-names: Wang
+      given-names: Chi
+    - family-names: Bhattacharya
+      given-names: Pamela
+    - family-names: Peng
+      given-names: Tianyi
+    - family-names: Liang
+      given-names: Paul Pu
+    - family-names: Gordon
+      given-names: Mitchell
+    - family-names: Du
+      given-names: Yilun
+    - family-names: Zitnik
+      given-names: Marinka
+    - family-names: Zou
+      given-names: James
+    - family-names: Tambe
+      given-names: Prasanna
+    - family-names: Torr
+      given-names: Philip
+    - family-names: Fox
+      given-names: Emily
+    - family-names: Ozdaglar
+      given-names: Asu
+    - family-names: Song
+      given-names: Dawn

--- a/README.md
+++ b/README.md
@@ -220,45 +220,23 @@ Large generated datasets stay outside git (see the Hugging Face release above).
 If you use MatrAIx, the Persona 1M dataset, or results from this repository,
 please cite:
 
+> Xiaomin Li et al. *MatrAIx: Simulating the World with 8.3 Billion Persona Agents*. arXiv:2608.04205, 2026.  
+> https://arxiv.org/abs/2608.04205
+
 ```bibtex
 @article{li2026matraix,
-  title   = {MatrAIx: Simulating the World with 8.3 Billion Persona Agents},
-  author  = {Li, Xiaomin and Hao, Yuexing and Hou, Jianheng and Huang, Jintao
-             and Wen, Qianfeng and Huang, Shirley and Liu, Yifan and Liu, Xiaoyi
-             and Fan, Yilan and Wang, Yijun and Wu, Koutian and Gao, Ruoqi
-             and Mohsin, Muhammad Ahmed and Tang, Jing and Joshi, Brihi
-             and Liu, Heming and Deng, Zheyuan and Di, Zonglin and Jajee, Sankalp
-             and Lu, Jiuyao and Zhang, Zhiwei and Kapoor, Saksham and Gupta, Ishan
-             and Zhao, Yunhan and Park, Chanwoo and Lu, Yucheng and Hu, Bing
-             and Xiao, Weihang and Mohan, Aravind and Xing, Hanwen and Zhang, Runyu
-             and Kulshreshtha, Mihir and Xu, Yuanda and Zhu, Qianyu and Wang, Dianzhuo
-             and Xiao, Yuxin and Jiang, Bowen and Su, Yongye and Chai, Wenhao
-             and Liu, Zuxin and Chen, Lawrence Yunliang and Zhao, Xuandong
-             and Ye, Ethan and Patel, Shivam and Xie, Jason
-             and Richmond, Alex Martin and Ding, Weixiang and Okcular, Emre
-             and Mathew, Diya and Wang, Ziheng and Khan, Rana M. Shahroz
-             and Peng, Zhejian and Wu, Fang and Nie, Fan and Han, Xinyang
-             and Kim, Yubin and Zhang, Jiawei and Qi, Zhenting and Su, Huangyuan
-             and Pan, Xu and Gourabathina, Abinitha and Jeong, Hyewon
-             and Ramesh, Hemanth Neelgund and Alhamoud, Kumail and Hamidieh, Kimia
-             and Xiong, Zidi and Schmidgall, Samuel and Han, Pengrui
-             and Huang, Yepeng and Wang, Yongheng and Yang, Bowen and Gu, Alex
-             and Wang, Yuchu and Paruchuri, Akshay and Li, Brenna and Cui, Hejie
-             and Ding, Jiayuan and Dong, Chaosheng and Wang, Jiahao and He, Yixuan
-             and Wang, Chi and Bhattacharya, Pamela and Peng, Tianyi
-             and Liang, Paul Pu and Gordon, Mitchell and Du, Yilun
-             and Zitnik, Marinka and Zou, James and Tambe, Prasanna
-             and Torr, Philip and Fox, Emily and Ozdaglar, Asu and Song, Dawn},
-  year    = {2026},
-  eprint  = {2608.04205},
+  title         = {MatrAIx: Simulating the World with 8.3 Billion Persona Agents},
+  author        = {Li, Xiaomin and others},
+  year          = {2026},
+  eprint        = {2608.04205},
   archivePrefix = {arXiv},
   primaryClass  = {cs.AI},
-  url     = {https://arxiv.org/abs/2608.04205}
+  url           = {https://arxiv.org/abs/2608.04205}
 }
 ```
 
-Paper: [arXiv:2608.04205](https://arxiv.org/abs/2608.04205) ·
-Dataset: [Persona 1M on Hugging Face](https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release)
+Full author list: GitHub **Cite this repository** (`CITATION.cff`) or the [arXiv abstract](https://arxiv.org/abs/2608.04205).  
+Dataset: [Persona 1M on Hugging Face](https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -215,6 +215,51 @@ Large generated datasets stay outside git (see the Hugging Face release above).
 2. Say hi to us! We like to connect you for the shared interest or experience!
 3. Participating MatrAIx research community for collaboration or contribution!
 
+## Citation
+
+If you use MatrAIx, the Persona 1M dataset, or results from this repository,
+please cite:
+
+```bibtex
+@article{li2026matraix,
+  title   = {MatrAIx: Simulating the World with 8.3 Billion Persona Agents},
+  author  = {Li, Xiaomin and Hao, Yuexing and Hou, Jianheng and Huang, Jintao
+             and Wen, Qianfeng and Huang, Shirley and Liu, Yifan and Liu, Xiaoyi
+             and Fan, Yilan and Wang, Yijun and Wu, Koutian and Gao, Ruoqi
+             and Mohsin, Muhammad Ahmed and Tang, Jing and Joshi, Brihi
+             and Liu, Heming and Deng, Zheyuan and Di, Zonglin and Jajee, Sankalp
+             and Lu, Jiuyao and Zhang, Zhiwei and Kapoor, Saksham and Gupta, Ishan
+             and Zhao, Yunhan and Park, Chanwoo and Lu, Yucheng and Hu, Bing
+             and Xiao, Weihang and Mohan, Aravind and Xing, Hanwen and Zhang, Runyu
+             and Kulshreshtha, Mihir and Xu, Yuanda and Zhu, Qianyu and Wang, Dianzhuo
+             and Xiao, Yuxin and Jiang, Bowen and Su, Yongye and Chai, Wenhao
+             and Liu, Zuxin and Chen, Lawrence Yunliang and Zhao, Xuandong
+             and Ye, Ethan and Patel, Shivam and Xie, Jason
+             and Richmond, Alex Martin and Ding, Weixiang and Okcular, Emre
+             and Mathew, Diya and Wang, Ziheng and Khan, Rana M. Shahroz
+             and Peng, Zhejian and Wu, Fang and Nie, Fan and Han, Xinyang
+             and Kim, Yubin and Zhang, Jiawei and Qi, Zhenting and Su, Huangyuan
+             and Pan, Xu and Gourabathina, Abinitha and Jeong, Hyewon
+             and Ramesh, Hemanth Neelgund and Alhamoud, Kumail and Hamidieh, Kimia
+             and Xiong, Zidi and Schmidgall, Samuel and Han, Pengrui
+             and Huang, Yepeng and Wang, Yongheng and Yang, Bowen and Gu, Alex
+             and Wang, Yuchu and Paruchuri, Akshay and Li, Brenna and Cui, Hejie
+             and Ding, Jiayuan and Dong, Chaosheng and Wang, Jiahao and He, Yixuan
+             and Wang, Chi and Bhattacharya, Pamela and Peng, Tianyi
+             and Liang, Paul Pu and Gordon, Mitchell and Du, Yilun
+             and Zitnik, Marinka and Zou, James and Tambe, Prasanna
+             and Torr, Philip and Fox, Emily and Ozdaglar, Asu and Song, Dawn},
+  year    = {2026},
+  eprint  = {2608.04205},
+  archivePrefix = {arXiv},
+  primaryClass  = {cs.AI},
+  url     = {https://arxiv.org/abs/2608.04205}
+}
+```
+
+Paper: [arXiv:2608.04205](https://arxiv.org/abs/2608.04205) ·
+Dataset: [Persona 1M on Hugging Face](https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release)
+
 ## License
 
 MIT — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ The name nods to *The Matrix*: a simulated world useful for exploration, stress
 testing, and hypothesis generation, **not a replacement for evidence from real
 people**.
 
+## News
+
+- **[2026-08-10]** Featured as an [X Trending Story](https://x.com/i/trending/2086626337561911419): *Harvard and MIT Unveil MatrAIx with 8.3 Billion Virtual Personas*. Also covered across tech media, including [AI Era](https://www.36kr.com/p/3932853833759876), [Numerama](https://www.numerama.com/tech/2308727-ces-chercheurs-ont-cree-83-milliards-dhumains-virtuels-pour-tester-des-produits-a-notre-place.html), [Infobae](https://www.infobae.com/tecno/2026/08/10/asi-prueba-la-ia-un-mundo-con-8300-millones-de-personas-digitales-matraix-es-el-metaverso/), [AI타임스](https://www.aitimes.com/news/articleView.html?idxno=213824), [CryptoBriefing](https://cryptobriefing.com/matraix-simulation-harvard-mit-ai-personas/), and [Startup Fortune](https://startupfortune.com/harvard-and-mit-built-an-ai-model-of-83-billion-people-to-test-products-on/), among others.
+- **[2026-08-04]** Technical report on arXiv: [MatrAIx: Simulating the World with 8.3 Billion Persona Agents](https://arxiv.org/abs/2608.04205) (`2608.04205`).
+- **[2026-08-01]** Released [Persona 1M](https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release) on Hugging Face (~1M quality-filtered personas).
+- **[2026-07-31]** Open-sourced the Playground and task library: [MatrAIx-Persona-8B](https://github.com/MatrAIx-ai/MatrAIx-Persona-8B).
+- **[2026-07-29]** Position note: [From Personas to Simulated Users](https://matraix.ai/research/survey-from-personas-to-simulated-users.html).
+
 ## Requirements
 
 - [Docker](https://docs.docker.com/get-docker/)

--- a/README.md
+++ b/README.md
@@ -220,9 +220,6 @@ Large generated datasets stay outside git (see the Hugging Face release above).
 If you use MatrAIx, the Persona 1M dataset, or results from this repository,
 please cite:
 
-> Xiaomin Li, Yuexing Hao, Jianheng Hou, Jintao Huang, Qianfeng Wen, Shirley Huang, Yifan Liu, Xiaoyi Liu, Yilan Fan, Yijun Wang, et al. *MatrAIx: Simulating the World with 8.3 Billion Persona Agents*. arXiv:2608.04205, 2026.  
-> https://arxiv.org/abs/2608.04205
-
 ```bibtex
 @article{li2026matraix,
   title         = {MatrAIx: Simulating the World with 8.3 Billion Persona Agents},
@@ -237,7 +234,8 @@ please cite:
 }
 ```
 
-Full author list: GitHub **Cite this repository** (`CITATION.cff`) or the [arXiv abstract](https://arxiv.org/abs/2608.04205).  
+Paper: [arXiv:2608.04205](https://arxiv.org/abs/2608.04205) ·
+Full authors: GitHub **Cite this repository** (`CITATION.cff`) ·
 Dataset: [Persona 1M on Hugging Face](https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release).
 
 ## License

--- a/README.md
+++ b/README.md
@@ -220,13 +220,15 @@ Large generated datasets stay outside git (see the Hugging Face release above).
 If you use MatrAIx, the Persona 1M dataset, or results from this repository,
 please cite:
 
-> Xiaomin Li et al. *MatrAIx: Simulating the World with 8.3 Billion Persona Agents*. arXiv:2608.04205, 2026.  
+> Xiaomin Li, Yuexing Hao, Jianheng Hou, Jintao Huang, Qianfeng Wen, Shirley Huang, Yifan Liu, Xiaoyi Liu, Yilan Fan, Yijun Wang, et al. *MatrAIx: Simulating the World with 8.3 Billion Persona Agents*. arXiv:2608.04205, 2026.  
 > https://arxiv.org/abs/2608.04205
 
 ```bibtex
 @article{li2026matraix,
   title         = {MatrAIx: Simulating the World with 8.3 Billion Persona Agents},
-  author        = {Li, Xiaomin and others},
+  author        = {Li, Xiaomin and Hao, Yuexing and Hou, Jianheng and Huang, Jintao
+                   and Wen, Qianfeng and Huang, Shirley and Liu, Yifan and Liu, Xiaoyi
+                   and Fan, Yilan and Wang, Yijun and others},
   year          = {2026},
   eprint        = {2608.04205},
   archivePrefix = {arXiv},

--- a/docs/i18n/README.es.md
+++ b/docs/i18n/README.es.md
@@ -59,6 +59,14 @@ El nombre alude a *The Matrix*: un mundo simulado útil para exploración,
 pruebas de estrés y generación de hipótesis — **no un sustituto de la evidencia
 de personas reales**.
 
+## Novedades
+
+- **[2026-08-10]** Destacado como [X Trending Story](https://x.com/i/trending/2086626337561911419): *Harvard and MIT Unveil MatrAIx with 8.3 Billion Virtual Personas*. También cubierto en medios tecnológicos, incluidos [AI Era](https://www.36kr.com/p/3932853833759876), [Numerama](https://www.numerama.com/tech/2308727-ces-chercheurs-ont-cree-83-milliards-dhumains-virtuels-pour-tester-des-produits-a-notre-place.html), [Infobae](https://www.infobae.com/tecno/2026/08/10/asi-prueba-la-ia-un-mundo-con-8300-millones-de-personas-digitales-matraix-es-el-metaverso/), [AI타임스](https://www.aitimes.com/news/articleView.html?idxno=213824), [CryptoBriefing](https://cryptobriefing.com/matraix-simulation-harvard-mit-ai-personas/) y [Startup Fortune](https://startupfortune.com/harvard-and-mit-built-an-ai-model-of-83-billion-people-to-test-products-on/), entre otros.
+- **[2026-08-04]** Informe técnico en arXiv: [MatrAIx: Simulating the World with 8.3 Billion Persona Agents](https://arxiv.org/abs/2608.04205) (`2608.04205`).
+- **[2026-08-01]** Publicado [Persona 1M](https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release) en Hugging Face (~1M personas filtradas por calidad).
+- **[2026-07-31]** Código abierto del Playground y la biblioteca de tareas: [MatrAIx-Persona-8B](https://github.com/MatrAIx-ai/MatrAIx-Persona-8B).
+- **[2026-07-29]** Nota de posición: [From Personas to Simulated Users](https://matraix.ai/research/survey-from-personas-to-simulated-users.html).
+
 ## Requisitos
 
 - [Docker](https://docs.docker.com/get-docker/)
@@ -216,6 +224,29 @@ Los datasets grandes generados quedan fuera de git (ver el release de Hugging Fa
    (trasfondo, intereses, autoría / agradecimientos en papers).
 2. ¡Saluda! Nos gusta conectar a quienes comparten intereses o experiencia.
 3. Participa en la comunidad de investigación MatrAIx para colaborar o contribuir.
+
+## Cita
+
+Si usas MatrAIx, el dataset Persona 1M o resultados de este repositorio,
+cita:
+
+```bibtex
+@article{li2026matraix,
+  title         = {MatrAIx: Simulating the World with 8.3 Billion Persona Agents},
+  author        = {Li, Xiaomin and Hao, Yuexing and Hou, Jianheng and Huang, Jintao
+                   and Wen, Qianfeng and Huang, Shirley and Liu, Yifan and Liu, Xiaoyi
+                   and Fan, Yilan and Wang, Yijun and others},
+  year          = {2026},
+  eprint        = {2608.04205},
+  archivePrefix = {arXiv},
+  primaryClass  = {cs.AI},
+  url           = {https://arxiv.org/abs/2608.04205}
+}
+```
+
+Artículo: [arXiv:2608.04205](https://arxiv.org/abs/2608.04205) ·
+Autores completos: GitHub **Cite this repository** (`CITATION.cff`) ·
+Dataset: [Persona 1M on Hugging Face](https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release).
 
 ## Licencia
 

--- a/docs/i18n/README.ja.md
+++ b/docs/i18n/README.ja.md
@@ -54,6 +54,14 @@
 名前は *The Matrix* に由来します。探索・ストレステスト・仮説生成に有用なシミュレート世界であり、
 **実在の人々からの証拠の代替ではありません**。
 
+## ニュース
+
+- **[2026-08-10]** [X Trending Story](https://x.com/i/trending/2086626337561911419) に掲載: *Harvard and MIT Unveil MatrAIx with 8.3 Billion Virtual Personas*。テックメディアでも取り上げられ、[AI Era](https://www.36kr.com/p/3932853833759876)、[Numerama](https://www.numerama.com/tech/2308727-ces-chercheurs-ont-cree-83-milliards-dhumains-virtuels-pour-tester-des-produits-a-notre-place.html)、[Infobae](https://www.infobae.com/tecno/2026/08/10/asi-prueba-la-ia-un-mundo-con-8300-millones-de-personas-digitales-matraix-es-el-metaverso/)、[AI타임스](https://www.aitimes.com/news/articleView.html?idxno=213824)、[CryptoBriefing](https://cryptobriefing.com/matraix-simulation-harvard-mit-ai-personas/)、[Startup Fortune](https://startupfortune.com/harvard-and-mit-built-an-ai-model-of-83-billion-people-to-test-products-on/) などが含まれます。
+- **[2026-08-04]** arXiv 技術レポート: [MatrAIx: Simulating the World with 8.3 Billion Persona Agents](https://arxiv.org/abs/2608.04205) (`2608.04205`)。
+- **[2026-08-01]** Hugging Face で [Persona 1M](https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release) を公開（約 100 万件の品質フィルタ済みペルソナ）。
+- **[2026-07-31]** Playground とタスクライブラリをオープンソース化: [MatrAIx-Persona-8B](https://github.com/MatrAIx-ai/MatrAIx-Persona-8B)。
+- **[2026-07-29]** ポジションノート: [From Personas to Simulated Users](https://matraix.ai/research/survey-from-personas-to-simulated-users.html)。
+
 ## 要件
 
 - [Docker](https://docs.docker.com/get-docker/)
@@ -210,6 +218,28 @@ MatrAIx/
    （背景、興味、論文の著者 / 謝辞）。
 2. あいさつしてください！共通の関心や経験でつなぎたいです。
 3. MatrAIx 研究コミュニティに参加して、コラボや貢献を！
+
+## 引用
+
+MatrAIx、Persona 1M データセット、または本リポジトリの結果を利用する場合は、次を引用してください。
+
+```bibtex
+@article{li2026matraix,
+  title         = {MatrAIx: Simulating the World with 8.3 Billion Persona Agents},
+  author        = {Li, Xiaomin and Hao, Yuexing and Hou, Jianheng and Huang, Jintao
+                   and Wen, Qianfeng and Huang, Shirley and Liu, Yifan and Liu, Xiaoyi
+                   and Fan, Yilan and Wang, Yijun and others},
+  year          = {2026},
+  eprint        = {2608.04205},
+  archivePrefix = {arXiv},
+  primaryClass  = {cs.AI},
+  url           = {https://arxiv.org/abs/2608.04205}
+}
+```
+
+論文: [arXiv:2608.04205](https://arxiv.org/abs/2608.04205) ·
+全著者リスト: GitHub **Cite this repository** (`CITATION.cff`) ·
+データセット: [Persona 1M on Hugging Face](https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release)。
 
 ## ライセンス
 

--- a/docs/i18n/README.ko.md
+++ b/docs/i18n/README.ko.md
@@ -54,6 +54,14 @@
 이름은 *The Matrix*를 가리킵니다. 탐색·스트레스 테스트·가설 생성에 유용한 시뮬레이션
 세계이며, **실제 사람으로부터의 증거를 대체하지 않습니다**.
 
+## 소식
+
+- **[2026-08-10]** [X Trending Story](https://x.com/i/trending/2086626337561911419)에 선정: *Harvard and MIT Unveil MatrAIx with 8.3 Billion Virtual Personas*. 테크 미디어에서도 다뤄졌으며, [AI Era](https://www.36kr.com/p/3932853833759876), [Numerama](https://www.numerama.com/tech/2308727-ces-chercheurs-ont-cree-83-milliards-dhumains-virtuels-pour-tester-des-produits-a-notre-place.html), [Infobae](https://www.infobae.com/tecno/2026/08/10/asi-prueba-la-ia-un-mundo-con-8300-millones-de-personas-digitales-matraix-es-el-metaverso/), [AI타임스](https://www.aitimes.com/news/articleView.html?idxno=213824), [CryptoBriefing](https://cryptobriefing.com/matraix-simulation-harvard-mit-ai-personas/), [Startup Fortune](https://startupfortune.com/harvard-and-mit-built-an-ai-model-of-83-billion-people-to-test-products-on/) 등이 포함됩니다.
+- **[2026-08-04]** arXiv 기술 보고서: [MatrAIx: Simulating the World with 8.3 Billion Persona Agents](https://arxiv.org/abs/2608.04205) (`2608.04205`).
+- **[2026-08-01]** Hugging Face에 [Persona 1M](https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release) 공개(약 100만 품질 필터 페르소나).
+- **[2026-07-31]** Playground와 태스크 라이브러리 오픈소스: [MatrAIx-Persona-8B](https://github.com/MatrAIx-ai/MatrAIx-Persona-8B).
+- **[2026-07-29]** 입장문: [From Personas to Simulated Users](https://matraix.ai/research/survey-from-personas-to-simulated-users.html).
+
 ## 요구 사항
 
 - [Docker](https://docs.docker.com/get-docker/)
@@ -210,6 +218,28 @@ MatrAIx/
    (배경, 관심사, 논문 저자 / 사사).
 2. 인사해 주세요! 공통 관심사나 경험으로 연결하고 싶습니다.
 3. MatrAIx 연구 커뮤니티에 참여해 협업하거나 기여하세요!
+
+## 인용
+
+MatrAIx, Persona 1M 데이터셋, 또는 이 저장소의 결과를 사용할 경우 다음을 인용해 주세요.
+
+```bibtex
+@article{li2026matraix,
+  title         = {MatrAIx: Simulating the World with 8.3 Billion Persona Agents},
+  author        = {Li, Xiaomin and Hao, Yuexing and Hou, Jianheng and Huang, Jintao
+                   and Wen, Qianfeng and Huang, Shirley and Liu, Yifan and Liu, Xiaoyi
+                   and Fan, Yilan and Wang, Yijun and others},
+  year          = {2026},
+  eprint        = {2608.04205},
+  archivePrefix = {arXiv},
+  primaryClass  = {cs.AI},
+  url           = {https://arxiv.org/abs/2608.04205}
+}
+```
+
+논문: [arXiv:2608.04205](https://arxiv.org/abs/2608.04205) ·
+전체 저자 목록: GitHub **Cite this repository** (`CITATION.cff`) ·
+데이터셋: [Persona 1M on Hugging Face](https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release).
 
 ## 라이선스
 

--- a/docs/i18n/README.pt-BR.md
+++ b/docs/i18n/README.pt-BR.md
@@ -58,6 +58,14 @@ O nome remete a *The Matrix*: um mundo simulado útil para exploração, testes 
 estresse e geração de hipóteses — **não um substituto para evidências de pessoas
 reais**.
 
+## Novidades
+
+- **[2026-08-10]** Destaque como [X Trending Story](https://x.com/i/trending/2086626337561911419): *Harvard and MIT Unveil MatrAIx with 8.3 Billion Virtual Personas*. Também coberto pela mídia de tecnologia, incluindo [AI Era](https://www.36kr.com/p/3932853833759876), [Numerama](https://www.numerama.com/tech/2308727-ces-chercheurs-ont-cree-83-milliards-dhumains-virtuels-pour-tester-des-produits-a-notre-place.html), [Infobae](https://www.infobae.com/tecno/2026/08/10/asi-prueba-la-ia-un-mundo-con-8300-millones-de-personas-digitales-matraix-es-el-metaverso/), [AI타임스](https://www.aitimes.com/news/articleView.html?idxno=213824), [CryptoBriefing](https://cryptobriefing.com/matraix-simulation-harvard-mit-ai-personas/) e [Startup Fortune](https://startupfortune.com/harvard-and-mit-built-an-ai-model-of-83-billion-people-to-test-products-on/), entre outros.
+- **[2026-08-04]** Relatório técnico no arXiv: [MatrAIx: Simulating the World with 8.3 Billion Persona Agents](https://arxiv.org/abs/2608.04205) (`2608.04205`).
+- **[2026-08-01]** Publicado o [Persona 1M](https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release) no Hugging Face (~1M personas filtradas por qualidade).
+- **[2026-07-31]** Playground e biblioteca de tarefas em código aberto: [MatrAIx-Persona-8B](https://github.com/MatrAIx-ai/MatrAIx-Persona-8B).
+- **[2026-07-29]** Nota de posição: [From Personas to Simulated Users](https://matraix.ai/research/survey-from-personas-to-simulated-users.html).
+
 ## Requisitos
 
 - [Docker](https://docs.docker.com/get-docker/)
@@ -215,6 +223,29 @@ Datasets grandes gerados ficam fora do git (veja o release no Hugging Face acima
    (background, interesses, autoria / agradecimentos em papers).
 2. Diga oi! Gostamos de conectar pessoas com interesses ou experiências em comum!
 3. Participe da comunidade de pesquisa MatrAIx para colaboração ou contribuição!
+
+## Citação
+
+Se você usar MatrAIx, o dataset Persona 1M ou resultados deste repositório,
+cite:
+
+```bibtex
+@article{li2026matraix,
+  title         = {MatrAIx: Simulating the World with 8.3 Billion Persona Agents},
+  author        = {Li, Xiaomin and Hao, Yuexing and Hou, Jianheng and Huang, Jintao
+                   and Wen, Qianfeng and Huang, Shirley and Liu, Yifan and Liu, Xiaoyi
+                   and Fan, Yilan and Wang, Yijun and others},
+  year          = {2026},
+  eprint        = {2608.04205},
+  archivePrefix = {arXiv},
+  primaryClass  = {cs.AI},
+  url           = {https://arxiv.org/abs/2608.04205}
+}
+```
+
+Artigo: [arXiv:2608.04205](https://arxiv.org/abs/2608.04205) ·
+Autores completos: GitHub **Cite this repository** (`CITATION.cff`) ·
+Dataset: [Persona 1M on Hugging Face](https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release).
 
 ## Licença
 

--- a/docs/i18n/README.zh-CN.md
+++ b/docs/i18n/README.zh-CN.md
@@ -45,6 +45,14 @@
 
 名称致敬 *The Matrix*：这是一个便于探索、压力测试与假设生成的模拟世界，**不能替代来自真实人群的证据**。
 
+## 动态
+
+- **[2026-08-10]** 登上 [X Trending Story](https://x.com/i/trending/2086626337561911419)：*Harvard and MIT Unveil MatrAIx with 8.3 Billion Virtual Personas*。科技媒体亦有报道，包括 [AI Era](https://www.36kr.com/p/3932853833759876)、[Numerama](https://www.numerama.com/tech/2308727-ces-chercheurs-ont-cree-83-milliards-dhumains-virtuels-pour-tester-des-produits-a-notre-place.html)、[Infobae](https://www.infobae.com/tecno/2026/08/10/asi-prueba-la-ia-un-mundo-con-8300-millones-de-personas-digitales-matraix-es-el-metaverso/)、[AI타임스](https://www.aitimes.com/news/articleView.html?idxno=213824)、[CryptoBriefing](https://cryptobriefing.com/matraix-simulation-harvard-mit-ai-personas/)、[Startup Fortune](https://startupfortune.com/harvard-and-mit-built-an-ai-model-of-83-billion-people-to-test-products-on/) 等。
+- **[2026-08-04]** 技术报告发布于 arXiv：[MatrAIx: Simulating the World with 8.3 Billion Persona Agents](https://arxiv.org/abs/2608.04205)（`2608.04205`）。
+- **[2026-08-01]** 在 Hugging Face 发布 [Persona 1M](https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release)（约 100 万条质量过滤人格）。
+- **[2026-07-31]** 开源 Playground 与任务库：[MatrAIx-Persona-8B](https://github.com/MatrAIx-ai/MatrAIx-Persona-8B)。
+- **[2026-07-29]** 立场短文：[From Personas to Simulated Users](https://matraix.ai/research/survey-from-personas-to-simulated-users.html)。
+
 ## 环境要求
 
 - [Docker](https://docs.docker.com/get-docker/)
@@ -199,6 +207,28 @@ MatrAIx/
    （背景、兴趣、论文署名 / 致谢意向）。
 2. 来打个招呼！我们很乐意按共同兴趣或经历帮你对接。
 3. 参与 MatrAIx 研究社区，一起协作或贡献！
+
+## 引用
+
+若你使用 MatrAIx、Persona 1M 数据集或本仓库中的结果，请引用：
+
+```bibtex
+@article{li2026matraix,
+  title         = {MatrAIx: Simulating the World with 8.3 Billion Persona Agents},
+  author        = {Li, Xiaomin and Hao, Yuexing and Hou, Jianheng and Huang, Jintao
+                   and Wen, Qianfeng and Huang, Shirley and Liu, Yifan and Liu, Xiaoyi
+                   and Fan, Yilan and Wang, Yijun and others},
+  year          = {2026},
+  eprint        = {2608.04205},
+  archivePrefix = {arXiv},
+  primaryClass  = {cs.AI},
+  url           = {https://arxiv.org/abs/2608.04205}
+}
+```
+
+论文：[arXiv:2608.04205](https://arxiv.org/abs/2608.04205) ·
+完整作者名单：GitHub **Cite this repository**（`CITATION.cff`） ·
+数据集：[Persona 1M on Hugging Face](https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release)。
 
 ## 许可证
 

--- a/docs/i18n/README.zh-TW.md
+++ b/docs/i18n/README.zh-TW.md
@@ -45,6 +45,14 @@
 
 名稱致敬 *The Matrix*：這是一個便於探索、壓力測試與假設生成的模擬世界，**不能取代來自真實人群的證據**。
 
+## 動態
+
+- **[2026-08-10]** 登上 [X Trending Story](https://x.com/i/trending/2086626337561911419)：*Harvard and MIT Unveil MatrAIx with 8.3 Billion Virtual Personas*。科技媒體亦有報導，包括 [AI Era](https://www.36kr.com/p/3932853833759876)、[Numerama](https://www.numerama.com/tech/2308727-ces-chercheurs-ont-cree-83-milliards-dhumains-virtuels-pour-tester-des-produits-a-notre-place.html)、[Infobae](https://www.infobae.com/tecno/2026/08/10/asi-prueba-la-ia-un-mundo-con-8300-millones-de-personas-digitales-matraix-es-el-metaverso/)、[AI타임스](https://www.aitimes.com/news/articleView.html?idxno=213824)、[CryptoBriefing](https://cryptobriefing.com/matraix-simulation-harvard-mit-ai-personas/)、[Startup Fortune](https://startupfortune.com/harvard-and-mit-built-an-ai-model-of-83-billion-people-to-test-products-on/) 等。
+- **[2026-08-04]** 技術報告發布於 arXiv：[MatrAIx: Simulating the World with 8.3 Billion Persona Agents](https://arxiv.org/abs/2608.04205)（`2608.04205`）。
+- **[2026-08-01]** 在 Hugging Face 發布 [Persona 1M](https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release)（約 100 萬條品質過濾人格）。
+- **[2026-07-31]** 開源 Playground 與任務庫：[MatrAIx-Persona-8B](https://github.com/MatrAIx-ai/MatrAIx-Persona-8B)。
+- **[2026-07-29]** 立場短文：[From Personas to Simulated Users](https://matraix.ai/research/survey-from-personas-to-simulated-users.html)。
+
 ## 環境需求
 
 - [Docker](https://docs.docker.com/get-docker/)
@@ -199,6 +207,28 @@ MatrAIx/
    （背景、興趣、論文署名 / 致謝意向）。
 2. 來打個招呼！我們很樂意按共同興趣或經歷幫你對接。
 3. 參與 MatrAIx 研究社群，一起協作或貢獻！
+
+## 引用
+
+若你使用 MatrAIx、Persona 1M 資料集或本倉庫中的結果，請引用：
+
+```bibtex
+@article{li2026matraix,
+  title         = {MatrAIx: Simulating the World with 8.3 Billion Persona Agents},
+  author        = {Li, Xiaomin and Hao, Yuexing and Hou, Jianheng and Huang, Jintao
+                   and Wen, Qianfeng and Huang, Shirley and Liu, Yifan and Liu, Xiaoyi
+                   and Fan, Yilan and Wang, Yijun and others},
+  year          = {2026},
+  eprint        = {2608.04205},
+  archivePrefix = {arXiv},
+  primaryClass  = {cs.AI},
+  url           = {https://arxiv.org/abs/2608.04205}
+}
+```
+
+論文：[arXiv:2608.04205](https://arxiv.org/abs/2608.04205) ·
+完整作者名單：GitHub **Cite this repository**（`CITATION.cff`） ·
+資料集：[Persona 1M on Hugging Face](https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release)。
 
 ## 授權條款
 


### PR DESCRIPTION
## Summary
- Add a **Citation** section to the root README with BibTeX for [arXiv:2608.04205](https://arxiv.org/abs/2608.04205).
- Add `CITATION.cff` so GitHub can surface “Cite this repository”.

## Test plan
- [ ] README renders the BibTeX block correctly on GitHub
- [ ] Repository shows the citation from `CITATION.cff`


Made with [Cursor](https://cursor.com)