### PR TITLE
refactor(playground): shared cockpit launch assembly (useCockpitLaunch), phase 1 of #47

### DIFF
--- a/application/playground/frontend/src/components/cockpit/PlaygroundCockpit.tsx
+++ b/application/playground/frontend/src/components/cockpit/PlaygroundCockpit.tsx
@@ -33,11 +33,7 @@ import { OsAppEvalCockpit } from "./OsAppEvalCockpit";
 import { type PlaygroundTaskType } from "./TaskTypeSwitch";
 import { CockpitSetupShell } from "./setup/CockpitSetupShell";
 import { PersonaSamplingRail } from "./setup/PersonaSamplingRail";
-import {
-  buildPersonaLaunchFields,
-  hasLaunchableCohort,
-  resolveCohortSize,
-} from "./setup/personaLaunchFields";
+import { resolveCohortSize } from "./setup/personaLaunchFields";
 import { CockpitPipelineDiagram } from "./setup/CockpitPipelineDiagram";
 import { TaskSelectionRail, type ChatTransport, type TaskCardModel } from "./setup/TaskSelectionRail";
 import { BatchTrialGrid } from "./setup/BatchTrialGrid";
@@ -49,13 +45,12 @@ import {
   BATCH_RUN_COMPLETE_HINT,
   formatBatchProgressLabel,
   resolveRunLaunchPhase,
-  useCockpitBatchJob,
 } from "./setup/useCockpitBatchJob";
 import { readCockpitBatch } from "./setup/cockpitBatchStorage";
-import { useSetupPersonaSampling } from "./setup/useSetupPersonaSampling";
+import { useCockpitLaunch } from "./setup/useCockpitLaunch";
 import { useCockpitRunCancel } from "./setup/useCockpitRunCancel";
 import { useCockpitSetupLock } from "./setup/useCockpitSetupLock";
-import { api, ApiError } from "@/lib/api";
+import { api } from "@/lib/api";
 import { useHarborCockpitRun, type HarborCockpitPhase } from "@/lib/useHarborCockpitRun";
 import { useUrlState } from "@/lib/useUrlState";
 import { usePgTaskIdDeepLink } from "@/lib/usePgTaskIdDeepLink";
