### PR TITLE
fix: write generate_dev_personas pools as selectable datasets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -256,8 +256,9 @@ persona/post_process/**/jobs/sbatch_logs/
 persona/curation/attribute_pool/outputs/
 persona/curation/attribute_pool/sources/acs_pums/*.csv
 persona/curation/attribute_pool/sources/raw/
-# Generated synthetic pools (bench-dev-2000, etc.). Checked-in fixture is
-# persona/datasets/matraix-persona-dev-sample/ (not matched by this pattern).
+# Local generate_dev_personas.py pools (Playground-selectable, not checked in).
+# Checked-in fixture is persona/datasets/matraix-persona-dev-sample/.
+persona/datasets/generated-persona-dev-*/
 persona/datasets/bench-dev-*/
 persona/datasets/_generated/
 # Launch caches next to a source dataset (dev sample, saved datasets, …).

--- a/application/playground/backend/tests/test_persona_pool_service.py
+++ b/application/playground/backend/tests/test_persona_pool_service.py
@@ -105,6 +105,12 @@ def test_list_datasets_includes_default_and_extras(tmp_path):
         json.dumps({"count": 1, "personas": [{"persona_id": "0001"}]}),
         encoding="utf-8",
     )
+    generated_dev = repo / "persona" / "datasets" / "generated-persona-dev-50"
+    generated_dev.mkdir(parents=True)
+    (generated_dev / "manifest.json").write_text(
+        json.dumps({"count": 50, "personas": []}),
+        encoding="utf-8",
+    )
     generated = repo / "persona" / "datasets" / "_generated" / "strategy-demo"
     generated.mkdir(parents=True)
     (generated / "manifest.json").write_text(
@@ -132,13 +138,15 @@ def test_list_datasets_includes_default_and_extras(tmp_path):
     assert listed[0]["default"] is True
     assert listed[0]["label"] == "matraix-persona-dev-sample"
     assert "persona/datasets/bench-dev-extra" in pools
-    # Legacy synthetic top-up pools are no longer listed.
+    assert "persona/datasets/generated-persona-dev-50" in pools
+    # Nested leftover `_generated/` dirs stay omitted from Dataset.
     assert "persona/datasets/_generated/strategy-demo" not in pools
     assert "persona/datasets/cohorts/ignore-me" not in pools
     # Production sample caches must not appear as Dataset sources.
     assert "persona/datasets/matraix-persona-1m/cohorts/cohort-deadbeef" not in pools
     by_pool = {item["pool"]: item for item in listed}
     assert by_pool["persona/datasets/bench-dev-extra"]["count"] == 1
+    assert by_pool["persona/datasets/generated-persona-dev-50"]["count"] == 50
     assert "persona/datasets/matraix-persona-1m" in by_pool
     assert by_pool["persona/datasets/matraix-persona-1m"]["kind"] == "production"
 

--- a/application/task-spec/docs/authoring-bundle.md
+++ b/application/task-spec/docs/authoring-bundle.md
@@ -147,5 +147,7 @@ undershoot it.
 3. Use a saved cohort under `persona/datasets/cohorts/` that already has enough
    personas.
 
-Playground / job launch **does not** auto-synthesize `_generated` pools. Thin
-coverage raises an error with the same recovery hint.
+Playground / job launch **does not** auto-synthesize local generated pools.
+Write a selectable pool with `generate_dev_personas.py` (default
+`persona/datasets/generated-persona-dev-<count>/`), or recover with the
+hints above. Thin coverage raises an error with the same recovery hint.

--- a/docs/persona/README.md
+++ b/docs/persona/README.md
@@ -189,7 +189,7 @@ Use `persona/datasets/matraix-persona-1m` for any Playground or job launch. This
 Generate lightweight offline cohorts:
 ```bash
 uv run python persona/scripts/generate_dev_personas.py
-# → persona/datasets/_generated/bench-dev-2000/
+# → persona/datasets/generated-persona-dev-2000/  (listed in Playground Dataset)
 ```
 
 Optional flags:
@@ -245,7 +245,7 @@ persona/
 │   └── eval_grounding_job.py        # Aggregate job-level metrics
 ├── datasets/
 │   ├── matraix-persona-1m/          # Public 1M coreset (HF mirror + indexes)
-│   └── _generated/                  # Local dev cohorts (gitignored)
+│   └── generated-persona-dev-*/     # Local generate_dev_personas output (gitignored)
 └── post_process/                    # Build pipeline: dedup, quality, calibration
     ├── coreset_1m/                  # 1M build, calibration, audit
     ├── deduplication/               # MinHash + contradiction detection

--- a/persona/scripts/generate_dev_personas.py
+++ b/persona/scripts/generate_dev_personas.py
@@ -34,14 +34,31 @@ from matraix.task_catalog import (
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_COUNT = 2000
-DEFAULT_GENERATED_DATASETS_DIR = REPO_ROOT / "persona" / "datasets" / "_generated"
+DATASETS_DIR = REPO_ROOT / "persona" / "datasets"
+DEFAULT_POOL_PREFIX = "generated-persona-dev"
+# Keep in sync with playground persona_pool_service._DATASETS_SKIP_TOP_LEVEL.
+_DATASETS_SKIP_TOP_LEVEL = frozenset(
+    {"_generated", "_sampled", "cohorts", "matraix-persona-1m"}
+)
 DEFAULT_STRATEGY_STRATUM_MIN = 2
 # Keep in sync with playground persona_pool_service.MAX_FILTER_STRATA.
 MAX_FILTER_STRATA = 2048
 
 
 def _default_out_dir(count: int) -> Path:
-    return DEFAULT_GENERATED_DATASETS_DIR / f"bench-dev-{count}"
+    return DATASETS_DIR / f"{DEFAULT_POOL_PREFIX}-{count}"
+
+
+def _strategy_out_dir(task_slug: str) -> Path:
+    return DATASETS_DIR / f"{DEFAULT_POOL_PREFIX}-strategy-{task_slug}"
+
+
+def _is_picker_listed(out: Path) -> bool:
+    try:
+        rel = out.resolve().relative_to(DATASETS_DIR.resolve())
+    except ValueError:
+        return False
+    return len(rel.parts) == 1 and rel.parts[0] not in _DATASETS_SKIP_TOP_LEVEL
 
 
 def _slug(value: str) -> str:
@@ -227,7 +244,11 @@ def main() -> None:
         "--out",
         type=Path,
         default=None,
-        help="Output directory (default: persona/datasets/_generated/...)",
+        help=(
+            "Output directory (default: "
+            f"persona/datasets/{DEFAULT_POOL_PREFIX}-<count>, listed in "
+            "the Playground Dataset picker)"
+        ),
     )
     parser.add_argument("--smoke-id", default="0042")
     parser.add_argument(
@@ -245,7 +266,8 @@ def main() -> None:
         help=(
             "Task persona_strategy.json (or task directory). Expands "
             "dimensionFilters into strata and tops up each cell under "
-            "persona/datasets/_generated/ (gitignored)."
+            f"persona/datasets/{DEFAULT_POOL_PREFIX}-strategy-<task>/ "
+            "(gitignored, listed in the Playground Dataset picker)."
         ),
     )
     parser.add_argument(
@@ -295,8 +317,7 @@ def main() -> None:
     if args.out is not None:
         out = args.out if args.out.is_absolute() else REPO_ROOT / args.out
     elif strategy_path is not None:
-        slug = _slug(strategy_path.parent.name)
-        out = DEFAULT_GENERATED_DATASETS_DIR / f"strategy-{slug}"
+        out = _strategy_out_dir(_slug(strategy_path.parent.name))
     else:
         out = _default_out_dir(count if count > 0 else DEFAULT_COUNT)
 
@@ -320,9 +341,9 @@ def main() -> None:
         raise SystemExit(f"{violations} personas failed consistency checks")
 
     kind = (
-        f"strategy-{_slug(strategy_path.parent.name)}"
+        f"{DEFAULT_POOL_PREFIX}-strategy-{_slug(strategy_path.parent.name)}"
         if strategy_path is not None
-        else f"bench-dev-{count if count > 0 else len(personas)}"
+        else f"{DEFAULT_POOL_PREFIX}-{count if count > 0 else len(personas)}"
     )
     manifest = write_persona_dataset(
         out_dir=out,
@@ -358,6 +379,13 @@ def main() -> None:
     print(
         f"Dimensions: {manifest.get('dimension_count', len(manifest['dimension_ids']))} fields"
     )
+    if _is_picker_listed(out):
+        print(f"Playground Dataset picker: {rel_out}")
+    else:
+        print(
+            "Not listed in the Playground Dataset picker "
+            f"(use --out persona/datasets/{DEFAULT_POOL_PREFIX}-<name>)."
+        )
     if stratum_top_up and args.task:
         print(
             f"Stratum top-up: {len(stratum_top_up)} cells × min {stratum_min} "
@@ -369,11 +397,8 @@ def main() -> None:
             f"from {strategy_path.relative_to(REPO_ROOT)}"
         )
         print("Next:")
-        print(
-            f'  1. Point persona_strategy.json "pool" at "{rel_out}" '
-            "(local only; _generated is gitignored),"
-        )
-        print("  2. Or pass that pool path in Playground / CLI sampling,")
+        print(f'  1. Point persona_strategy.json "pool" at "{rel_out}",')
+        print("  2. Or pick that pool in Playground / pass it to CLI sampling,")
         print("  3. Then sample — do this before Playground/CLI coverage failures.")
 
 


### PR DESCRIPTION
## Summary
- Default `generate_dev_personas.py` output is now `persona/datasets/generated-persona-dev-<count>/` (strategy: `generated-persona-dev-strategy-<task>/`) so Playground Dataset can list it.
- Nested `persona/datasets/_generated/` stays skipped; leftover `_generated` paths print a picker warning.
- Documents the new path and gitignores `generated-persona-dev-*`.

Closes #50.

## Test plan
- [ ] `uv run python persona/scripts/generate_dev_personas.py --count 50` writes `persona/datasets/generated-persona-dev-50/` and prints `Playground Dataset picker: ...`
- [ ] Playground Dataset dropdown lists `generated-persona-dev-50`
- [ ] `--out persona/datasets/_generated/tmp` still writes, but is not listed and prints the not-listed warning
- [ ] `uv run pytest application/playground/backend/tests/test_persona_pool_service.py::test_list_datasets_includes_default_and_extras -q`


Made with [Cursor](https://cursor.com)