@@ -314,66 +309,71 @@ function ChatbotEvalCockpit({
   const setupTaskPath =
     chatbotTasks.find((task) => task.id === selectedTaskId)?.taskPath ?? null;
   const {
-    persona,
-    personaModel,
-    setPersonaModel,
-    personaModelOptions,
-    samplingMode,
-    setSamplingMode,
-    selectedPersonaIds,
-    setSelectedPersonaIds,
-    selectedCount,
-    setSelectedCount,
-    useEntirePool,
-    setUseEntirePool,
-    groupFilters,
-    setGroupFilters,
-    fields,
-    setFields,
-    stratifiedAllocation,
-    setStratifiedAllocation,
-    sampleSize,
-    setSampleSize,
-    perCell,
-    setPerCell,
-    seed,
-    parallelTrials,
-    setParallelTrials,
-    personaPool,
-    setPersonaPool,
-    isBatchRun,
-    hasTaskStrategy,
-    taskPersonaStrategy,
-    useTaskDefaultStrategy,
-    setUseTaskDefaultStrategy,
-  } = useSetupPersonaSampling(options, "chatbot", setupTaskPath, isActive);
+    sampling: {
+      persona,
+      personaModel,
+      setPersonaModel,
+      personaModelOptions,
+      samplingMode,
+      setSamplingMode,
+      selectedPersonaIds,
+      setSelectedPersonaIds,
+      selectedCount,
+      setSelectedCount,
+      useEntirePool,
+      setUseEntirePool,
+      groupFilters,
+      setGroupFilters,
+      fields,
+      setFields,
+      stratifiedAllocation,
+      setStratifiedAllocation,
+      sampleSize,
+      setSampleSize,
+      perCell,
+      setPerCell,
+      seed,
+      parallelTrials,
+      setParallelTrials,
+      personaPool,
+      setPersonaPool,
+      isBatchRun,
+      hasTaskStrategy,
+      taskPersonaStrategy,
+      useTaskDefaultStrategy,
+      setUseTaskDefaultStrategy,
+    },
+    batch: {
+      batchJobName,
+      batchTaskId,
+      batchPersonaIds,
+      batchPersonaPool,
+      clearBatch,
+      cancelBatch,
+      cancelBusy,
+      batchCancelled,
+      retryFailed,
+      retryBusy,
+      retryError,
+      failedTrials,
+      isBatchActive,
+      batchComplete,
+      batchGridCells,
+      completedTrials: batchCompletedTrials,
+      expectedTrialCount,
+      personaById,
+      batchError,
+    },
+    launchError,
+    setLaunchError,
+    clearLaunchError,
+    canLaunchCohort,
+    launchBatch,
+  } = useCockpitLaunch(options, "chatbot", setupTaskPath, isActive);
   const pipelinePersonaModelLabel = useMemo(
     () => personaModelPipelineLabel(personaModel, personaModelOptions),
     [personaModel, personaModelOptions],
   );
-  const [launchError, setLaunchError] = useState<string | null>(null);
-  const {
-    batchJobName,
-    batchTaskId,
-    batchPersonaIds,
-    batchPersonaPool,
-    setBatchJobName,
-    clearBatch,
-    cancelBatch,
-    cancelBusy,
-    batchCancelled,
-    retryFailed,
-    retryBusy,
-    retryError,
-    failedTrials,
-    isBatchActive,
-    batchComplete,
-    batchGridCells,
-    completedTrials: batchCompletedTrials,
-    expectedTrialCount,
-    personaById,
-    batchError,
-  } = useCockpitBatchJob(selectedPersonaIds, parallelTrials, "chatbot", selectedCount, personaPool);
   const [exportSnapshot, setExportSnapshot] = useState<ExportSnapshot | null>(null);
 
   // After navigating away/back, single-trial restore brings back the transcript
@@ -564,62 +564,35 @@ function ChatbotEvalCockpit({
   ]);
 
   const handleLaunch = useCallback(async () => {
-    if (
-      !hasLaunchableCohort({ selectedPersonaIds, selectedCount, useEntirePool }) ||
-      isRunning ||
-      !chatTaskPath ||
-      !selectedTask
-    ) {
+    if (!canLaunchCohort || isRunning || !chatTaskPath || !selectedTask) {
       return;
     }
     if (isBatchRun) {
-      setLaunchError(null);
-      try {
-        const personaFields = buildPersonaLaunchFields({
-          personaPool,
-          selectedPersonaIds,
-          selectedCount,
-          useEntirePool,
-          parallelTrials,
-        });
-        const launched = await api.launchHarborJob({
-          taskPath: chatTaskPath,
-          seed,
-          personaModel,
-          ...personaFields,
-          mode: "auto",
+      await launchBatch({
+        taskPath: chatTaskPath,
+        taskId: selectedTask.id,
+        overrides: {
           chatDomain: requestDomain,
           chatApplicationId: knownLaunchApplicationId ?? undefined,
           chatApplicationContext: launchChatApplicationContext,
           chatMaxTurns: maxTurns,
-        });
-        setBatchJobName(launched.jobName, { taskId: selectedTask.id, personaPool });
-      } catch (exc) {
-        const message = exc instanceof ApiError ? exc.message : exc instanceof Error ? exc.message : String(exc);
-        setLaunchError(message);
-      }
+        },
+      });
       return;
     }
     handleRun();
   }, [
-    selectedPersonaIds,
-    selectedCount,
-    useEntirePool,
+    canLaunchCohort,
     isRunning,
     isBatchRun,
-    applicationId,
-    seed,
-    personaModel,
-    parallelTrials,
-    personaPool,
     requestDomain,
     knownLaunchApplicationId,
     launchChatApplicationContext,
     maxTurns,
     chatTaskPath,
     selectedTask,
+    launchBatch,
     handleRun,
-    setBatchJobName,
   ]);
 
   const handleRetry = useCallback(() => {
@@ -630,10 +603,10 @@ function ChatbotEvalCockpit({
   const handleNewRun = useCallback(() => {
     reset();
     clearBatch();
-    setLaunchError(null);
+    clearLaunchError();
     setFocusedTurnIndex(null);
     setExpandedTurns(new Set());
-  }, [reset, clearBatch]);
+  }, [reset, clearBatch, clearLaunchError]);
 
   const { onCancelRun, cancelRunBusy } = useCockpitRunCancel({
     batchJobName,
@@ -932,7 +905,7 @@ function ChatbotEvalCockpit({
           )}
           <RunLaunchBar
             canRun={
-              hasLaunchableCohort({ selectedPersonaIds, selectedCount, useEntirePool }) &&
+              canLaunchCohort &&
               Boolean(chatTaskPath) &&
               !runBusy
             }

--- a/application/playground/frontend/src/components/cockpit/SurveyEvalCockpit.tsx
+++ b/application/playground/frontend/src/components/cockpit/SurveyEvalCockpit.tsx
@@ -19,7 +19,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
-import { listSurveyHarborTasks, api, ApiError } from "@/lib/api";
+import { listSurveyHarborTasks, api } from "@/lib/api";
 import { personaModelPipelineLabel } from "@/lib/personaAgentCatalog";
 import type {
   ConfigOptionsResponse,
@@ -56,21 +56,16 @@ import { InstructionPanel } from "./InstructionPanel";
 import { SurveyEvalScorecard } from "./TaskEvalScorecard";
 import { CockpitSetupShell } from "./setup/CockpitSetupShell";
 import { PersonaSamplingRail } from "./setup/PersonaSamplingRail";
-import {
-  buildPersonaLaunchFields,
-  hasLaunchableCohort,
-  resolveCohortSize,
-} from "./setup/personaLaunchFields";
+import { resolveCohortSize } from "./setup/personaLaunchFields";
 import { CockpitPipelineDiagram } from "./setup/CockpitPipelineDiagram";
 import { TaskSelectionRail } from "./setup/TaskSelectionRail";
 import { CockpitRunCenter } from "./setup/CockpitRunCenter";
-import { useSetupPersonaSampling } from "./setup/useSetupPersonaSampling";
+import { useCockpitLaunch } from "./setup/useCockpitLaunch";
 import {
   batchProgressPct as computeBatchProgressPct,
   BATCH_RUN_COMPLETE_HINT,
   formatBatchProgressLabel,
   resolveRunLaunchPhase,
-  useCockpitBatchJob,
 } from "./setup/useCockpitBatchJob";
 import { useCockpitRunCancel } from "./setup/useCockpitRunCancel";
 import { surveyHarborTaskCards } from "./setup/cockpitTaskCards";
@@ -173,7 +168,6 @@ export function SurveyEvalCockpit({
   const [selectedTaskId, setSelectedTaskId] = useState("");
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [tab, setTab] = useState<InspectorTab>("evaluation");
-  const [launchError, setLaunchError] = useState<string | null>(null);
   const [exportSnapshot, setExportSnapshot] = useState<{
     persona: { id: string; name: string; source: string } | null;
     taskId: string;
@@ -204,60 +198,66 @@ export function SurveyEvalCockpit({
     retry: 1,
   });
   const {
-    persona,
-    personaModel,
-    setPersonaModel,
-    personaModelOptions,
-    samplingMode,
-    setSamplingMode,
-    selectedPersonaIds,
-    setSelectedPersonaIds,
-    selectedCount,
-    setSelectedCount,
-    useEntirePool,
-    setUseEntirePool,
-    groupFilters,
-    setGroupFilters,
-    fields,
-    setFields,
-    stratifiedAllocation,
-    setStratifiedAllocation,
-    sampleSize,
-    setSampleSize,
-    perCell,
-    setPerCell,
-    seed,
-    parallelTrials,
-    setParallelTrials,
-    personaPool,
-    setPersonaPool,
-    isBatchRun,
-    hasTaskStrategy,
-    taskPersonaStrategy,
-    useTaskDefaultStrategy,
-    setUseTaskDefaultStrategy,
-  } = useSetupPersonaSampling(options, "survey", setupTaskPath, isActive);
-  const {
-    batchJobName,
-    batchTaskId,
-    batchPersonaIds,
-    batchPersonaPool,
-    setBatchJobName,
-    clearBatch,
-    cancelBatch,
-    cancelBusy,
-    batchCancelled,
-    retryFailed,
-    retryBusy,
-    retryError,
-    failedTrials,
-    isBatchActive,
-    batchComplete,
-    batchGridCells,
-    expectedTrialCount,
-    completedTrials: batchCompletedTrials,
-    batchError,
-  } = useCockpitBatchJob(selectedPersonaIds, parallelTrials, "survey", selectedCount, personaPool);
+    sampling: {
+      persona,
+      personaModel,
+      setPersonaModel,
+      personaModelOptions,
+      samplingMode,
+      setSamplingMode,
+      selectedPersonaIds,
+      setSelectedPersonaIds,
+      selectedCount,
+      setSelectedCount,
+      useEntirePool,
+      setUseEntirePool,
+      groupFilters,
+      setGroupFilters,
+      fields,
+      setFields,
+      stratifiedAllocation,
+      setStratifiedAllocation,
+      sampleSize,
+      setSampleSize,
+      perCell,
+      setPerCell,
+      seed,
+      parallelTrials,
+      setParallelTrials,
+      personaPool,
+      setPersonaPool,
+      isBatchRun,
+      hasTaskStrategy,
+      taskPersonaStrategy,
+      useTaskDefaultStrategy,
+      setUseTaskDefaultStrategy,
+    },
+    batch: {
+      batchJobName,
+      batchTaskId,
+      batchPersonaIds,
+      batchPersonaPool,
+      clearBatch,
+      cancelBatch,
+      cancelBusy,
+      batchCancelled,
+      retryFailed,
+      retryBusy,
+      retryError,
+      failedTrials,
+      isBatchActive,
+      batchComplete,
+      batchGridCells,
+      expectedTrialCount,
+      completedTrials: batchCompletedTrials,
+      batchError,
+    },
+    launchError,
+    setLaunchError,
+    clearLaunchError,
+    canLaunchCohort,
+    launchBatch,
+  } = useCockpitLaunch(options, "survey", setupTaskPath, isActive);
   const setupLocked = phase !== "idle" || Boolean(batchJobName);
   const visiblePersonaIds = setupLocked && batchPersonaIds.length > 0 ? batchPersonaIds : selectedPersonaIds;
   // Locked batches must read cards from the launch-time pool (cohort path);
@@ -384,58 +384,24 @@ export function SurveyEvalCockpit({
   }, [selectedCard, launchSurveyRun]);
 
   const handleLaunch = useCallback(async () => {
-    if (
-      !hasLaunchableCohort({ selectedPersonaIds, selectedCount, useEntirePool }) ||
-      !selectedCard ||
-      isRunning
-    ) {
+    if (!canLaunchCohort || !selectedCard || isRunning) {
       return;
     }
     if (isBatchRun) {
-      setLaunchError(null);
-      try {
-        const personaFields = buildPersonaLaunchFields({
-          personaPool,
-          selectedPersonaIds,
-          selectedCount,
-          useEntirePool,
-          parallelTrials,
-        });
-        const launched = await api.launchHarborJob({
-          taskPath: selectedCard.taskPath || HARBOR_TASK_PATHS.survey,
-          seed,
-          personaModel,
-          ...personaFields,
-          mode: "auto",
-        });
-        setBatchJobName(launched.jobName, { taskId: selectedCard.id, personaPool });
-      } catch (exc) {
-        const message = exc instanceof ApiError ? exc.message : exc instanceof Error ? exc.message : String(exc);
-        setLaunchError(message);
-      }
+      await launchBatch({
+        taskPath: selectedCard.taskPath || HARBOR_TASK_PATHS.survey,
+        taskId: selectedCard.id,
+      });
       return;
     }
     handleRun();
-  }, [
-    selectedPersonaIds,
-    selectedCount,
-    useEntirePool,
-    selectedCard,
-    isRunning,
-    isBatchRun,
-    seed,
-    personaModel,
-    parallelTrials,
-    personaPool,
-    handleRun,
-    setBatchJobName,
-  ]);
+  }, [canLaunchCohort, selectedCard, isRunning, isBatchRun, launchBatch, handleRun]);
 
   const handleNewRun = useCallback(() => {
     reset();
     clearBatch();
-    setLaunchError(null);
-  }, [reset, clearBatch]);
+    clearLaunchError();
+  }, [reset, clearBatch, clearLaunchError]);
 
   const { onCancelRun, cancelRunBusy } = useCockpitRunCancel({
     batchJobName,
@@ -621,7 +587,7 @@ export function SurveyEvalCockpit({
             batchJobName && batchComplete ? BATCH_RUN_COMPLETE_HINT : undefined
           }
           canRun={
-            hasLaunchableCohort({ selectedPersonaIds, selectedCount, useEntirePool }) &&
+            canLaunchCohort &&
             Boolean(selectedCard) &&
             !runBusy
           }

--- a/application/playground/frontend/src/components/cockpit/setup/useCockpitLaunch.ts
+++ b/application/playground/frontend/src/components/cockpit/setup/useCockpitLaunch.ts
@@ -1,0 +1,133 @@
+import { useCallback, useState } from "react";
+
+import { api, ApiError } from "@/lib/api";
+import type { HarborCockpitTaskKind } from "@/lib/harborCockpitMappers";
+import type { ConfigOptionsResponse } from "@/lib/types";
+
+import { buildPersonaLaunchFields, hasLaunchableCohort } from "./personaLaunchFields";
+import { useCockpitBatchJob } from "./useCockpitBatchJob";
+import { useSetupPersonaSampling } from "./useSetupPersonaSampling";
+
+type HarborLaunchBody = Parameters<typeof api.launchHarborJob>[0];
+
+/**
+ * Cockpit-specific launch extras. Everything a cockpit may add on top of the
+ * shared launch assembly; typed straight off the API client so the two can
+ * never drift.
+ */
+export type CockpitLaunchOverrides = Pick<
+  HarborLaunchBody,
+  | "mode"
+  | "agentName"
+  | "chatDomain"
+  | "chatApplicationId"
+  | "chatApplicationContext"
+  | "chatMaxTurns"
+  | "osAppSubmissionProfile"
+  | "osAppBackend"
+>;
+
+/**
+ * Shared launch assembly for the cockpits (#47).
+ *
+ * Owns everything every cockpit repeated by hand: the sampling + batch hook
+ * pair, the launch-error state, the launchable-cohort guard, and the batch
+ * launch call (persona fields, common body, batch record with the launch-time
+ * persona pool). Cockpit-specific launch fields go through `overrides`;
+ * debrief/live mappers and single-run wiring stay in the cockpits, which own
+ * their result shapes.
+ */
+export function useCockpitLaunch(
+  options: ConfigOptionsResponse | null,
+  taskKind: HarborCockpitTaskKind,
+  taskPath: string | null = null,
+  isActive = true,
+) {
+  const sampling = useSetupPersonaSampling(options, taskKind, taskPath, isActive);
+  const batch = useCockpitBatchJob(
+    sampling.selectedPersonaIds,
+    sampling.parallelTrials,
+    taskKind,
+    sampling.selectedCount,
+    sampling.personaPool,
+  );
+  const [launchError, setLaunchError] = useState<string | null>(null);
+
+  const canLaunchCohort = hasLaunchableCohort({
+    selectedPersonaIds: sampling.selectedPersonaIds,
+    selectedCount: sampling.selectedCount,
+    useEntirePool: sampling.useEntirePool,
+  });
+
+  const {
+    personaPool,
+    selectedPersonaIds,
+    selectedCount,
+    useEntirePool,
+    parallelTrials,
+    seed,
+    personaModel,
+  } = sampling;
+  const { setBatchJobName } = batch;
+
+  /**
+   * Launch a batch job for `taskPath` and record it against `taskId`.
+   * Resolves to true on success; on failure the message lands in
+   * `launchError` and the call resolves to false.
+   */
+  const launchBatch = useCallback(
+    async (input: {
+      taskPath: string;
+      taskId: string;
+      overrides?: CockpitLaunchOverrides;
+    }): Promise<boolean> => {
+      setLaunchError(null);
+      try {
+        const personaFields = buildPersonaLaunchFields({
+          personaPool,
+          selectedPersonaIds,
+          selectedCount,
+          useEntirePool,
+          parallelTrials,
+        });
+        const launched = await api.launchHarborJob({
+          taskPath: input.taskPath,
+          seed,
+          personaModel,
+          ...personaFields,
+          mode: "auto",
+          ...input.overrides,
+        });
+        setBatchJobName(launched.jobName, { taskId: input.taskId, personaPool });
+        return true;
+      } catch (exc) {
+        const message =
+          exc instanceof ApiError ? exc.message : exc instanceof Error ? exc.message : String(exc);
+        setLaunchError(message);
+        return false;
+      }
+    },
+    [
+      personaPool,
+      selectedPersonaIds,
+      selectedCount,
+      useEntirePool,
+      parallelTrials,
+      seed,
+      personaModel,
+      setBatchJobName,
+    ],
+  );
+
+  const clearLaunchError = useCallback(() => setLaunchError(null), []);
+
+  return {
+    sampling,
+    batch,
+    launchError,
+    setLaunchError,
+    clearLaunchError,
+    canLaunchCohort,
+    launchBatch,
+  };
+}


### PR DESCRIPTION
## What

Phase 1 of #47: extracts the launch assembly the cockpits repeated by hand into a shared `useCockpitLaunch(taskKind)` hook, and migrates the survey and chat cockpits to it. Web and os-app follow in phase 2.

The hook owns what every cockpit duplicated:

- the `useSetupPersonaSampling` + `useCockpitBatchJob` pairing (including threading the launch-time `personaPool` into the batch record, the #45 concern),
- the launch-error state and the launchable-cohort guard,
- `launchBatch({ taskPath, taskId, overrides })`: builds persona fields, posts the common launch body, records the batch with `taskId` + `personaPool`, and routes failures into `launchError`.

Per the boundaries agreed in #47:

- Cockpit-specific launch fields go through a typed `CockpitLaunchOverrides` (chat domain/application/max-turns, `agentName`, os-app fields), typed straight off the API client (`Pick<Parameters<typeof api.launchHarborJob>[0], ...>`) so the hook and the API can never drift.
- Debrief/live mappers and single-run wiring stay in the cockpits.

Behavior-preserving: no request field changes, no UI changes. Net -61 lines, and the next launch-shaped change lands in one file instead of four.

## Verified

- Frontend `tsc`: no new errors vs `main`.
- Live check against a running backend: survey batch launched through the new `launchBatch` completed 1/1 with 0 errors, with the batch record carrying `taskId` and the launch-time `personaPool`; the single-run path and reset/new-run flows exercised in the GUI.

## Phase 2

Migrating `WebEvalCockpit` and `OsAppEvalCockpit` (os-app already half-extracts its body via a local `harborLaunchBody` helper, which should fold into the same overrides) in a follow-up PR, as agreed.
