### PR TITLE
feat(playground): persona sampling rail generate, strategy UX, and saved pools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -261,6 +261,10 @@ persona/curation/attribute_pool/sources/raw/
 persona/datasets/generated-persona-dev-*/
 persona/datasets/bench-dev-*/
 persona/datasets/_generated/
+# Playground “Save cohort” recipes/frozen sets (persona/datasets/saved-cohorts/<id>/).
+persona/datasets/saved-cohorts/
+# Legacy Save-cohort root (pre-rename); keep ignored if leftover locally.
+persona/datasets/cohorts/
 # Launch caches next to a source dataset (dev sample, saved datasets, …).
 persona/datasets/*/cohorts/
 # Production 1M release mirror + sampled cohorts (large / machine-local).

--- a/application/playground/backend/api/app.py
+++ b/application/playground/backend/api/app.py
@@ -1018,6 +1018,76 @@ def create_app(catalog_path: Optional[str] = None) -> FastAPI:
         except ValueError as exc:
             raise HTTPException(status_code=422, detail=str(exc)) from exc
 
+    @app.post(
+        "/api/persona-pool/generate",
+        response_model=None,
+        tags=["persona-pool"],
+    )
+    def generate_persona_pool(
+        body: schemas.PersonaPoolGenerateRequest,
+        services: AppState = Depends(get_services),
+        stream: bool = Query(
+            default=False,
+            description="When true, stream NDJSON progress events then a final result line.",
+        ),
+    ):
+        kwargs = dict(
+            count=body.count,
+            seed=body.seed,
+            dimension_filters=body.dimensionFilters,
+            stratify_fields=body.fields,
+            allocation=body.allocation,
+            per_cell=body.perCell,
+            sample_size=body.sampleSize,
+            task_path=body.taskPath,
+            name=body.name,
+        )
+        if not stream:
+            try:
+                return services.persona_pool.generate_synthetic_pool(**kwargs)
+            except FileNotFoundError as exc:
+                raise HTTPException(status_code=404, detail=str(exc)) from exc
+            except ValueError as exc:
+                raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+        import json
+        import queue
+        import threading
+
+        from starlette.responses import StreamingResponse
+
+        events: queue.Queue = queue.Queue()
+
+        def on_progress(event: Dict[str, Any]) -> None:
+            events.put(event)
+
+        def worker() -> None:
+            try:
+                result = services.persona_pool.generate_synthetic_pool(
+                    on_progress=on_progress,
+                    **kwargs,
+                )
+                events.put({"type": "result", **result})
+            except FileNotFoundError as exc:
+                events.put({"type": "error", "status": 404, "detail": str(exc)})
+            except ValueError as exc:
+                events.put({"type": "error", "status": 422, "detail": str(exc)})
+            except Exception as exc:  # noqa: BLE001 — surface to client stream
+                events.put({"type": "error", "status": 500, "detail": str(exc)})
+            finally:
+                events.put(None)
+
+        threading.Thread(target=worker, daemon=True).start()
+
+        def ndjson():
+            while True:
+                item = events.get()
+                if item is None:
+                    break
+                yield json.dumps(item, ensure_ascii=False) + "\n"
+
+        return StreamingResponse(ndjson(), media_type="application/x-ndjson")
+
     @app.get(
         "/api/persona-pool/personas",
         tags=["persona-pool"],

--- a/application/playground/backend/api/schemas.py
+++ b/application/playground/backend/api/schemas.py
@@ -921,6 +921,34 @@ class PersonaPoolSampleRequest(BaseModel):
     includePersonaIds: Optional[bool] = None
 
 
+class PersonaPoolGenerateRequest(BaseModel):
+    """Write a Full-DAG synthetic pool under ``persona/datasets/generated-persona-dev-*``."""
+
+    count: Optional[int] = None
+    seed: int = 42
+    dimensionFilters: Optional[Dict[str, Any]] = None
+    fields: Optional[List[str]] = None
+    perCell: Optional[int] = None
+    allocation: Optional[str] = None
+    sampleSize: Optional[int] = None
+    taskPath: Optional[str] = None
+    """When set, fill that task's ``persona_strategy.json`` (one-time synthesize)."""
+    name: Optional[str] = None
+
+
+class PersonaPoolGenerateResponse(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    pool: str
+    label: str
+    count: int
+    dimensionCount: int = 0
+    source: str = "synthetic"
+    kind: str = "dataset"
+    personaIds: List[str] = Field(default_factory=list)
+    seed: int = 42
+
+
 class TaskPersonaSampling(BaseModel):
     """Unified ``sampling`` block inside ``persona_strategy.json``."""
 

--- a/application/playground/backend/service/persona_pool_service.py
+++ b/application/playground/backend/service/persona_pool_service.py
@@ -10,7 +10,7 @@ import yaml
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Callable, Literal
 
 from matraix.persona_dimension_catalog import values_for_dimension
 from matraix.persona_job import (
@@ -33,10 +33,16 @@ PERSONA_CARD_DIMENSIONS = (
 
 DEFAULT_PERSONA_POOL = "persona/datasets/matraix-persona-dev-sample"
 DATASETS_DIR = "persona/datasets"
-COHORTS_DIR = "persona/datasets/cohorts"
+COHORTS_DIR = "persona/datasets/saved-cohorts"
 # Top-level dirs under persona/datasets that are not selectable pools.
 _DATASETS_SKIP_TOP_LEVEL = frozenset(
-    {"_generated", "_sampled", "cohorts", "matraix-persona-1m"}
+    {
+        "_generated",
+        "_sampled",
+        "cohorts",  # legacy Save-cohort root; superseded by saved-cohorts
+        "saved-cohorts",
+        "matraix-persona-1m",
+    }
 )
 # Names that cannot be used when saving a pool as a named dataset.
 _RESERVED_DATASET_SLUGS = frozenset(
@@ -44,6 +50,7 @@ _RESERVED_DATASET_SLUGS = frozenset(
         "_generated",
         "_sampled",
         "cohorts",
+        "saved-cohorts",
         "matraix-persona-1m",
         "matraix-persona-dev-sample",
     }
@@ -54,17 +61,24 @@ MAX_FILTER_STRATA = 2048
 # UI keeps a full personaId list only at or below this size; larger cohorts are ref-based.
 PERSONA_UI_ID_LIST_MAX = 100
 PERSONA_CARD_PREVIEW_DEFAULT = 32
+GENERATE_COUNT_DEFAULT = 2000
+GENERATE_COUNT_MAX = 5000
+GENERATED_POOL_PREFIX = "generated-persona-dev"
 CohortKind = Literal["recipe", "frozen"]
 
 
 def coverage_recovery_hint(*, task_path: str | None = None) -> str:
-    """Hint when a dataset cannot satisfy filters — never synthesize personas."""
-    _ = task_path
+    """Hint when a dataset cannot satisfy the current (task) filters."""
+    synthesize = (
+        " With Task default persona strategy on, you can also Synthesize to fill this task."
+        if task_path
+        else ""
+    )
     return (
         "Not enough matching personas in this dataset for the current filters. "
-        "Widen filters / sources, switch dataset (dev sample vs matraix-persona-1m), "
-        "or use a saved cohort that already has enough matches. "
-        "Playground does not synthesize missing personas."
+        "Consider switching Dataset to matraix-persona-1m for fuller coverage."
+        + synthesize
+        + " Or widen filters / sources, or use a saved cohort that already has enough matches."
     )
 
 
@@ -393,6 +407,17 @@ class PersonaPoolService:
         except OSError:
             return 0
 
+    def _manifest_dataset_kind(self, path: Path) -> str | None:
+        manifest_path = path / "manifest.json"
+        if not manifest_path.is_file():
+            return None
+        try:
+            raw = self._read_json(manifest_path)
+        except Exception:  # noqa: BLE001
+            return None
+        kind = str(raw.get("kind") or "").strip()
+        return kind or None
+
     def _dataset_entry(self, *, pool: str, label: str, kind: str, path: Path) -> dict[str, Any]:
         return {
             "pool": pool,
@@ -424,8 +449,15 @@ class PersonaPoolService:
                 if not self._is_persona_dataset_dir(child):
                     continue
                 pool = f"{DATASETS_DIR}/{child.name}"
+                manifest_kind = self._manifest_dataset_kind(child)
+                # Promote Save-as-dataset pools so the UI can default sampling to All.
+                kind = (
+                    "saved"
+                    if manifest_kind == "saved-persona-dataset"
+                    else "dataset"
+                )
                 by_pool[pool] = self._dataset_entry(
-                    pool=pool, label=child.name, kind="dataset", path=child
+                    pool=pool, label=child.name, kind=kind, path=child
                 )
 
             # Intentionally omit matraix-persona-1m/cohorts/* from Dataset.
@@ -450,8 +482,9 @@ class PersonaPoolService:
             key=lambda item: (
                 0 if item["default"] else
                 1 if item.get("kind") == "production" else
-                2 if item.get("kind") == "dataset" else
-                3,
+                2 if item.get("kind") == "saved" else
+                3 if item.get("kind") == "dataset" else
+                4,
                 str(item["label"]).lower(),
             ),
         )
@@ -579,6 +612,225 @@ class PersonaPoolService:
             "count": manifest["count"],
             "sourcePool": src_rel,
             "kind": "dataset",
+        }
+
+    def generate_synthetic_pool(
+        self,
+        *,
+        count: int | None = None,
+        seed: int = 42,
+        dimension_filters: dict[str, str | list[str]] | None = None,
+        stratify_fields: list[str] | None = None,
+        allocation: str | None = None,
+        per_cell: int | None = None,
+        sample_size: int | None = None,
+        task_path: str | None = None,
+        name: str | None = None,
+        on_progress: Callable[[dict[str, Any]], None] | None = None,
+    ) -> dict[str, Any]:
+        """Write a Full-DAG synthetic pool under ``persona/datasets/generated-persona-dev-*``.
+
+        ``task_path`` loads that task's ``persona_strategy.json`` (one-time fill).
+        Otherwise this is a custom Generation draw (plain ``count`` or stratified).
+
+        ``on_progress`` receives NDJSON-friendly events::
+            ``{"type":"progress","stage":...,"ratio":0..1,"label":...}``.
+        """
+        from matraix.persona_generator import (
+            generate_persona_pool,
+            stratified_cell_quota,
+            strategy_pin_cells,
+            write_persona_dataset,
+        )
+
+        def emit(
+            stage: str,
+            *,
+            ratio: float,
+            label: str,
+            done: int | None = None,
+            total: int | None = None,
+        ) -> None:
+            if on_progress is None:
+                return
+            payload: dict[str, Any] = {
+                "type": "progress",
+                "stage": stage,
+                "ratio": max(0.0, min(1.0, float(ratio))),
+                "label": label,
+            }
+            if done is not None:
+                payload["done"] = int(done)
+            if total is not None:
+                payload["total"] = int(total)
+            on_progress(payload)
+
+        filters = self._filters_as_lists(self._normalize_dimension_filters(dimension_filters))
+        fields = [
+            str(field).removeprefix("dimensions.").strip()
+            for field in (stratify_fields or [])
+            if str(field).strip()
+        ]
+        alloc = str(allocation or "").strip() or None
+        per_cell_n = per_cell if isinstance(per_cell, int) and per_cell >= 1 else None
+        sample_n = sample_size if isinstance(sample_size, int) and sample_size >= 1 else None
+        kind_slug = _cohort_slug(name) if name and str(name).strip() else None
+
+        if task_path and str(task_path).strip():
+            from backend.service.task_persona_strategy_service import (
+                get_task_persona_strategy,
+            )
+
+            strategy = get_task_persona_strategy(task_path, repo_root=self.repo_root)
+            if not strategy:
+                raise ValueError(f"{task_path}: no persona_strategy.json")
+            filters = {
+                str(key): list(values)
+                for key, values in (strategy.get("dimensionFilters") or {}).items()
+                if isinstance(values, list) and values
+            }
+            if not filters:
+                raise ValueError(f"{task_path}: persona_strategy.json has no dimensionFilters")
+            sampling = strategy.get("sampling") if isinstance(strategy.get("sampling"), dict) else {}
+            fields = [
+                str(field).removeprefix("dimensions.").strip()
+                for field in (sampling.get("fields") or [])
+                if str(field).strip()
+            ]
+            alloc = str(sampling.get("allocation") or "").strip() or None
+            per_cell_n = (
+                sampling.get("perCell")
+                if isinstance(sampling.get("perCell"), int)
+                else None
+            )
+            sample_n = (
+                sampling.get("sampleSize")
+                if isinstance(sampling.get("sampleSize"), int)
+                else None
+            )
+            if isinstance(strategy.get("seed"), int):
+                seed = int(strategy["seed"])
+            task_slug = _cohort_slug(Path(str(task_path).strip()).name)
+            kind_slug = kind_slug or f"strategy-{task_slug}"
+
+        missing = [field for field in fields if field not in filters]
+        if missing:
+            raise ValueError(
+                "every sampling.fields entry must also appear in dimensionFilters "
+                f"(missing: {', '.join(missing)})"
+            )
+
+        stratum_top_up: list[dict[str, str]] | None = None
+        min_per_stratum = 0
+        pool_count = 0
+        pin_cells = bool(task_path) or bool(fields) or bool(filters and alloc)
+        if pin_cells:
+            if not filters:
+                raise ValueError("stratified generation requires dimensionFilters")
+            cells, dropped = strategy_pin_cells(
+                dimension_filters=filters,
+                stratify_fields=fields,
+                seed=seed,
+                max_strata=MAX_FILTER_STRATA,
+            )
+            del dropped
+            if not cells:
+                raise ValueError("dimensionFilters produced zero cells the DAG can pin")
+            min_per_stratum = stratified_cell_quota(
+                allocation=alloc,
+                per_cell=per_cell_n,
+                sample_size=sample_n,
+                n_cells=len(cells),
+            )
+            estimated = len(cells) * min_per_stratum
+            if estimated > GENERATE_COUNT_MAX:
+                raise ValueError(
+                    f"stratified generation would write {estimated} personas "
+                    f"(max {GENERATE_COUNT_MAX})"
+                )
+            stratum_top_up = cells
+            pool_count = 0
+        else:
+            pool_count = GENERATE_COUNT_DEFAULT if count is None else int(count)
+            if pool_count < 1:
+                raise ValueError("count must be >= 1")
+            if pool_count > GENERATE_COUNT_MAX:
+                raise ValueError(f"count must be <= {GENERATE_COUNT_MAX}")
+
+        if not kind_slug:
+            kind_slug = str(pool_count if pool_count > 0 else "stratified")
+        folder = f"{GENERATED_POOL_PREFIX}-{kind_slug}"
+        rel_pool = f"{DATASETS_DIR}/{folder}"
+        out_dir = self.repo_root / rel_pool
+
+        emit("prepare", ratio=0.02, label="Preparing output folder…")
+        if out_dir.exists():
+            for stale in out_dir.glob("persona_*.yaml"):
+                stale.unlink()
+
+        emit(
+            "sample",
+            ratio=0.08,
+            label=(
+                f"Sampling Full DAG ({pool_count} personas)…"
+                if pool_count > 0
+                else "Sampling stratified cells…"
+            ),
+        )
+        personas = generate_persona_pool(
+            count=pool_count,
+            seed=seed,
+            stratum_top_up=stratum_top_up,
+            min_per_stratum=min_per_stratum,
+            include_smoke=pool_count > 0,
+        )
+        if not personas:
+            raise ValueError("generation produced no personas")
+        emit(
+            "sample",
+            ratio=0.18,
+            label=f"Sampled {len(personas)} personas",
+            done=len(personas),
+            total=len(personas),
+        )
+
+        def _write_progress(stage: str, payload: dict[str, Any]) -> None:
+            if stage == "write":
+                done = int(payload.get("done") or 0)
+                total = max(1, int(payload.get("total") or 1))
+                # Write dominates wall time — map 18% → 90%.
+                ratio = 0.18 + 0.72 * (done / total)
+                emit(
+                    "write",
+                    ratio=ratio,
+                    label=str(payload.get("label") or "Writing personas…"),
+                    done=done,
+                    total=total,
+                )
+                return
+            if stage == "manifest":
+                emit("manifest", ratio=0.92, label=str(payload.get("label") or "Writing manifest…"))
+
+        manifest = write_persona_dataset(
+            out_dir=out_dir,
+            personas=personas,
+            repo_root=self.repo_root,
+            kind=folder,
+            seed=seed,
+            smoke_persona_id="0042",
+            on_progress=_write_progress if on_progress is not None else None,
+        )
+        emit("done", ratio=1.0, label=f"Generated {int(manifest['count'])} personas")
+        persona_ids = [str(entry["persona_id"]) for entry in personas]
+        return {
+            "pool": rel_pool,
+            "label": folder,
+            "count": int(manifest["count"]),
+            "dimensionCount": int(manifest.get("dimension_count") or 0),
+            "source": "synthetic",
+            "kind": "dataset",
+            "personaIds": persona_ids,
+            "seed": seed,
         }
 
     def _normalize_dimension_filters(

--- a/application/playground/backend/tests/test_persona_pool_service.py
+++ b/application/playground/backend/tests/test_persona_pool_service.py
@@ -117,8 +117,10 @@ def test_list_datasets_includes_default_and_extras(tmp_path):
         json.dumps({"count": 3, "personas": []}),
         encoding="utf-8",
     )
-    (repo / "persona" / "datasets" / "cohorts" / "ignore-me").mkdir(parents=True)
-    (repo / "persona" / "datasets" / "cohorts" / "ignore-me" / "manifest.json").write_text(
+    (repo / "persona" / "datasets" / "saved-cohorts" / "ignore-me").mkdir(parents=True)
+    (
+        repo / "persona" / "datasets" / "saved-cohorts" / "ignore-me" / "manifest.json"
+    ).write_text(
         "{}",
         encoding="utf-8",
     )
@@ -141,7 +143,7 @@ def test_list_datasets_includes_default_and_extras(tmp_path):
     assert "persona/datasets/generated-persona-dev-50" in pools
     # Nested leftover `_generated/` dirs stay omitted from Dataset.
     assert "persona/datasets/_generated/strategy-demo" not in pools
-    assert "persona/datasets/cohorts/ignore-me" not in pools
+    assert "persona/datasets/saved-cohorts/ignore-me" not in pools
     # Production sample caches must not appear as Dataset sources.
     assert "persona/datasets/matraix-persona-1m/cohorts/cohort-deadbeef" not in pools
     by_pool = {item["pool"]: item for item in listed}
@@ -200,8 +202,9 @@ def test_save_pool_as_dataset(tmp_path):
         "persona/datasets/my-robinhood-cohort/"
     )
 
-    listed = {item["pool"] for item in service.list_datasets()}
+    listed = {item["pool"]: item for item in service.list_datasets()}
     assert "persona/datasets/my-robinhood-cohort" in listed
+    assert listed["persona/datasets/my-robinhood-cohort"]["kind"] == "saved"
 
     with pytest.raises(FileExistsError):
         service.save_pool_as_dataset(
@@ -266,7 +269,9 @@ def test_save_list_and_resolve_cohort(tmp_path, monkeypatch):
         dimension_filters={"economic_motivation": "Price-sensitive"},
     )
     assert saved["cohortId"] == "nemotron-price-sensitive"
-    assert (repo / "persona/datasets/cohorts/nemotron-price-sensitive/cohort.json").is_file()
+    assert (
+        repo / "persona/datasets/saved-cohorts/nemotron-price-sensitive/cohort.json"
+    ).is_file()
 
     listed = service.list_cohorts()
     assert len(listed) == 1
@@ -714,3 +719,113 @@ def test_list_persona_ids_truncates_over_ui_max(tmp_path, monkeypatch):
     assert listed["count"] == 120
     assert listed["idsTruncated"] is True
     assert len(listed["personaIds"]) <= 32
+
+
+def test_coverage_recovery_hint_mentions_synthesize_when_task_path():
+    from backend.service.persona_pool_service import coverage_recovery_hint
+
+    plain = coverage_recovery_hint()
+    assert "Not enough matching personas" in plain
+    assert "matraix-persona-1m" in plain
+    assert "does not synthesize" not in plain
+    tasked = coverage_recovery_hint(task_path="application/tasks/demo")
+    assert "matraix-persona-1m" in tasked
+    assert "Synthesize to fill this task" in tasked
+
+
+def _fake_generated_persona(persona_id: str = "0001") -> dict:
+    return {
+        "persona_id": persona_id,
+        "version": "1.0",
+        "source": "synthetic",
+        "dimensions": {"age_bracket": "25-34"},
+    }
+
+
+def test_generate_synthetic_pool_random_count(tmp_path, monkeypatch):
+    _write_pool(tmp_path)
+    service = PersonaPoolService(repo_root=tmp_path)
+
+    def fake_generate(**kwargs):
+        assert kwargs["count"] == 2
+        assert kwargs["stratum_top_up"] is None
+        return [_fake_generated_persona("0001"), _fake_generated_persona("0002")]
+
+    monkeypatch.setattr(
+        "matraix.persona_generator.generate_persona_pool",
+        fake_generate,
+    )
+    result = service.generate_synthetic_pool(count=2, seed=7)
+    assert result["pool"] == "persona/datasets/generated-persona-dev-2"
+    assert result["count"] == 2
+    assert result["source"] == "synthetic"
+    assert result["personaIds"] == ["0001", "0002"]
+    dest = tmp_path / "persona/datasets/generated-persona-dev-2"
+    assert (dest / "persona_0001.yaml").is_file()
+    assert (dest / "manifest.json").is_file()
+
+
+def test_generate_synthetic_pool_rejects_over_max(tmp_path):
+    _write_pool(tmp_path)
+    service = PersonaPoolService(repo_root=tmp_path)
+    with pytest.raises(ValueError, match="count must be <="):
+        service.generate_synthetic_pool(count=5001)
+
+
+def test_generate_synthetic_pool_stratified(tmp_path, monkeypatch):
+    _write_pool(tmp_path)
+    service = PersonaPoolService(repo_root=tmp_path)
+    monkeypatch.setattr(
+        "matraix.persona_generator.strategy_pin_cells",
+        lambda **kwargs: ([{"age_bracket": "25-34"}], []),
+    )
+    monkeypatch.setattr(
+        "matraix.persona_generator.generate_persona_pool",
+        lambda **kwargs: (
+            [_fake_generated_persona("0001"), _fake_generated_persona("0002")]
+            if kwargs["min_per_stratum"] == 2
+            else []
+        ),
+    )
+    result = service.generate_synthetic_pool(
+        dimension_filters={"age_bracket": ["25-34"]},
+        stratify_fields=["age_bracket"],
+        allocation="perCell",
+        per_cell=2,
+        seed=1,
+    )
+    assert result["pool"] == "persona/datasets/generated-persona-dev-stratified"
+    assert result["count"] == 2
+
+
+def test_generate_synthetic_pool_from_task_strategy(tmp_path, monkeypatch):
+    _write_pool(tmp_path)
+    task_dir = tmp_path / "application" / "tasks" / "demo-task"
+    task_dir.mkdir(parents=True)
+    (task_dir / "persona_strategy.json").write_text(
+        json.dumps(
+            {
+                "schemaVersion": "1.0",
+                "dimensionFilters": {"age_bracket": ["25-34"]},
+                "sampling": {
+                    "mode": "stratified",
+                    "fields": ["age_bracket"],
+                    "allocation": "perCell",
+                    "perCell": 2,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    service = PersonaPoolService(repo_root=tmp_path)
+    monkeypatch.setattr(
+        "matraix.persona_generator.strategy_pin_cells",
+        lambda **kwargs: ([{"age_bracket": "25-34"}], []),
+    )
+    monkeypatch.setattr(
+        "matraix.persona_generator.generate_persona_pool",
+        lambda **kwargs: [_fake_generated_persona("0001"), _fake_generated_persona("0002")],
+    )
+    result = service.generate_synthetic_pool(task_path="application/tasks/demo-task")
+    assert result["pool"] == "persona/datasets/generated-persona-dev-strategy-demo-task"
+    assert result["count"] == 2

--- a/application/playground/frontend/scripts/cohort-ref-contract.test.mjs
+++ b/application/playground/frontend/scripts/cohort-ref-contract.test.mjs
@@ -22,8 +22,10 @@ test("PERSONA_UI_ID_LIST_MAX is 100", () => {
 test("Save as dataset is offered for both 1M and dev sample launch caches", () => {
   const rail = read("src/components/cockpit/setup/PersonaSamplingRail.tsx");
   assert.match(rail, /isMaterializedCohortPool/);
+  assert.match(rail, /isGeneratedDevPool/);
   assert.match(rail, /parentDatasetFromCohortPool/);
   assert.match(rail, /canSaveAsDataset/);
+  assert.match(rail, /Synthesize to fill this task/);
 });
 
 test("storage persists selectedCount / useEntirePool without giant ID arrays", () => {

--- a/application/playground/frontend/src/components/cockpit/OsAppEvalCockpit.tsx
+++ b/application/playground/frontend/src/components/cockpit/OsAppEvalCockpit.tsx
@@ -179,6 +179,7 @@ export function OsAppEvalCockpit({
     clearBatch,
     cancelBatch,
     cancelBusy,
+    batchCancelled,
     retryFailed,
     retryBusy,
     retryError,
@@ -427,10 +428,11 @@ export function OsAppEvalCockpit({
     batchComplete,
     batchError,
     phase,
+    batchCancelled,
   );
   const runProgressPct = batchJobName
     ? computeBatchProgressPct(batchJobName, batchCompletedTrials, expectedTrialCount)
-    : phase === "done"
+    : phase === "done" || phase === "error" || phase === "timeout"
       ? 100
       : phase === "launching"
         ? 12
@@ -440,10 +442,12 @@ export function OsAppEvalCockpit({
             ? 20
             : 0;
   const runProgressLabel = batchJobName
-    ? formatBatchProgressLabel(
-        batchCompletedTrials,
-        expectedTrialCount,
-      )
+    ? batchCancelled
+      ? "Batch stopped"
+      : formatBatchProgressLabel(
+          batchCompletedTrials,
+          expectedTrialCount,
+        )
     : phase === "launching"
       ? "Launching OS app trial…"
       : phase === "running"
@@ -453,7 +457,9 @@ export function OsAppEvalCockpit({
         : phase === "done"
           ? `OS app complete · ${stepCount} steps`
           : failed
-            ? "OS app trial failed"
+            ? error?.startsWith("Run stopped")
+              ? "Run stopped"
+              : "OS app trial failed"
             : undefined;
   const canExport = exportSnapshot !== null && osAppResult !== null;
 
@@ -568,7 +574,9 @@ export function OsAppEvalCockpit({
           }
           onDownload={!batchJobName ? handleExport : undefined}
           canDownload={canExport}
-          onRetryFailed={batchJobName ? () => void retryFailed() : undefined}
+          onRetryFailed={
+            batchJobName && !batchCancelled ? () => void retryFailed() : undefined
+          }
           failedCount={failedTrials}
           retryBusy={retryBusy}
         />

--- a/application/playground/frontend/src/components/cockpit/PersonaGroupBuilder.tsx
+++ b/application/playground/frontend/src/components/cockpit/PersonaGroupBuilder.tsx
@@ -241,7 +241,7 @@ export function PersonaGroupBuilder({
               onClick={() => saveMutation.mutate()}
               className={`h-8 rounded-md bg-primary px-3 text-[13px] text-on-primary disabled:opacity-55 ${FOCUS_RING}`}
             >
-              {saveMutation.isPending ? "Saving…" : "Save to persona/datasets/cohorts/"}
+              {saveMutation.isPending ? "Saving…" : "Save to persona/datasets/saved-cohorts/"}
             </button>
           </div>
           {saveError && <p className="text-[13px] text-danger sm:col-span-2">{saveError}</p>}

--- a/application/playground/frontend/src/components/cockpit/PlaygroundCockpit.tsx
+++ b/application/playground/frontend/src/components/cockpit/PlaygroundCockpit.tsx
@@ -361,6 +361,7 @@ function ChatbotEvalCockpit({
     clearBatch,
     cancelBatch,
     cancelBusy,
+    batchCancelled,
     retryFailed,
     retryBusy,
     retryError,
@@ -795,14 +796,24 @@ function ChatbotEvalCockpit({
     batchComplete,
     batchError,
     phase,
+    batchCancelled,
   );
 
   const runProgressPct = batchJobName
-    ? computeBatchProgressPct(
-        batchJobName,
-        batchCompletedTrials,
-        expectedTrialCount,
-      )
+    ? batchCancelled
+      ? Math.max(
+          0,
+          computeBatchProgressPct(
+            batchJobName,
+            batchCompletedTrials,
+            expectedTrialCount,
+          ),
+        )
+      : computeBatchProgressPct(
+          batchJobName,
+          batchCompletedTrials,
+          expectedTrialCount,
+        )
     : pipelinePhase === "done"
       ? 100
       : pipelinePhase === "building"
@@ -811,13 +822,17 @@ function ChatbotEvalCockpit({
           ? maxTurns !== null
             ? Math.min(100, Math.round((turns.length / Math.max(1, maxTurns)) * 100))
             : Math.min(92, 18 + turns.length * 14)
-          : 0;
+          : pipelinePhase === "error" || pipelinePhase === "timeout"
+            ? 100
+            : 0;
 
   const runProgressLabel = batchJobName
-    ? formatBatchProgressLabel(
-        batchCompletedTrials,
-        expectedTrialCount,
-      )
+    ? batchCancelled
+      ? "Batch stopped"
+      : formatBatchProgressLabel(
+          batchCompletedTrials,
+          expectedTrialCount,
+        )
     : pipelinePhase === "building"
       ? "Starting the app…"
       : pipelinePhase === "running"
@@ -827,7 +842,9 @@ function ChatbotEvalCockpit({
         : pipelinePhase === "done"
           ? `Run complete · ${turns.length} turn${turns.length === 1 ? "" : "s"}`
           : pipelinePhase === "error" || pipelinePhase === "timeout"
-            ? error ?? "The run stopped before completing."
+            ? error?.startsWith("Run stopped")
+              ? "Run stopped"
+              : error ?? "The run stopped before completing."
             : undefined;
 
   const cockpitView = (
@@ -947,7 +964,9 @@ function ChatbotEvalCockpit({
             }
             onDownload={!batchJobName ? handleExport : undefined}
             canDownload={canExport}
-            onRetryFailed={batchJobName ? () => void retryFailed() : undefined}
+            onRetryFailed={
+              batchJobName && !batchCancelled ? () => void retryFailed() : undefined
+            }
             failedCount={failedTrials}
             retryBusy={retryBusy}
           />

--- a/application/playground/frontend/src/components/cockpit/SurveyEvalCockpit.tsx
+++ b/application/playground/frontend/src/components/cockpit/SurveyEvalCockpit.tsx
@@ -246,6 +246,7 @@ export function SurveyEvalCockpit({
     clearBatch,
     cancelBatch,
     cancelBusy,
+    batchCancelled,
     retryFailed,
     retryBusy,
     retryError,
@@ -506,10 +507,11 @@ export function SurveyEvalCockpit({
     batchComplete,
     batchError,
     phase,
+    batchCancelled,
   );
   const runProgressPct = batchJobName
     ? computeBatchProgressPct(batchJobName, batchCompletedTrials, expectedTrialCount)
-    : phase === "done"
+    : phase === "done" || phase === "error" || phase === "timeout"
       ? 100
       : phase === "launching"
         ? 12
@@ -519,10 +521,12 @@ export function SurveyEvalCockpit({
             ? 20
             : 0;
   const runProgressLabel = batchJobName
-    ? formatBatchProgressLabel(
-        batchCompletedTrials,
-        expectedTrialCount,
-      )
+    ? batchCancelled
+      ? "Batch stopped"
+      : formatBatchProgressLabel(
+          batchCompletedTrials,
+          expectedTrialCount,
+        )
     : phase === "launching"
       ? "Launching survey trial…"
       : phase === "running"
@@ -532,7 +536,9 @@ export function SurveyEvalCockpit({
         : phase === "done"
           ? `Survey complete · ${questionAnswered} answers`
           : failed
-            ? error ?? "The questionnaire didn't finish."
+            ? error?.startsWith("Run stopped")
+              ? "Run stopped"
+              : error ?? "The questionnaire didn't finish."
             : undefined;
   const canExport = exportSnapshot !== null && surveyResult !== null;
 
@@ -641,7 +647,9 @@ export function SurveyEvalCockpit({
           }
           onDownload={!batchJobName ? handleExport : undefined}
           canDownload={canExport}
-          onRetryFailed={batchJobName ? () => void retryFailed() : undefined}
+          onRetryFailed={
+            batchJobName && !batchCancelled ? () => void retryFailed() : undefined
+          }
           failedCount={failedTrials}
           retryBusy={retryBusy}
         />

--- a/application/playground/frontend/src/components/cockpit/WebEvalCockpit.tsx
+++ b/application/playground/frontend/src/components/cockpit/WebEvalCockpit.tsx
@@ -200,6 +200,7 @@ export function WebEvalCockpit({
     clearBatch,
     cancelBatch,
     cancelBusy,
+    batchCancelled,
     retryFailed,
     retryBusy,
     retryError,
@@ -455,10 +456,11 @@ export function WebEvalCockpit({
     batchComplete,
     batchError,
     phase,
+    batchCancelled,
   );
   const runProgressPct = batchJobName
     ? computeBatchProgressPct(batchJobName, batchCompletedTrials, expectedTrialCount)
-    : phase === "done"
+    : phase === "done" || phase === "error" || phase === "timeout"
       ? 100
       : phase === "launching"
         ? 12
@@ -468,10 +470,12 @@ export function WebEvalCockpit({
             ? 20
             : 0;
   const runProgressLabel = batchJobName
-    ? formatBatchProgressLabel(
-        batchCompletedTrials,
-        expectedTrialCount,
-      )
+    ? batchCancelled
+      ? "Batch stopped"
+      : formatBatchProgressLabel(
+          batchCompletedTrials,
+          expectedTrialCount,
+        )
     : phase === "launching"
       ? "Launching web trial…"
       : phase === "running"
@@ -481,7 +485,9 @@ export function WebEvalCockpit({
         : phase === "done"
           ? `Web run complete · ${stepCount} steps`
           : failed
-            ? displayError ?? "The website test didn't finish."
+            ? error?.startsWith("Run stopped")
+              ? "Run stopped"
+              : displayError ?? "The website test didn't finish."
             : undefined;
   const canExport = exportSnapshot !== null && webResult !== null;
 
@@ -595,7 +601,9 @@ export function WebEvalCockpit({
           }
           onDownload={!batchJobName ? handleExport : undefined}
           canDownload={canExport}
-          onRetryFailed={batchJobName ? () => void retryFailed() : undefined}
+          onRetryFailed={
+            batchJobName && !batchCancelled ? () => void retryFailed() : undefined
+          }
           failedCount={failedTrials}
           retryBusy={retryBusy}
         />

--- a/application/playground/frontend/src/components/cockpit/setup/CockpitPipelineDiagram.tsx
+++ b/application/playground/frontend/src/components/cockpit/setup/CockpitPipelineDiagram.tsx
@@ -432,7 +432,9 @@ export function CockpitPipelineDiagram({
 
       <p className="shrink-0 text-center text-[15px] font-medium leading-snug sm:text-[14px]">
         {ready ? (
-          <span className="font-semibold text-secondary">Ready to launch — pipeline locked.</span>
+          <span className="font-semibold text-secondary">
+            Run config complete — Ready to launch.
+          </span>
         ) : (
           <span className="text-text-variant">Select personas and a task, then run below.</span>
         )}

--- a/application/playground/frontend/src/components/cockpit/setup/PersonaSamplingRail.tsx
+++ b/application/playground/frontend/src/components/cockpit/setup/PersonaSamplingRail.tsx
@@ -1,18 +1,33 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { api, ApiError } from "@/lib/api";
 import {
   PERSONA_BENCH_POOL,
   PERSONA_CARD_PREVIEW_LIMIT,
+  PERSONA_GENERATE_COUNT_DEFAULT,
+  PERSONA_GENERATE_COUNT_MAX,
   PERSONA_PRODUCTION_1M_POOL,
   PERSONA_SAMPLE_SIZE_MAX_DEV,
   PERSONA_SAMPLE_SIZE_MAX_PRODUCTION,
   PERSONA_UI_ID_LIST_MAX,
+  type PersonaPoolGenerateProgress,
+  type PersonaPoolGenerateResult,
   type PersonaPoolPersonaCard,
   type TaskPersonaStrategy,
 } from "@/lib/types";
-import { formatPersonaSampleError, poolSlugLabel } from "@/lib/personaPoolCopy";
+import {
+  formatPersonaSampleError,
+  isPersonaPoolCoverageError,
+  poolSlugLabel,
+} from "@/lib/personaPoolCopy";
 import { syntheticDisplayName } from "@/lib/personaDisplay";
 import { FOCUS_RING, Sym, humanizeToken } from "../cockpitShared";
 import { CockpitSelect, type CockpitSelectOption } from "./CockpitSelect";
@@ -23,11 +38,13 @@ import { CockpitRailHeader } from "./CockpitRailHeader";
 import { PersonaFilterModal } from "./PersonaFilterModal";
 import {
   activeFilterCount,
+  emptyPersonaDimensionFilters,
   filtersForSampleApi,
   readStrategySampling,
   type PersonaDimensionFilters,
   type PersonaSamplingMode,
   type StratifiedAllocation,
+  type StrategySamplingView,
 } from "./personaSamplingTypes";
 import type { PlaygroundTaskType } from "../TaskTypeSwitch";
 
@@ -97,6 +114,62 @@ function isMaterializedCohortPool(pool: string): boolean {
   return isProduction1mCohortPool(pool) || isSampleCohortPool(pool);
 }
 
+function isGeneratedDevPool(pool: string): boolean {
+  return /(?:^|\/)generated-persona-dev-/.test(pool);
+}
+
+function clampGenerateCount(value: number): number {
+  if (!Number.isFinite(value)) return PERSONA_GENERATE_COUNT_DEFAULT;
+  return Math.min(PERSONA_GENERATE_COUNT_MAX, Math.max(1, Math.round(value)));
+}
+
+function PersonaFilterChips({
+  filters,
+  fields,
+  showStratify,
+}: {
+  filters: PersonaDimensionFilters;
+  fields: string[];
+  showStratify: boolean;
+}) {
+  const filterCount = activeFilterCount(filters);
+  if (filterCount === 0 && !(showStratify && fields.length > 0)) return null;
+  return (
+    <div className="flex flex-wrap gap-1 px-0.5">
+      {filters.sources.map((source) => (
+        <span
+          key={`src:${source}`}
+          className="rounded-full bg-primary/10 px-2 py-0.5 text-[11px] text-primary"
+        >
+          {source}
+        </span>
+      ))}
+      {Object.entries(filters.dimensionFilters)
+        .filter(([, values]) => values.length > 0)
+        .map(([dim, values]) => (
+          <span
+            key={dim}
+            className="rounded-full bg-primary/10 px-2 py-0.5 text-[11px] text-primary"
+            title={values.join(", ")}
+          >
+            {humanizeToken(dim)}
+            <span className="text-primary/70"> · {values.length}</span>
+          </span>
+        ))}
+      {showStratify
+        ? fields.map((field) => (
+            <span
+              key={`st:${field}`}
+              className="rounded-full border border-secondary/35 bg-secondary/10 px-2 py-0.5 text-[11px] text-secondary"
+            >
+              stratify · {humanizeToken(field)}
+            </span>
+          ))
+        : null}
+    </div>
+  );
+}
+
 /** Dataset dropdown source — cohorts are launch caches, not selectable sources. */
 function datasetSourcePool(pool: string): string {
   if (pool === PERSONA_PRODUCTION_1M_POOL || isProduction1mCohortPool(pool)) {
@@ -123,26 +196,144 @@ function strategyModeLabel(mode: string | null | undefined): string {
   return "Custom";
 }
 
-function strategyHeadline(strategy: TaskPersonaStrategy): string {
-  const sampling = readStrategySampling(strategy);
-  const mode = strategyModeLabel(sampling.mode);
-  const isStratified = sampling.mode === "stratified" || sampling.fields.length > 0;
-  if (isStratified) {
-    const allocLabel = ALLOCATION_LABELS[sampling.allocation];
-    if (sampling.allocation === "perCell" && sampling.perCell != null) {
-      return `${mode} · ${allocLabel} · ${sampling.perCell} per combination`;
-    }
-    if (sampling.sampleSize != null) {
-      return `${mode} · ${allocLabel} · sample ${sampling.sampleSize}`;
-    }
-    return `${mode} · ${allocLabel}`;
+function strategySampleTypeLabel(sampling: StrategySamplingView): string | null {
+  if (sampling.mode === "all") return "Entire filtered pool";
+  if (sampling.mode === "single") return "1 persona";
+  if (sampling.mode === "stratified" && sampling.allocation === "perCell") {
+    const n = sampling.perCell ?? 1;
+    return `${n} persona${n === 1 ? "" : "s"} per cell`;
   }
-  if (sampling.sampleSize != null) return `${mode} · sample ${sampling.sampleSize}`;
-  return mode;
+  if (sampling.sampleSize != null) {
+    return `Total sample · ${sampling.sampleSize} persona${sampling.sampleSize === 1 ? "" : "s"}`;
+  }
+  if (sampling.perCell != null) {
+    return `${sampling.perCell} persona${sampling.perCell === 1 ? "" : "s"} per cell`;
+  }
+  return null;
 }
 
-function TaskStrategySummary({ strategy }: { strategy: TaskPersonaStrategy }) {
-  const [expanded, setExpanded] = useState(false);
+const STRATEGY_CHIP =
+  "rounded-full px-2 py-0.5 text-[11px] leading-5 transition-colors duration-150";
+const STRATEGY_FILTER_CHIP = `${STRATEGY_CHIP} bg-primary/10 text-primary hover:bg-primary/15`;
+const STRATEGY_STRATIFY_CHIP = `${STRATEGY_CHIP} border border-secondary/35 bg-secondary/10 text-secondary`;
+
+function StrategySectionLabel({ children }: { children: ReactNode }) {
+  return (
+    <p className="text-[10px] font-medium uppercase tracking-[0.08em] text-text-dim">{children}</p>
+  );
+}
+
+function StrategyKvRow({
+  label,
+  children,
+  title,
+}: {
+  label: string;
+  children: ReactNode;
+  title?: string;
+}) {
+  return (
+    <div className="grid grid-cols-[4.75rem_minmax(0,1fr)] items-start gap-x-2 gap-y-0.5">
+      <dt className="pt-0.5 text-[11px] text-text-dim">{label}</dt>
+      <dd className="min-w-0 text-[12px] leading-snug text-text-main" title={title}>
+        {children}
+      </dd>
+    </div>
+  );
+}
+
+/** Compact dim chip — click to peek selected values. */
+function StrategyFilterValueChip({
+  label,
+  values,
+  open,
+  onToggle,
+}: {
+  label: string;
+  values: string[];
+  open: boolean;
+  onToggle: () => void;
+}) {
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) onToggle();
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onToggle();
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open, onToggle]);
+
+  return (
+    <div ref={rootRef} className="relative">
+      <button
+        type="button"
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        onClick={onToggle}
+        className={`${STRATEGY_FILTER_CHIP} cursor-pointer ${FOCUS_RING} ${
+          open ? "ring-1 ring-primary/40" : ""
+        }`}
+        title={values.join(", ")}
+      >
+        {label}
+        <span className="text-primary/70"> · {values.length}</span>
+      </button>
+      {open ? (
+        <div
+          role="dialog"
+          aria-label={`${label} selected values`}
+          className="absolute left-0 top-[calc(100%+0.35rem)] z-20 w-[min(16.5rem,calc(100vw-2rem))] rounded-lg border border-outline/50 bg-surface-low p-2.5 shadow-[0_12px_28px_-16px_rgb(0_0_0/0.55)]"
+        >
+          <div className="mb-1.5 flex items-center justify-between gap-2">
+            <p className="min-w-0 truncate text-[11px] font-medium text-text-main">{label}</p>
+            <p className="shrink-0 text-[10px] text-text-dim">
+              {values.length} selected
+            </p>
+          </div>
+          <div className="flex max-h-40 flex-wrap gap-1 overflow-y-auto">
+            {values.map((value) => (
+              <span
+                key={value}
+                className="rounded-full bg-primary/10 px-2 py-0.5 text-[11px] leading-5 text-primary"
+              >
+                {value}
+              </span>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function strategyCollapsedHeadline(sampling: StrategySamplingView): string {
+  const mode = strategyModeLabel(sampling.mode);
+  const sample = strategySampleTypeLabel(sampling);
+  if (sampling.mode === "stratified" || sampling.fields.length > 0) {
+    const alloc = ALLOCATION_LABELS[sampling.allocation] ?? sampling.allocation;
+    return sample ? `${mode} · ${alloc} · ${sample}` : `${mode} · ${alloc}`;
+  }
+  return sample ? `${mode} · ${sample}` : mode;
+}
+
+function TaskStrategySummary({
+  strategy,
+  expanded,
+  onExpandedChange,
+}: {
+  strategy: TaskPersonaStrategy;
+  expanded: boolean;
+  onExpandedChange: (expanded: boolean) => void;
+}) {
   const sampling = readStrategySampling(strategy);
   const dimEntries = Object.entries(strategy.dimensionFilters ?? {}).filter(
     ([, values]) => Array.isArray(values) && values.length > 0,
@@ -150,97 +341,116 @@ function TaskStrategySummary({ strategy }: { strategy: TaskPersonaStrategy }) {
   const sources = (strategy.sources ?? []).filter((value) => value.trim());
   const stratify = sampling.fields;
   const filterBits = dimEntries.length + (sources.length > 0 ? 1 : 0);
-  const hasDetails = sources.length > 0 || dimEntries.length > 0 || stratify.length > 0;
+  const showAllocation = sampling.mode === "stratified" || stratify.length > 0;
+  const sampleType = strategySampleTypeLabel(sampling);
+  const allocLabel = ALLOCATION_LABELS[sampling.allocation] ?? sampling.allocation;
+  const [openFilterKey, setOpenFilterKey] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!expanded) setOpenFilterKey(null);
+  }, [expanded]);
 
   return (
-    <div className="border-t border-outline/35 pt-1.5">
+    <div className="mt-2 border-t border-outline/35 pt-1.5">
       <button
         type="button"
         aria-expanded={expanded}
-        onClick={() => setExpanded((open) => !open)}
-        className={`flex w-full items-start gap-1.5 rounded-md py-0.5 text-left transition hover:bg-primary/5 ${FOCUS_RING}`}
+        onClick={() => onExpandedChange(!expanded)}
+        className={`flex w-full items-start gap-1.5 rounded-md py-0.5 text-left transition-colors duration-150 hover:bg-primary/5 ${FOCUS_RING}`}
       >
         <div className="min-w-0 flex-1">
           <p className="text-[12px] font-medium leading-snug text-text-main">
-            {strategyHeadline(strategy)}
+            {strategyCollapsedHeadline(sampling)}
           </p>
-          {!expanded && hasDetails ? (
+          {!expanded ? (
             <p className="mt-0.5 truncate text-[11px] leading-snug text-text-dim">
+              {filterBits > 0 ? `${filterBits} filter${filterBits === 1 ? "" : "s"}` : "No filters"}
               {stratify.length > 0
-                ? `Stratify ${stratify.map(humanizeToken).join(" × ")}`
-                : null}
-              {stratify.length > 0 && filterBits > 0 ? " · " : null}
-              {filterBits > 0 ? `${filterBits} filter${filterBits === 1 ? "" : "s"}` : null}
+                ? ` · Stratify ${stratify.map(humanizeToken).join(" × ")}`
+                : ""}
             </p>
           ) : null}
         </div>
-        {hasDetails ? (
-          <Sym
-            name={expanded ? "expand_less" : "expand_more"}
-            size={16}
-            className="mt-0.5 shrink-0 text-text-dim"
-          />
-        ) : null}
+        <Sym
+          name={expanded ? "expand_less" : "expand_more"}
+          size={16}
+          className="mt-0.5 shrink-0 text-text-dim"
+        />
       </button>
+
       {expanded ? (
-        <div className="mt-1.5 max-h-36 space-y-2 overflow-y-auto custom-scrollbar pr-0.5">
-          {sources.length > 0 || dimEntries.length > 0 ? (
-            <div>
-              <p className="mb-1 text-[10px] font-medium uppercase tracking-wide text-text-dim">
-                Filters · {filterBits}
-              </p>
-              <div className="flex flex-wrap gap-1">
-                {sources.map((source) => (
-                  <span
-                    key={source}
-                    className="rounded-full bg-primary/10 px-2 py-0.5 text-[11px] text-primary"
-                  >
-                    {source}
-                  </span>
-                ))}
-                {dimEntries.map(([dim, values]) => (
-                  <span
-                    key={dim}
-                    className="rounded-full bg-primary/10 px-2 py-0.5 text-[11px] text-primary"
-                    title={values.join(", ")}
-                  >
-                    {humanizeToken(dim)} · {values.length}
-                  </span>
-                ))}
-              </div>
-            </div>
-          ) : null}
-          {stratify.length > 0 ? (
-            <div>
-              <p className="mb-1 text-[10px] font-medium uppercase tracking-wide text-text-dim">
-                Stratify · {stratify.length}
-              </p>
-              <div className="flex flex-wrap gap-1">
-                {stratify.map((field) => (
-                  <span
-                    key={field}
-                    className="rounded-full border border-secondary/35 bg-secondary/10 px-2 py-0.5 text-[11px] text-secondary"
-                  >
-                    {humanizeToken(field)}
-                  </span>
-                ))}
-              </div>
-            </div>
-          ) : null}
-          {sampling.mode === "stratified" ? (
-            <p className="text-[12px] leading-snug text-text-variant">
-              <span className="text-text-dim">Allocation · </span>
-              {ALLOCATION_LABELS[sampling.allocation]}
-              {sampling.allocation === "perCell" && sampling.perCell != null
-                ? ` · ${sampling.perCell}/cell`
-                : sampling.sampleSize != null
-                  ? ` · sample ${sampling.sampleSize}`
-                  : ""}
+        <div className="mt-1 divide-y divide-outline/30">
+          <section className="space-y-1.5 py-2.5">
+            <StrategySectionLabel>Mode</StrategySectionLabel>
+            <p className="text-[13px] font-medium leading-snug text-text-main">
+              {strategyModeLabel(sampling.mode)}
             </p>
-          ) : null}
-          {!hasDetails ? (
-            <p className="text-[12px] text-text-dim">No filters — full pool.</p>
-          ) : null}
+          </section>
+
+          <section className="space-y-1.5 py-2.5">
+            <StrategySectionLabel>
+              Filter{filterBits > 0 ? ` · ${filterBits}` : ""}
+            </StrategySectionLabel>
+            {filterBits > 0 ? (
+              <div className="flex flex-wrap gap-1">
+                {sources.length > 0 ? (
+                  <StrategyFilterValueChip
+                    label="Sources"
+                    values={sources}
+                    open={openFilterKey === "sources"}
+                    onToggle={() =>
+                      setOpenFilterKey((key) => (key === "sources" ? null : "sources"))
+                    }
+                  />
+                ) : null}
+                {dimEntries.map(([dim, values]) => (
+                  <StrategyFilterValueChip
+                    key={dim}
+                    label={humanizeToken(dim)}
+                    values={values}
+                    open={openFilterKey === dim}
+                    onToggle={() => setOpenFilterKey((key) => (key === dim ? null : dim))}
+                  />
+                ))}
+              </div>
+            ) : (
+              <p className="text-[12px] leading-snug text-text-dim">No filters — full pool.</p>
+            )}
+          </section>
+
+          <section className="space-y-2 py-2.5">
+            <StrategySectionLabel>Sampling</StrategySectionLabel>
+            <dl className="space-y-1.5">
+              {showAllocation ? (
+                <StrategyKvRow label="Allocation" title={ALLOCATION_TITLES[sampling.allocation]}>
+                  <span className="font-medium">{allocLabel}</span>
+                  <span className="mt-0.5 block text-[11px] leading-snug text-text-dim">
+                    {ALLOCATION_TITLES[sampling.allocation]}
+                  </span>
+                </StrategyKvRow>
+              ) : null}
+              {sampleType ? (
+                <StrategyKvRow label="Sample">
+                  <span className="font-medium">{sampleType}</span>
+                </StrategyKvRow>
+              ) : null}
+              {stratify.length > 0 || sampling.mode === "stratified" ? (
+                <StrategyKvRow label="Stratify">
+                  {stratify.length > 0 ? (
+                    <div className="flex flex-wrap gap-1">
+                      {stratify.map((field) => (
+                        <span key={field} className={STRATEGY_STRATIFY_CHIP}>
+                          {humanizeToken(field)}
+                        </span>
+                      ))}
+                    </div>
+                  ) : (
+                    <span className="text-text-dim">No stratify axes</span>
+                  )}
+                </StrategyKvRow>
+              ) : null}
+            </dl>
+          </section>
         </div>
       ) : null}
     </div>
@@ -254,6 +464,35 @@ function fallbackQuickPickCards(): PersonaPoolPersonaCard[] {
     source: "matraix-persona-dev-sample",
     dimensions: {},
   }));
+}
+
+function GenerateProgressBar({
+  progress,
+}: {
+  progress: Pick<PersonaPoolGenerateProgress, "ratio" | "label" | "stage">;
+}) {
+  const pct = Math.max(0, Math.min(100, Math.round(progress.ratio * 100)));
+  return (
+    <div className="space-y-1" aria-live="polite">
+      <div className="flex items-center justify-between gap-2 text-[11px] leading-snug">
+        <span className="min-w-0 truncate text-text-variant">{progress.label}</span>
+        <span className="shrink-0 font-mono text-text-dim">{pct}%</span>
+      </div>
+      <div
+        className="h-1.5 overflow-hidden rounded-full bg-outline/35"
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={pct}
+        aria-label={progress.label}
+      >
+        <div
+          className="h-full rounded-full bg-primary transition-[width] duration-200 ease-out"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
 }
 
 export interface PersonaSamplingRailProps {
@@ -329,6 +568,8 @@ export function PersonaSamplingRail({
   disabled,
 }: PersonaSamplingRailProps) {
   const [filterOpen, setFilterOpen] = useState(false);
+  const [filterTarget, setFilterTarget] = useState<"dataset" | "generation">("dataset");
+  const [railSegment, setRailSegment] = useState<"generation" | "dataset">("dataset");
   const [detailPersona, setDetailPersona] = useState<PersonaPoolPersonaCard | null>(null);
   const [previewCards, setPreviewCards] = useState<PersonaPoolPersonaCard[]>([]);
   const [pullError, setPullError] = useState<string | null>(null);
@@ -340,6 +581,22 @@ export function PersonaSamplingRail({
   const [saveOpen, setSaveOpen] = useState(false);
   const [savingDataset, setSavingDataset] = useState(false);
   const [saveDatasetError, setSaveDatasetError] = useState<string | null>(null);
+  const [genMode, setGenMode] = useState<"random" | "stratified">("random");
+  const [genCount, setGenCount] = useState(PERSONA_GENERATE_COUNT_DEFAULT);
+  const [genCountDraft, setGenCountDraft] = useState<string | null>(null);
+  const [genSeed, setGenSeed] = useState(42);
+  const [genAllocation, setGenAllocation] = useState<StratifiedAllocation>("perCell");
+  const [genPerCell, setGenPerCell] = useState(2);
+  const [genSampleSize, setGenSampleSize] = useState(32);
+  const [genFilters, setGenFilters] = useState<PersonaDimensionFilters>(emptyPersonaDimensionFilters);
+  const [genFields, setGenFields] = useState<string[]>([]);
+  const [generating, setGenerating] = useState(false);
+  const [generateError, setGenerateError] = useState<string | null>(null);
+  const [generateProgress, setGenerateProgress] = useState<PersonaPoolGenerateProgress | null>(
+    null,
+  );
+  /** Task-default strategy detail — collapses after a successful pull / synthesize. */
+  const [strategySummaryOpen, setStrategySummaryOpen] = useState(true);
 
   const queryClient = useQueryClient();
   const activePool = personaPool?.trim() || PERSONA_BENCH_POOL;
@@ -347,11 +604,19 @@ export function PersonaSamplingRail({
   const isBenchPool = sourcePool === PERSONA_BENCH_POOL;
   const isProduction1m = sourcePool === PERSONA_PRODUCTION_1M_POOL;
   const canSaveAsDataset =
-    isMaterializedCohortPool(activePool) && (selectedCount > 0 || selectedPersonaIds.length > 0);
+    (isMaterializedCohortPool(activePool) || isGeneratedDevPool(activePool)) &&
+    (selectedCount > 0 || selectedPersonaIds.length > 0);
   const cohortSize = Math.max(selectedCount, selectedPersonaIds.length);
   const sampleSizeMax = isProduction1m
     ? PERSONA_SAMPLE_SIZE_MAX_PRODUCTION
     : PERSONA_SAMPLE_SIZE_MAX_DEV;
+  const strategyLocked = hasTaskStrategy && useTaskDefaultStrategy;
+  const customSamplingUnlocked = !strategyLocked;
+  const strategyView = taskPersonaStrategy ? readStrategySampling(taskPersonaStrategy) : null;
+  const panelMode = strategyLocked && strategyView ? strategyView.mode : mode;
+  const panelAllocation =
+    strategyLocked && strategyView ? strategyView.allocation : stratifiedAllocation;
+  const panelFields = strategyLocked && strategyView ? strategyView.fields : fields;
 
   const datasetsQuery = useQuery({
     queryKey: ["persona-pool-datasets"],
@@ -417,7 +682,7 @@ export function PersonaSamplingRail({
   }, [defaultCardsQuery.data?.personas, defaultCardsQuery.isError]);
 
   const displayCards = useMemo(() => {
-    if (mode === "single") return quickPickCards;
+    if (panelMode === "single") return quickPickCards;
     if (disabled && selectedPersonaIds.length > 0) {
       const locked = lockedCohortQuery.data?.personas ?? [];
       if (locked.length > 0) return locked;
@@ -432,7 +697,7 @@ export function PersonaSamplingRail({
   }, [
     quickPickCards,
     previewCards,
-    mode,
+    panelMode,
     disabled,
     selectedPersonaIds,
     lockedCohortQuery.data?.personas,
@@ -441,6 +706,20 @@ export function PersonaSamplingRail({
   useEffect(() => {
     if (mode === "single") setPreviewCards([]);
   }, [mode]);
+
+  // New task / re-enable Task default → show strategy detail again.
+  useEffect(() => {
+    if (useTaskDefaultStrategy) setStrategySummaryOpen(true);
+  }, [taskPath, useTaskDefaultStrategy]);
+
+  // Turning Task default off resets pool/selection in the parent — drop local preview too.
+  useEffect(() => {
+    if (!useTaskDefaultStrategy) {
+      setPreviewCards([]);
+      setPullError(null);
+      setGenerateError(null);
+    }
+  }, [useTaskDefaultStrategy]);
 
   const togglePersona = useCallback(
     (personaId: string) => {
@@ -510,15 +789,20 @@ export function PersonaSamplingRail({
   ]);
 
   const handlePull = useCallback(async () => {
-    if (mode === "all") {
+    if (panelMode === "all") {
       await handleSelectAll();
+      if (strategyLocked) setStrategySummaryOpen(false);
+      return;
+    }
+    if (panelMode === "stratified" && panelFields.length === 0) {
+      setPullError("Pick at least one stratify axis in Persona filters before pulling.");
       return;
     }
     setPulling(true);
     setPullError(null);
     try {
       const dimensionFilters = filtersForSampleApi(filters);
-      const isPerCell = mode === "stratified" && stratifiedAllocation === "perCell";
+      const isPerCell = panelMode === "stratified" && panelAllocation === "perCell";
       const perCellQuota = isPerCell
         ? clampPerCell(perCell ?? 1)
         : undefined;
@@ -528,9 +812,9 @@ export function PersonaSamplingRail({
         seed,
         sources: filters.sources.length ? filters.sources : undefined,
         dimensionFilters,
-        fields: mode === "stratified" ? fields : undefined,
+        fields: panelMode === "stratified" ? panelFields : undefined,
         perCell: perCellQuota,
-        allocation: mode === "stratified" ? stratifiedAllocation : undefined,
+        allocation: panelMode === "stratified" ? panelAllocation : undefined,
         taskPath: taskPath?.trim() || undefined,
       });
       const cards = result.personas.slice(0, PERSONA_CARD_PREVIEW_LIMIT).map((row) => ({
@@ -550,6 +834,7 @@ export function PersonaSamplingRail({
         // Launch needs the materialized YAML dir; Dataset UI still shows sourcePool.
         onPersonaPoolChange?.(result.pool);
       }
+      if (strategyLocked) setStrategySummaryOpen(false);
     } catch (err) {
       const raw = err instanceof ApiError ? err.message : "Could not pull cohort from this dataset.";
       const formatted = formatPersonaSampleError(raw, taskPath);
@@ -560,19 +845,170 @@ export function PersonaSamplingRail({
   }, [
     filters,
     handleSelectAll,
-    mode,
     onPersonaPoolChange,
     onSelectedCountChange,
     onSelectedPersonaIdsChange,
     onUseEntirePoolChange,
+    panelAllocation,
+    panelFields,
+    panelMode,
     sampleSize,
     perCell,
     seed,
     sourcePool,
-    stratifiedAllocation,
-    fields,
+    strategyLocked,
     taskPath,
   ]);
+
+  const applyGeneratedPool = useCallback(
+    async (
+      result: PersonaPoolGenerateResult,
+      options?: {
+        /**
+         * Task-default Synthesize replaces a failed Pull — select the fill cohort.
+         * Custom Generation only materializes a Dataset; operator still Pulls.
+         */
+        selectCohort?: boolean;
+      },
+    ) => {
+      await queryClient.invalidateQueries({ queryKey: ["persona-pool-datasets"] });
+      const count = result.count;
+      const ids = result.personaIds ?? [];
+      const selectCohort = options?.selectCohort === true;
+      const truncated = selectCohort && count > PERSONA_UI_ID_LIST_MAX;
+      const previewIds = ids.slice(0, PERSONA_CARD_PREVIEW_LIMIT);
+      onPersonaPoolChange?.(result.pool);
+      if (selectCohort) {
+        onSelectedCountChange?.(count);
+        onUseEntirePoolChange?.(truncated);
+        onSelectedPersonaIdsChange(truncated ? previewIds : ids);
+      } else {
+        // Pool is ready as Dataset — do not treat the whole draw as the launch cohort.
+        onSelectedCountChange?.(0);
+        onUseEntirePoolChange?.(false);
+        onSelectedPersonaIdsChange([]);
+        onModeChange("random");
+      }
+      try {
+        const preview = await api.getPersonaPoolCards({
+          pool: result.pool,
+          limit: Math.min(
+            PERSONA_CARD_PREVIEW_LIMIT,
+            Math.max(selectCohort ? previewIds.length : 8, 1),
+          ),
+          personaIds: selectCohort && previewIds.length ? previewIds : undefined,
+        });
+        setPreviewCards(preview.personas);
+      } catch {
+        setPreviewCards(
+          (selectCohort ? previewIds : ids.slice(0, 8)).map((personaId) => ({
+            personaId,
+            name: syntheticDisplayName(personaId),
+            source: "synthetic",
+            dimensions: {},
+          })),
+        );
+      }
+      setPullError(null);
+      setGenerateError(null);
+      setRailSegment("dataset");
+      if (useTaskDefaultStrategy) setStrategySummaryOpen(false);
+    },
+    [
+      onModeChange,
+      onPersonaPoolChange,
+      onSelectedCountChange,
+      onSelectedPersonaIdsChange,
+      onUseEntirePoolChange,
+      queryClient,
+      useTaskDefaultStrategy,
+    ],
+  );
+
+  const handleGenerate = useCallback(async () => {
+    setGenerating(true);
+    setGenerateError(null);
+    setGenerateProgress({
+      type: "progress",
+      stage: "prepare",
+      ratio: 0.02,
+      label: "Starting generation…",
+    });
+    try {
+      const isStratified = genMode === "stratified";
+      if (isStratified && genFields.length === 0) {
+        throw new ApiError(422, "Pick at least one stratify field before generating.");
+      }
+      const dimensionFilters = isStratified ? filtersForSampleApi(genFilters) : undefined;
+      const result = await api.generatePersonaPool(
+        {
+          count: isStratified ? undefined : genCount,
+          seed: genSeed,
+          dimensionFilters,
+          fields: isStratified ? genFields : undefined,
+          perCell:
+            isStratified && genAllocation === "perCell"
+              ? clampPerCell(genPerCell)
+              : undefined,
+          allocation: isStratified ? genAllocation : undefined,
+          sampleSize:
+            isStratified && genAllocation !== "perCell" ? genSampleSize : undefined,
+        },
+        { onProgress: setGenerateProgress },
+      );
+      await applyGeneratedPool(result, { selectCohort: false });
+    } catch (err) {
+      setGenerateError(
+        err instanceof ApiError ? err.message : "Could not generate a synthetic pool.",
+      );
+    } finally {
+      setGenerating(false);
+      setGenerateProgress(null);
+    }
+  }, [
+    applyGeneratedPool,
+    genAllocation,
+    genCount,
+    genFields,
+    genFilters,
+    genMode,
+    genPerCell,
+    genSampleSize,
+    genSeed,
+  ]);
+
+  const handleSynthesizeTask = useCallback(async () => {
+    const path = taskPath?.trim();
+    if (!path) {
+      setPullError("Select a task before synthesizing.");
+      return;
+    }
+    setGenerating(true);
+    setPullError(null);
+    setGenerateProgress({
+      type: "progress",
+      stage: "prepare",
+      ratio: 0.02,
+      label: "Starting synthesize…",
+    });
+    try {
+      const result = await api.generatePersonaPool(
+        { taskPath: path },
+        { onProgress: setGenerateProgress },
+      );
+      // Synthesize stands in for Pull when coverage fails under Task default.
+      await applyGeneratedPool(result, { selectCohort: true });
+    } catch (err) {
+      setPullError(
+        err instanceof ApiError
+          ? err.message
+          : "Could not synthesize a pool for this task.",
+      );
+    } finally {
+      setGenerating(false);
+      setGenerateProgress(null);
+    }
+  }, [applyGeneratedPool, taskPath]);
 
   const datasetOptions = useMemo<CockpitSelectOption[]>(() => {
     const listed = datasetsQuery.data?.datasets ?? [];
@@ -610,14 +1046,27 @@ export function PersonaSamplingRail({
       onUseEntirePoolChange?.(false);
       setPreviewCards([]);
       setPullError(null);
-        setDetailPersona(null);
+      setDetailPersona(null);
       setSaveOpen(false);
       setSaveDatasetError(null);
-      if (pool === PERSONA_PRODUCTION_1M_POOL && mode === "all") {
+      const option = datasetsQuery.data?.datasets?.find((item) => item.pool === pool);
+      // Saved cohorts are already curated — default to All (inverse of 1M).
+      if (option?.kind === "saved") {
+        onModeChange("all");
+      } else if (pool === PERSONA_PRODUCTION_1M_POOL && mode === "all") {
         onModeChange("random");
       }
     },
-    [mode, onModeChange, onPersonaPoolChange, onSelectedCountChange, onSelectedPersonaIdsChange, onUseEntirePoolChange, sourcePool],
+    [
+      datasetsQuery.data?.datasets,
+      mode,
+      onModeChange,
+      onPersonaPoolChange,
+      onSelectedCountChange,
+      onSelectedPersonaIdsChange,
+      onUseEntirePoolChange,
+      sourcePool,
+    ],
   );
 
   const handleSaveAsDataset = useCallback(async () => {
@@ -636,6 +1085,7 @@ export function PersonaSamplingRail({
       });
       await queryClient.invalidateQueries({ queryKey: ["persona-pool-datasets"] });
       onPersonaPoolChange?.(saved.pool);
+      onModeChange("all");
       setSaveOpen(false);
       setSaveNameDraft("");
     } catch (err) {
@@ -647,18 +1097,17 @@ export function PersonaSamplingRail({
     }
   }, [
     activePool,
+    cohortSize,
+    onModeChange,
     onPersonaPoolChange,
     queryClient,
     saveNameDraft,
-    cohortSize,
   ]);
 
   const filterCount = activeFilterCount(filters);
   const poolCount = catalogQuery.data?.count;
   const showModelSelector =
     taskType === "survey" || taskType === "chatbot" || taskType === "web" || taskType === "os-app";
-  const strategyLocked = hasTaskStrategy && useTaskDefaultStrategy;
-  const customSamplingUnlocked = !strategyLocked;
   const poolFooterLabel = isMaterializedCohortPool(activePool)
     ? `${poolSlugLabel(sourcePool)} · cohort ready`
     : poolSlugLabel(sourcePool);
@@ -691,7 +1140,202 @@ export function PersonaSamplingRail({
               onChange={onPersonaModelChange}
             />
           )}
-          <CockpitSelect
+        </div>
+
+        <div className="cockpit-segment cockpit-segment--grid mb-2 grid-cols-2">
+          {(["generation", "dataset"] as const).map((segment) => (
+            <button
+              key={segment}
+              type="button"
+              disabled={disabled}
+              onClick={() => setRailSegment(segment)}
+              className={`cockpit-segment__btn cockpit-segment__btn--compact w-full ${FOCUS_RING} ${
+                railSegment === segment ? "cockpit-segment__btn--active" : ""
+              }`}
+            >
+              {segment === "generation" ? "Generation" : "Dataset"}
+            </button>
+          ))}
+        </div>
+
+        {railSegment === "generation" ? (
+          <div className="mb-2 space-y-1.5">
+            <div className="cockpit-segment cockpit-segment--grid grid-cols-2">
+              {(["random", "stratified"] as const).map((tab) => (
+                <button
+                  key={tab}
+                  type="button"
+                  disabled={disabled || generating}
+                  onClick={() => setGenMode(tab)}
+                  className={`cockpit-segment__btn cockpit-segment__btn--compact w-full ${FOCUS_RING} ${
+                    genMode === tab ? "cockpit-segment__btn--active" : ""
+                  }`}
+                >
+                  {tab === "random" ? "Random" : "Stratified"}
+                </button>
+              ))}
+            </div>
+            {genMode === "stratified" ? (
+              <div className="cockpit-segment cockpit-segment--grid grid-cols-3">
+                {ALLOCATION_ORDER.map((alloc) => (
+                  <button
+                    key={alloc}
+                    type="button"
+                    title={ALLOCATION_TITLES[alloc]}
+                    disabled={disabled || generating}
+                    onClick={() => setGenAllocation(alloc)}
+                    className={`cockpit-segment__btn cockpit-segment__btn--compact w-full ${FOCUS_RING} ${
+                      genAllocation === alloc ? "cockpit-segment__btn--active" : ""
+                    }`}
+                  >
+                    {ALLOCATION_LABELS[alloc]}
+                  </button>
+                ))}
+              </div>
+            ) : null}
+            {genMode === "stratified" ? (
+              <div className="space-y-1.5">
+                <button
+                  type="button"
+                  disabled={disabled || generating}
+                  onClick={() => {
+                    setFilterTarget("generation");
+                    setFilterOpen(true);
+                  }}
+                  className={`glass-tile glass-tile--hover flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition ${FOCUS_RING}`}
+                >
+                  <Sym name="tune" size={16} className="shrink-0 text-primary" />
+                  <span className="min-w-0 flex-1 text-[13px] font-medium text-text-main">
+                    Persona filters
+                  </span>
+                  {activeFilterCount(genFilters) > 0 ? (
+                    <span className="rounded-full bg-primary/15 px-1.5 font-mono text-[11px] text-primary">
+                      {activeFilterCount(genFilters)}
+                    </span>
+                  ) : null}
+                  {genFields.length > 0 ? (
+                    <span className="rounded-full bg-secondary/15 px-1.5 font-mono text-[11px] text-secondary">
+                      {genFields.length}×
+                    </span>
+                  ) : null}
+                  <Sym name="chevron_right" size={16} className="shrink-0 text-text-dim" />
+                </button>
+                <PersonaFilterChips
+                  filters={genFilters}
+                  fields={genFields}
+                  showStratify
+                />
+              </div>
+            ) : null}
+            <div className="flex items-end gap-2">
+              {genMode === "random" ? (
+                <>
+                  <label className="flex w-[4.25rem] shrink-0 flex-col gap-0.5">
+                    <span className="text-[12px] text-text-dim">Count</span>
+                    <input
+                      type="number"
+                      inputMode="numeric"
+                      min={1}
+                      max={PERSONA_GENERATE_COUNT_MAX}
+                      step={1}
+                      value={genCountDraft ?? genCount}
+                      disabled={disabled || generating}
+                      onFocus={() => setGenCountDraft(String(genCount))}
+                      onChange={(e) => {
+                        const raw = e.target.value;
+                        if (raw === "" || /^\d+$/.test(raw)) setGenCountDraft(raw);
+                      }}
+                      onBlur={() => {
+                        const raw = genCountDraft;
+                        setGenCountDraft(null);
+                        setGenCount(
+                          clampGenerateCount(
+                            raw === "" || raw == null ? genCount : Number(raw),
+                          ),
+                        );
+                      }}
+                      className={`h-9 w-full rounded-lg border border-outline/50 bg-surface/60 px-1.5 text-center font-mono text-[15px] text-text-main disabled:opacity-50 ${FOCUS_RING}`}
+                    />
+                  </label>
+                  <label className="flex w-[4.25rem] shrink-0 flex-col gap-0.5">
+                    <span className="text-[12px] text-text-dim">Seed</span>
+                    <input
+                      type="number"
+                      inputMode="numeric"
+                      step={1}
+                      value={genSeed}
+                      disabled={disabled || generating}
+                      onChange={(e) => setGenSeed(Number(e.target.value) || 0)}
+                      className={`h-9 w-full rounded-lg border border-outline/50 bg-surface/60 px-1.5 text-center font-mono text-[15px] text-text-main disabled:opacity-50 ${FOCUS_RING}`}
+                    />
+                  </label>
+                </>
+              ) : genAllocation === "perCell" ? (
+                <label className="flex w-[4.25rem] shrink-0 flex-col gap-0.5">
+                  <span className="text-[12px] text-text-dim">Per cell</span>
+                  <input
+                    type="number"
+                    inputMode="numeric"
+                    min={1}
+                    max={50}
+                    step={1}
+                    value={genPerCell}
+                    disabled={disabled || generating}
+                    onChange={(e) => setGenPerCell(clampPerCell(Number(e.target.value)))}
+                    className={`h-9 w-full rounded-lg border border-outline/50 bg-surface/60 px-1.5 text-center font-mono text-[15px] text-text-main disabled:opacity-50 ${FOCUS_RING}`}
+                  />
+                </label>
+              ) : (
+                <label className="flex w-[4.25rem] shrink-0 flex-col gap-0.5">
+                  <span className="text-[12px] text-text-dim">Sample</span>
+                  <input
+                    type="number"
+                    inputMode="numeric"
+                    min={2}
+                    max={PERSONA_GENERATE_COUNT_MAX}
+                    step={1}
+                    value={genSampleSize}
+                    disabled={disabled || generating}
+                    onChange={(e) =>
+                      setGenSampleSize(clampGenerateCount(Number(e.target.value)))
+                    }
+                    className={`h-9 w-full rounded-lg border border-outline/50 bg-surface/60 px-1.5 text-center font-mono text-[15px] text-text-main disabled:opacity-50 ${FOCUS_RING}`}
+                  />
+                </label>
+              )}
+              <button
+                type="button"
+                disabled={disabled || generating}
+                onClick={() => void handleGenerate()}
+                className={`flex h-9 min-w-0 flex-1 items-center justify-center gap-1.5 rounded-lg bg-surface-high/90 text-[13px] font-medium text-text-main hover:bg-surface-high disabled:opacity-50 ${FOCUS_RING}`}
+              >
+                <Sym
+                  name={generating ? "autorenew" : "auto_awesome"}
+                  size={15}
+                  className={generating ? "animate-rb-spin text-primary" : "text-primary"}
+                />
+                {generating ? "Generating…" : "Generate"}
+              </button>
+            </div>
+            {generating && generateProgress ? (
+              <GenerateProgressBar progress={generateProgress} />
+            ) : (
+              <p className="text-[11px] leading-snug text-text-dim">
+                Writes a synthetic Full-DAG pool (no quality filter, dedup, or calibrate).
+              </p>
+            )}
+            {generateError ? (
+              <div className="rounded-lg border border-danger/30 bg-danger/5 px-2.5 py-2">
+                <p className="whitespace-pre-wrap text-[12px] leading-snug text-danger">
+                  {generateError}
+                </p>
+              </div>
+            ) : null}
+          </div>
+        ) : (
+        <>
+        <div className="mb-2">
+        <CockpitSelect
             label="Dataset"
             inlineLabel
             labelClassName="w-[4.25rem]"
@@ -705,7 +1349,7 @@ export function PersonaSamplingRail({
 
         {hasTaskStrategy && taskPersonaStrategy ? (
           <div
-            className="glass-tile mb-2 rounded-lg px-2.5 py-1.5"
+            className="glass-tile mb-2 rounded-lg px-2.5 py-2"
             title={
               useTaskDefaultStrategy
                 ? "Filters follow persona_strategy.json"
@@ -719,11 +1363,59 @@ export function PersonaSamplingRail({
               onChange={(checked) => onUseTaskDefaultStrategyChange?.(checked)}
             />
             {useTaskDefaultStrategy ? (
-              <TaskStrategySummary strategy={taskPersonaStrategy} />
+              <TaskStrategySummary
+                strategy={taskPersonaStrategy}
+                expanded={strategySummaryOpen}
+                onExpandedChange={setStrategySummaryOpen}
+              />
             ) : null}
           </div>
         ) : null}
 
+        {strategyLocked ? (
+          <div className="mb-2 space-y-1.5">
+            <button
+              type="button"
+              disabled={disabled || pulling}
+              onClick={() => void handlePull()}
+              className={`flex h-9 w-full items-center justify-center gap-1.5 rounded-lg bg-surface-high/90 text-[13px] font-medium text-text-main hover:bg-surface-high disabled:opacity-50 ${FOCUS_RING}`}
+            >
+              <Sym
+                name={pulling ? "autorenew" : "download"}
+                size={15}
+                className={pulling ? "animate-rb-spin text-primary" : "text-primary"}
+              />
+              {pulling ? "Pulling…" : "Pull cohort"}
+            </button>
+            {pullError ? (
+              <div className="space-y-1.5 rounded-lg border border-danger/30 bg-danger/5 px-2.5 py-2">
+                <p className="whitespace-pre-wrap text-[12px] leading-snug text-danger">{pullError}</p>
+                {isPersonaPoolCoverageError(pullError) && Boolean(taskPath?.trim()) ? (
+                  <div className="space-y-1.5">
+                    <button
+                      type="button"
+                      disabled={disabled || generating}
+                      onClick={() => void handleSynthesizeTask()}
+                      className={`flex h-8 w-full items-center justify-center gap-1.5 rounded-md bg-primary/90 text-[12px] font-medium text-white hover:bg-primary disabled:opacity-50 ${FOCUS_RING}`}
+                    >
+                      <Sym
+                        name={generating ? "autorenew" : "auto_awesome"}
+                        size={14}
+                        className={generating ? "animate-rb-spin" : ""}
+                      />
+                      {generating ? "Synthesizing…" : "Synthesize to fill this task"}
+                    </button>
+                    {generating && generateProgress ? (
+                      <GenerateProgressBar progress={generateProgress} />
+                    ) : null}
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+
+        {!strategyLocked ? (
         <div className="cockpit-segment cockpit-segment--grid mb-2 grid-cols-4">
           {TAB_ORDER.map((tab) => {
             const allBlocked = tab === "all" && isProduction1m;
@@ -736,10 +1428,10 @@ export function PersonaSamplingRail({
                     ? "All is disabled on the 1M production pool — sample up to 10,000 instead"
                     : TAB_TITLES[tab]
                 }
-                disabled={disabled || strategyLocked || allBlocked}
+                disabled={disabled || allBlocked}
                 onClick={() => onModeChange(tab)}
                 className={`cockpit-segment__btn cockpit-segment__btn--compact w-full ${FOCUS_RING} ${
-                  mode === tab ? "cockpit-segment__btn--active" : ""
+                  panelMode === tab ? "cockpit-segment__btn--active" : ""
                 }`}
               >
                 {TAB_LABELS[tab]}
@@ -747,8 +1439,9 @@ export function PersonaSamplingRail({
             );
           })}
         </div>
+        ) : null}
 
-        {mode === "stratified" ? (
+        {!strategyLocked && panelMode === "stratified" ? (
           <div className="cockpit-segment cockpit-segment--grid mb-2 grid-cols-3">
             {ALLOCATION_ORDER.map((alloc) => (
               <button
@@ -758,7 +1451,7 @@ export function PersonaSamplingRail({
                 disabled={disabled || strategyLocked}
                 onClick={() => onStratifiedAllocationChange(alloc)}
                 className={`cockpit-segment__btn cockpit-segment__btn--compact w-full ${FOCUS_RING} ${
-                  stratifiedAllocation === alloc ? "cockpit-segment__btn--active" : ""
+                  panelAllocation === alloc ? "cockpit-segment__btn--active" : ""
                 }`}
               >
                 {ALLOCATION_LABELS[alloc]}
@@ -773,7 +1466,7 @@ export function PersonaSamplingRail({
           </p>
         ) : null}
 
-        {mode === "all" && (
+        {!strategyLocked && panelMode === "all" && (
           <div className="mb-2 space-y-1.5">
             <p className="glass-tile rounded-lg px-2.5 py-1.5 text-[12px] leading-snug text-text-variant">
               Run the full selected dataset cohort
@@ -810,14 +1503,17 @@ export function PersonaSamplingRail({
           </div>
         )}
 
-        {mode !== "single" && mode !== "all" && (
+        {!strategyLocked && panelMode !== "single" && panelMode !== "all" ? (
           <div className="mb-2 space-y-1.5">
-            {customSamplingUnlocked ? (
-              <div className="space-y-1.5">
+            <div className="space-y-1.5">
+              {customSamplingUnlocked ? (
                 <button
                   type="button"
                   disabled={disabled}
-                  onClick={() => setFilterOpen(true)}
+                  onClick={() => {
+                    setFilterTarget("dataset");
+                    setFilterOpen(true);
+                  }}
                   className={`glass-tile glass-tile--hover flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition ${FOCUS_RING}`}
                 >
                   <Sym name="tune" size={16} className="shrink-0 text-primary" />
@@ -832,58 +1528,28 @@ export function PersonaSamplingRail({
                       {filterCount}
                     </span>
                   ) : null}
-                  {mode === "stratified" && fields.length > 0 ? (
+                  {panelMode === "stratified" && panelFields.length > 0 ? (
                     <span
                       className="rounded-full bg-secondary/15 px-1.5 font-mono text-[11px] text-secondary"
-                      title={`${fields.length} stratify axis${fields.length === 1 ? "" : "es"}`}
+                      title={`${panelFields.length} stratify axis${panelFields.length === 1 ? "" : "es"}`}
                     >
-                      {fields.length}×
+                      {panelFields.length}×
                     </span>
                   ) : null}
                   <Sym name="chevron_right" size={16} className="shrink-0 text-text-dim" />
                 </button>
-
-                {(filterCount > 0 || (mode === "stratified" && fields.length > 0)) && (
-                  <div className="flex flex-wrap gap-1 px-0.5">
-                    {filters.sources.map((source) => (
-                      <span
-                        key={`src:${source}`}
-                        className="rounded-full bg-primary/10 px-2 py-0.5 text-[11px] text-primary"
-                      >
-                        {source}
-                      </span>
-                    ))}
-                    {Object.entries(filters.dimensionFilters)
-                      .filter(([, values]) => values.length > 0)
-                      .map(([dim, values]) => (
-                        <span
-                          key={dim}
-                          className="rounded-full bg-primary/10 px-2 py-0.5 text-[11px] text-primary"
-                          title={values.join(", ")}
-                        >
-                          {humanizeToken(dim)}
-                          <span className="text-primary/70"> · {values.length}</span>
-                        </span>
-                      ))}
-                    {mode === "stratified"
-                      ? fields.map((field) => (
-                          <span
-                            key={`st:${field}`}
-                            className="rounded-full border border-secondary/35 bg-secondary/10 px-2 py-0.5 text-[11px] text-secondary"
-                          >
-                            stratify · {humanizeToken(field)}
-                          </span>
-                        ))
-                      : null}
-                  </div>
-                )}
-              </div>
-            ) : null}
+              ) : null}
+              {customSamplingUnlocked ? (
+              <PersonaFilterChips
+                filters={filters}
+                fields={panelFields}
+                showStratify={panelMode === "stratified"}
+              />
+              ) : null}
+            </div>
 
             <div className="flex items-end gap-2">
-              {customSamplingUnlocked ? (
-                <>
-                  {mode === "stratified" && stratifiedAllocation === "perCell" ? (
+              {panelMode === "stratified" && panelAllocation === "perCell" ? (
                     <label className="flex w-[4.25rem] shrink-0 flex-col gap-0.5">
                       <span className="text-[12px] text-text-dim">Per cell</span>
                       <input
@@ -893,7 +1559,7 @@ export function PersonaSamplingRail({
                         max={50}
                         step={1}
                         value={perCellDraft ?? (perCell ?? 1)}
-                        disabled={disabled}
+                        disabled={disabled || strategyLocked}
                         onFocus={() => setPerCellDraft(String(perCell ?? 1))}
                         onChange={(e) => {
                           const raw = e.target.value;
@@ -930,7 +1596,7 @@ export function PersonaSamplingRail({
                         max={sampleSizeMax}
                         step={1}
                         value={sampleSizeDraft ?? sampleSize}
-                        disabled={disabled}
+                        disabled={disabled || strategyLocked}
                         onFocus={() => setSampleSizeDraft(String(sampleSize))}
                         onChange={(e) => {
                           const raw = e.target.value;
@@ -957,8 +1623,6 @@ export function PersonaSamplingRail({
                       />
                     </label>
                   )}
-                </>
-              ) : null}
               <button
                 type="button"
                 disabled={disabled || pulling}
@@ -976,6 +1640,28 @@ export function PersonaSamplingRail({
             {pullError ? (
               <div className="space-y-1.5 rounded-lg border border-danger/30 bg-danger/5 px-2.5 py-2">
                 <p className="whitespace-pre-wrap text-[12px] leading-snug text-danger">{pullError}</p>
+                {useTaskDefaultStrategy &&
+                isPersonaPoolCoverageError(pullError) &&
+                Boolean(taskPath?.trim()) ? (
+                  <div className="space-y-1.5">
+                    <button
+                      type="button"
+                      disabled={disabled || generating}
+                      onClick={() => void handleSynthesizeTask()}
+                      className={`flex h-8 w-full items-center justify-center gap-1.5 rounded-md bg-primary/90 text-[12px] font-medium text-white hover:bg-primary disabled:opacity-50 ${FOCUS_RING}`}
+                    >
+                      <Sym
+                        name={generating ? "autorenew" : "auto_awesome"}
+                        size={14}
+                        className={generating ? "animate-rb-spin" : ""}
+                      />
+                      {generating ? "Synthesizing…" : "Synthesize to fill this task"}
+                    </button>
+                    {generating && generateProgress ? (
+                      <GenerateProgressBar progress={generateProgress} />
+                    ) : null}
+                  </div>
+                ) : null}
               </div>
             ) : null}
             {canSaveAsDataset && !disabled ? (
@@ -1060,17 +1746,27 @@ export function PersonaSamplingRail({
               </div>
             ) : null}
           </div>
+        ) : null}
+        </>
         )}
       </div>
 
+      {railSegment === "generation" ? (
+        <div className="flex min-h-0 flex-1 items-center justify-center px-2">
+          <p className="rounded-lg border border-dashed border-outline/40 p-4 text-center text-[13px] leading-snug text-text-dim">
+            Generate writes a new pool. Dataset then switches to it so you can Pull or Save.
+          </p>
+        </div>
+      ) : (
+      <>
       <div className="custom-scrollbar min-h-0 flex-1 overflow-y-auto pr-0.5">
           <div className="space-y-2">
-            {mode === "single" && defaultCardsQuery.isLoading && quickPickCards.length === 0 && (
+            {panelMode === "single" && defaultCardsQuery.isLoading && quickPickCards.length === 0 && (
               <p className="text-[13px] text-text-variant">
                 Loading {activePool.split("/").filter(Boolean).pop() || "dataset"}…
               </p>
             )}
-            {mode === "single" && defaultCardsQuery.isError && quickPickCards.length > 0 && (
+            {panelMode === "single" && defaultCardsQuery.isError && quickPickCards.length > 0 && (
               <p className="text-[12px] text-warn">
                 Using offline persona list — restart backend for full dimensions.
               </p>
@@ -1085,7 +1781,7 @@ export function PersonaSamplingRail({
                 onOpenDetail={() => setDetailPersona(persona)}
               />
             ))}
-            {mode !== "single" &&
+            {panelMode !== "single" &&
               cohortSize > displayCards.length &&
               displayCards.length > 0 && (
                 <p className="rounded-lg border border-dashed border-outline/40 px-3 py-2 text-center text-[12px] text-text-dim">
@@ -1093,21 +1789,21 @@ export function PersonaSamplingRail({
                   {useEntirePool ? " — launching by cohort ref" : " — full cohort is ready to launch"}.
                 </p>
               )}
-            {mode === "single" && !defaultCardsQuery.isLoading && displayCards.length === 0 && (
+            {panelMode === "single" && !defaultCardsQuery.isLoading && displayCards.length === 0 && (
               <p className="rounded-lg border border-dashed border-outline/40 p-4 text-center text-[13px] text-text-dim">
                 No personas loaded. Check that the backend is running.
               </p>
             )}
-            {mode !== "single" && displayCards.length === 0 && !disabled && (
+            {panelMode !== "single" && displayCards.length === 0 && !disabled && (
               <p className="rounded-lg border border-dashed border-outline/40 p-4 text-center text-[13px] text-text-dim">
                 {strategyLocked
                   ? "Pull the cohort this task recommends."
-                  : mode === "all"
+                  : panelMode === "all"
                     ? "Select all to use everyone in this dataset."
                     : "Choose a sample size and Pull a cohort from this dataset."}
               </p>
             )}
-            {mode !== "single" &&
+            {panelMode !== "single" &&
               displayCards.length === 0 &&
               disabled &&
               lockedCohortQuery.isLoading && (
@@ -1122,16 +1818,26 @@ export function PersonaSamplingRail({
       </p>
       </>
       )}
+      </>
+      )}
 
       <PersonaFilterModal
         open={filterOpen}
         catalog={catalogQuery.data ?? null}
-        filters={filters}
-        stratifyMode={mode === "stratified"}
-        fields={fields}
-        onFieldsChange={onFieldsChange}
+        filters={filterTarget === "generation" ? genFilters : filters}
+        stratifyMode={
+          filterTarget === "generation" ? genMode === "stratified" : panelMode === "stratified"
+        }
+        fields={filterTarget === "generation" ? genFields : fields}
+        onFieldsChange={filterTarget === "generation" ? setGenFields : onFieldsChange}
         onClose={() => setFilterOpen(false)}
-        onConfirm={onFiltersChange}
+        onConfirm={(next) => {
+          if (filterTarget === "generation") {
+            setGenFilters(next);
+            return;
+          }
+          onFiltersChange(next);
+        }}
       />
 
     </aside>

--- a/application/playground/frontend/src/components/cockpit/setup/cockpitPersonaSetupStorage.ts
+++ b/application/playground/frontend/src/components/cockpit/setup/cockpitPersonaSetupStorage.ts
@@ -14,7 +14,15 @@ import {
 /** Legacy pool slug renamed to matraix-persona-dev-sample (directory removed). */
 const LEGACY_BENCH_DEV_SAMPLE = "persona/datasets/bench-dev-sample";
 
-/** Drop legacy synthetic strategy pools from restored setup. */
+/**
+ * One-time Task-default fill pools (`generated-persona-dev-strategy-*`).
+ * Owned by Task default ON + Pull/Synthesize — not a durable Dataset choice.
+ */
+export function isTaskStrategyFillPool(pool: string | null | undefined): boolean {
+  return /(?:^|\/)generated-persona-dev-strategy-/.test((pool ?? "").trim());
+}
+
+/** Drop legacy / ephemeral pools that must not sticky-restore as Dataset. */
 export function sanitizePersonaPool(pool: string | null | undefined): string {
   const text = (pool ?? "").trim();
   if (!text) return PERSONA_BENCH_POOL;
@@ -175,7 +183,7 @@ function normalizeRecord(
     groupFilters: record.groupFilters ?? emptyPersonaDimensionFilters(),
     fields: Array.isArray(record.fields)
       ? record.fields.filter((field): field is string => typeof field === "string")
-      : ["age_bracket", "region"],
+      : [],
     stratifiedAllocation:
       record.stratifiedAllocation === "proportional" ||
       record.stratifiedAllocation === "equalTotal" ||
@@ -214,7 +222,8 @@ export function defaultPersonaSetup(fallbackPersonaModel: string): CockpitPerson
     useEntirePool: false,
     samplingMode: "single",
     groupFilters: emptyPersonaDimensionFilters(),
-    fields: ["age_bracket", "region"],
+    // Stratify axes are operator-chosen — never seed Age/Region by default.
+    fields: [],
     stratifiedAllocation: "perCell",
     sampleSize: 4,
     perCell: 1,
@@ -222,6 +231,25 @@ export function defaultPersonaSetup(fallbackPersonaModel: string): CockpitPerson
     personaModel: fallbackPersonaModel,
     personaPool: PERSONA_BENCH_POOL,
     useTaskDefaultStrategy: false,
+  };
+}
+
+/**
+ * Custom mode (Task default off) must not keep a task-fill cohort as Dataset.
+ * Returns a clean sandbox record when the stored pool is strategy-owned.
+ */
+export function scrubTaskStrategyFillForCustomMode(
+  record: CockpitPersonaSetupRecord,
+  fallbackPersonaModel: string,
+): CockpitPersonaSetupRecord {
+  if (!isTaskStrategyFillPool(record.personaPool)) return record;
+  const defaults = defaultPersonaSetup(fallbackPersonaModel);
+  return {
+    ...defaults,
+    personaModel: record.personaModel || defaults.personaModel,
+    parallelTrials: record.parallelTrials || defaults.parallelTrials,
+    useTaskDefaultStrategy: false,
+    taskDefaultStrategyDismissed: true,
   };
 }
 

--- a/application/playground/frontend/src/components/cockpit/setup/personaSamplingTypes.ts
+++ b/application/playground/frontend/src/components/cockpit/setup/personaSamplingTypes.ts
@@ -59,35 +59,63 @@ export function readStrategySampling(
   strategy: TaskPersonaStrategy | null | undefined,
 ): StrategySamplingView {
   const sampling = strategy?.sampling;
-  if (!sampling || typeof sampling !== "object") {
-    return {
-      mode: "single",
-      fields: [],
-      allocation: "perCell",
-      sampleSize: null,
-      perCell: null,
-    };
-  }
-  const mode = asSamplingMode(sampling.mode);
-  const fields = Array.isArray(sampling.fields)
-    ? sampling.fields.filter(
-        (field): field is string => typeof field === "string" && Boolean(field.trim()),
-      )
-    : [];
+  if (sampling && typeof sampling === "object") {
+    const mode = asSamplingMode(sampling.mode);
+    const fields = Array.isArray(sampling.fields)
+      ? sampling.fields.filter(
+          (field): field is string => typeof field === "string" && Boolean(field.trim()),
+        )
+      : [];
   const sampleSize =
     typeof sampling.sampleSize === "number" && sampling.sampleSize > 0
       ? Math.round(sampling.sampleSize)
-      : null;
+      : typeof (sampling as { sample_size?: number }).sample_size === "number"
+        ? Math.round((sampling as { sample_size?: number }).sample_size as number)
+        : null;
   const perCell =
     typeof sampling.perCell === "number" && sampling.perCell >= 1
       ? Math.round(sampling.perCell)
+      : typeof (sampling as { per_cell?: number }).per_cell === "number"
+        ? Math.round((sampling as { per_cell?: number }).per_cell as number)
+        : null;
+    const allocationFallback: StratifiedAllocation =
+      perCell != null ? "perCell" : sampleSize != null ? "equalTotal" : "perCell";
+    return {
+      mode: mode === "single" && fields.length > 0 ? "stratified" : mode,
+      fields,
+      allocation: asAllocation(sampling.allocation, allocationFallback),
+      sampleSize,
+      perCell,
+    };
+  }
+
+  const legacy = strategy as
+    | (TaskPersonaStrategy & {
+        defaultMode?: string;
+        stratifyFields?: string[];
+        sampleSizePerValueGroup?: number;
+        sampleSize?: number;
+      })
+    | null
+    | undefined;
+  const fields = Array.isArray(legacy?.stratifyFields)
+    ? legacy.stratifyFields.filter(
+        (field): field is string => typeof field === "string" && Boolean(field.trim()),
+      )
+    : [];
+  const perCell =
+    typeof legacy?.sampleSizePerValueGroup === "number" && legacy.sampleSizePerValueGroup >= 1
+      ? Math.round(legacy.sampleSizePerValueGroup)
       : null;
-  const allocationFallback: StratifiedAllocation =
-    perCell != null ? "perCell" : sampleSize != null ? "equalTotal" : "perCell";
+  const sampleSize =
+    typeof legacy?.sampleSize === "number" && legacy.sampleSize > 0
+      ? Math.round(legacy.sampleSize)
+      : null;
+  const mode = asSamplingMode(legacy?.defaultMode);
   return {
-    mode,
+    mode: fields.length > 0 ? "stratified" : mode,
     fields,
-    allocation: asAllocation(sampling.allocation, allocationFallback),
+    allocation: perCell != null ? "perCell" : sampleSize != null ? "equalTotal" : "perCell",
     sampleSize,
     perCell,
   };

--- a/application/playground/frontend/src/components/cockpit/setup/useCockpitBatchJob.ts
+++ b/application/playground/frontend/src/components/cockpit/setup/useCockpitBatchJob.ts
@@ -52,6 +52,8 @@ export function useCockpitBatchJob(
   const [restoredPersonaPool, setRestoredPersonaPool] = useState<string | null>(
     initial.personaPool,
   );
+  /** Operator stopped the batch — keep attachment locked until Reset. */
+  const [batchCancelled, setBatchCancelled] = useState(false);
 
   // Freeze the cohort to the batch launch snapshot until the user resets.
   const effectivePersonaIds = batchJobName
@@ -65,8 +67,13 @@ export function useCockpitBatchJob(
   // Large cohorts drop the heavy per-trial live feed for a lightweight,
   // incremental aggregate status feed that scales to tens of thousands.
   const aggregate = effectivePersonaIds.length > BATCH_MOSAIC_THRESHOLD;
-  const batchLive = useHarborBatchLive(batchJobName, { enabled: !aggregate });
-  const statusFeed = useHarborBatchStatus(batchJobName, aggregate);
+  const batchLive = useHarborBatchLive(batchJobName, {
+    enabled: !aggregate && !batchCancelled,
+  });
+  const statusFeed = useHarborBatchStatus(
+    batchCancelled ? null : batchJobName,
+    aggregate,
+  );
 
   const setBatchJobName = useCallback(
     (jobName: string | null, meta?: { taskId?: string; personaPool?: string }) => {
@@ -74,6 +81,7 @@ export function useCockpitBatchJob(
       if (!taskKind) return;
 
       if (jobName) {
+        setBatchCancelled(false);
         const personaIds = selectedPersonaIds.length > 0 ? selectedPersonaIds : restoredPersonaIds;
         const cohortSize = Math.max(
           selectedCount,
@@ -107,6 +115,7 @@ export function useCockpitBatchJob(
           });
         }
       } else {
+        setBatchCancelled(false);
         writeCockpitBatch(taskKind, null);
         setRestoredPersonaIds([]);
         setRestoredSelectedCount(0);
@@ -137,15 +146,16 @@ export function useCockpitBatchJob(
   const [retryError, setRetryError] = useState<string | null>(null);
 
   const cancelBatch = useCallback(async () => {
-    if (!batchJobName || cancelBusy) return;
+    if (!batchJobName || cancelBusy || batchCancelled) return;
     setCancelBusy(true);
     try {
       await api.deleteHarborJob(batchJobName);
-      clearBatch();
+      // Keep batchJobName so rails stay locked until Reset (same as done/failed).
+      setBatchCancelled(true);
     } finally {
       setCancelBusy(false);
     }
-  }, [batchJobName, cancelBusy, clearBatch]);
+  }, [batchCancelled, batchJobName, cancelBusy]);
 
   const retryFailed = useCallback(async () => {
     if (!batchJobName || retryBusy) return;
@@ -235,17 +245,19 @@ export function useCockpitBatchJob(
           (trial) => trial.completed && trial.error != null,
         ).length;
 
-  const isBatchActive = Boolean(batchJobName)
-    ? aggregate
-      ? statusSnapshot == null ||
-        statusSnapshot.launchStatus === "running" ||
-        statusSnapshot.launchStatus === "queued" ||
-        completedTrials < expectedTrialCount
-      : batchLive.isActive
-    : false;
+  const isBatchActive =
+    Boolean(batchJobName) && !batchCancelled
+      ? aggregate
+        ? statusSnapshot == null ||
+          statusSnapshot.launchStatus === "running" ||
+          statusSnapshot.launchStatus === "queued" ||
+          completedTrials < expectedTrialCount
+        : batchLive.isActive
+      : false;
 
   const batchComplete =
     Boolean(batchJobName) &&
+    !batchCancelled &&
     completedTrials >= expectedTrialCount &&
     expectedTrialCount > 0;
 
@@ -284,6 +296,7 @@ export function useCockpitBatchJob(
     clearBatch,
     cancelBatch,
     cancelBusy,
+    batchCancelled,
     retryFailed,
     retryBusy,
     retryError,
@@ -294,7 +307,11 @@ export function useCockpitBatchJob(
     completedTrials,
     expectedTrialCount,
     personaById,
-    batchError: aggregate ? statusFeed.error : batchLive.error,
+    batchError: batchCancelled
+      ? "Batch stopped. Reset to change setup and launch again."
+      : aggregate
+        ? statusFeed.error
+        : batchLive.error,
   };
 }
 
@@ -303,8 +320,10 @@ export function resolveRunLaunchPhase(
   batchComplete: boolean,
   batchError: string | null,
   phase: HarborCockpitPhase,
+  batchCancelled = false,
 ): RunLaunchPhase {
   if (batchJobName) {
+    if (batchCancelled) return "error";
     if (batchComplete) return "done";
     if (batchError) return "error";
     return "running";

--- a/application/playground/frontend/src/components/cockpit/setup/useSetupPersonaSampling.ts
+++ b/application/playground/frontend/src/components/cockpit/setup/useSetupPersonaSampling.ts
@@ -11,14 +11,17 @@ import { PERSONA_BENCH_POOL } from "@/lib/types";
 import {
   defaultPersonaSetup,
   hasStoredPersonaSetup,
+  isTaskStrategyFillPool,
   readCockpitPersonaSetup,
   sanitizePersonaPool,
+  scrubTaskStrategyFillForCustomMode,
   setupFromPersonaStrategy,
   writeCockpitPersonaSetup,
   type CockpitPersonaSetupRecord,
 } from "./cockpitPersonaSetupStorage";
 import {
   emptyPersonaDimensionFilters,
+  readStrategySampling,
   type PersonaDimensionFilters,
   type PersonaSamplingMode,
   type StratifiedAllocation,
@@ -150,22 +153,78 @@ export function useSetupPersonaSampling(
         resetToTaskStrategy();
         return;
       }
-      // Explicit operator opt-out — do not confuse with pre-hydrate false.
+      // Explicit opt-out: leave the task-fill / strategy cohort and return to
+      // the stock Quick-pick sandbox (dev-sample + empty selection).
+      const defaults = defaultPersonaSetup(fallbackPersonaModel);
       setTaskDefaultStrategyDismissed(true);
       setUseTaskDefaultStrategyState(false);
-      // Drop strategy-owned filters so custom mode starts clean.
+      setPersonaPool(PERSONA_BENCH_POOL);
+      setSelectedPersonaIds([]);
+      setSelectedCount(0);
+      setUseEntirePool(false);
+      setSamplingMode(defaults.samplingMode);
       setGroupFilters(emptyPersonaDimensionFilters());
-      // Custom stratified UI expects an editable per-cell; invent 1 only after unlock.
-      if (stratifiedAllocation === "perCell") {
-        setPerCell((prev) => (prev == null ? 1 : prev));
-      }
+      setFields(defaults.fields);
+      setStratifiedAllocationState(defaults.stratifiedAllocation);
+      setSampleSize(defaults.sampleSize);
+      setPerCell(defaults.perCell);
     },
-    [resetToTaskStrategy, stratifiedAllocation],
+    [fallbackPersonaModel, resetToTaskStrategy],
   );
 
   useEffect(() => {
     setTaskPersonaStrategy(strategyQuery.data ?? null);
   }, [strategyQuery.data]);
+
+  const appliedKeyRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!useTaskDefaultStrategy) {
+      appliedKeyRef.current = null;
+      return;
+    }
+    const strategy = strategyQuery.data;
+    if (!strategy) return;
+    const sampling = readStrategySampling(strategy);
+    const key = `${normalizedPath ?? ""}:${sampling.mode}:${sampling.allocation}:${sampling.sampleSize ?? ""}:${sampling.perCell ?? ""}:${sampling.fields.join(",")}`;
+    if (appliedKeyRef.current === key) return;
+    appliedKeyRef.current = key;
+    setSamplingMode(sampling.mode);
+    if (sampling.fields.length > 0) {
+      setFields(sampling.fields);
+    }
+    setStratifiedAllocationState(sampling.allocation);
+    if (sampling.allocation === "perCell") {
+      setPerCell(Math.min(50, Math.max(1, sampling.perCell ?? 1)));
+    } else {
+      setPerCell(null);
+      if (sampling.sampleSize != null) {
+        setSampleSize(Math.min(500, Math.max(2, sampling.sampleSize)));
+      }
+    }
+    setGroupFilters({
+      sources: Array.isArray(strategy.sources)
+        ? strategy.sources.filter(
+            (value): value is string => typeof value === "string" && Boolean(value.trim()),
+          )
+        : [],
+      dimensionFilters:
+        strategy.dimensionFilters && typeof strategy.dimensionFilters === "object"
+          ? Object.fromEntries(
+              Object.entries(strategy.dimensionFilters)
+                .map(([key, values]) => [
+                  key,
+                  Array.isArray(values)
+                    ? values.filter(
+                        (value): value is string =>
+                          typeof value === "string" && Boolean(value.trim()),
+                      )
+                    : [],
+                ])
+                .filter(([, values]) => (values as string[]).length > 0),
+            )
+          : {},
+    });
+  }, [normalizedPath, strategyQuery.data, useTaskDefaultStrategy]);
 
   useEffect(() => {
     const path = normalizedPath;
@@ -200,12 +259,20 @@ export function useSetupPersonaSampling(
         applied.selectedCount = stored.selectedCount || stored.selectedPersonaIds.length;
         applied.useEntirePool = stored.useEntirePool;
       }
+      // Task-fill pools belong to Task default ON — restore them with the cohort.
+      if (isTaskStrategyFillPool(stored.personaPool)) {
+        applied.personaPool = sanitizePersonaPool(stored.personaPool);
+      }
     } else if (hasTaskSpecificStore) {
-      applied = {
-        ...stored,
-        useTaskDefaultStrategy: Boolean(strategy) && stored.useTaskDefaultStrategy,
-        taskDefaultStrategyDismissed: dismissed,
-      };
+      // Custom / dismissed: restore draft, but never sticky-restore a task-fill pool.
+      applied = scrubTaskStrategyFillForCustomMode(
+        {
+          ...stored,
+          useTaskDefaultStrategy: Boolean(strategy) && stored.useTaskDefaultStrategy,
+          taskDefaultStrategyDismissed: dismissed,
+        },
+        fallbackPersonaModel,
+      );
     } else {
       applied = setupFromPersonaStrategy(strategy, fallbackPersonaModel, {
         ...defaultPersonaSetup(fallbackPersonaModel),
@@ -286,24 +353,28 @@ export function useSetupPersonaSampling(
       skipNextPersistRef.current = false;
       return;
     }
+    const draft: CockpitPersonaSetupRecord = {
+      selectedPersonaIds,
+      selectedCount,
+      useEntirePool,
+      samplingMode,
+      groupFilters,
+      fields,
+      stratifiedAllocation,
+      sampleSize,
+      perCell,
+      parallelTrials,
+      personaModel,
+      personaPool,
+      useTaskDefaultStrategy,
+      taskDefaultStrategyDismissed,
+    };
+    // Task-fill pools are valid only while Task default is on.
     writeCockpitPersonaSetup(
       taskKind,
-      {
-        selectedPersonaIds,
-        selectedCount,
-        useEntirePool,
-        samplingMode,
-        groupFilters,
-        fields,
-        stratifiedAllocation,
-        sampleSize,
-        perCell,
-        parallelTrials,
-        personaModel,
-        personaPool,
-        useTaskDefaultStrategy,
-        taskDefaultStrategyDismissed,
-      },
+      useTaskDefaultStrategy
+        ? draft
+        : scrubTaskStrategyFillForCustomMode(draft, fallbackPersonaModel),
       normalizedPath,
     );
   }, [
@@ -323,6 +394,7 @@ export function useSetupPersonaSampling(
     personaPool,
     useTaskDefaultStrategy,
     taskDefaultStrategyDismissed,
+    fallbackPersonaModel,
   ]);
 
   useEffect(() => {

--- a/application/playground/frontend/src/lib/api.ts
+++ b/application/playground/frontend/src/lib/api.ts
@@ -15,6 +15,8 @@ import type {
   PersonaPoolCardsResponse,
   PersonaPoolIdsResponse,
   PersonaPoolPersonaDetail,
+  PersonaPoolGenerateResult,
+  PersonaPoolGenerateProgress,
   PersonaPoolSampleResult,
   TaskDetail,
   TaskPersonaStrategy,
@@ -351,6 +353,87 @@ export const api = {
         ...body,
       }),
     }),
+  generatePersonaPool: async (
+    body: {
+      count?: number;
+      seed?: number;
+      dimensionFilters?: Record<string, string | string[]>;
+      fields?: string[];
+      perCell?: number;
+      allocation?: string;
+      sampleSize?: number;
+      taskPath?: string;
+      name?: string;
+    },
+    options?: { onProgress?: (event: PersonaPoolGenerateProgress) => void },
+  ): Promise<PersonaPoolGenerateResult> => {
+    if (!options?.onProgress) {
+      return request<PersonaPoolGenerateResult>("/api/persona-pool/generate", {
+        method: "POST",
+        body: JSON.stringify(body),
+      });
+    }
+
+    const response = await fetch("/api/persona-pool/generate?stream=1", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/x-ndjson" },
+      body: JSON.stringify(body),
+    });
+    if (!response.ok || !response.body) {
+      let message = response.statusText || "Generate failed";
+      try {
+        const data = await response.json();
+        if (data && typeof data === "object" && "detail" in data) {
+          message = typeof data.detail === "string" ? data.detail : message;
+        }
+      } catch {
+        /* ignore */
+      }
+      throw new ApiError(response.status, message);
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    let result: PersonaPoolGenerateResult | null = null;
+
+    const handleLine = (line: string) => {
+      const trimmed = line.trim();
+      if (!trimmed) return;
+      const event = JSON.parse(trimmed) as
+        | PersonaPoolGenerateProgress
+        | (PersonaPoolGenerateResult & { type: "result" })
+        | { type: "error"; detail?: string; status?: number };
+      if (event.type === "progress") {
+        options.onProgress?.(event);
+        return;
+      }
+      if (event.type === "error") {
+        throw new ApiError(
+          typeof event.status === "number" ? event.status : 500,
+          event.detail || "Generate failed",
+        );
+      }
+      if (event.type === "result") {
+        const { type: _type, ...payload } = event;
+        result = payload as PersonaPoolGenerateResult;
+      }
+    };
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+      for (const line of lines) handleLine(line);
+    }
+    if (buffer.trim()) handleLine(buffer);
+    if (!result) {
+      throw new ApiError(500, "Generate stream ended without a result");
+    }
+    return result;
+  },
 
   listPersonaCohorts: () =>
     request<{ cohorts: PersonaCohortSummary[] }>("/api/persona-pool/cohorts"),

--- a/application/playground/frontend/src/lib/personaPoolCopy.ts
+++ b/application/playground/frontend/src/lib/personaPoolCopy.ts
@@ -25,12 +25,15 @@ export function isPersonaPoolCoverageError(message: string | null | undefined): 
   );
 }
 
-export function personaPoolCoverageHint(_taskPath?: string | null): string {
+export function personaPoolCoverageHint(taskPath?: string | null): string {
+  const synthesize = taskPath
+    ? " With Task default persona strategy on, you can also Synthesize to fill this task."
+    : "";
   return (
     "Not enough matching personas in this dataset for the current filters. " +
-    "Widen filters / sources, switch dataset (dev sample vs matraix-persona-1m), " +
-    "or use a saved cohort that already has enough matches. " +
-    "Playground does not synthesize missing personas."
+    "Consider switching Dataset to matraix-persona-1m for fuller coverage." +
+    synthesize +
+    " Or widen filters / sources, or use a saved cohort that already has enough matches."
   );
 }
 
@@ -44,6 +47,7 @@ export function formatPersonaSampleError(
     const first = trimmed.split("\n").find((line) => line.trim()) || trimmed;
     const alreadyHinted =
       trimmed.includes("matraix-persona-1m") ||
+      trimmed.includes("Synthesize to fill") ||
       trimmed.includes("does not synthesize");
     return alreadyHinted ? trimmed : `${first}\n\n${personaPoolCoverageHint(taskPath)}`;
   }

--- a/application/playground/frontend/src/lib/types.ts
+++ b/application/playground/frontend/src/lib/types.ts
@@ -977,7 +977,7 @@ export interface PersonaMatchAttributesResponse {
 export interface PersonaDatasetOption {
   pool: string;
   label: string;
-  kind: "dataset" | "generated" | "production" | "production-cohort" | string;
+  kind: "dataset" | "saved" | "generated" | "production" | "production-cohort" | string;
   count: number;
   default?: boolean;
   available?: boolean;
@@ -993,6 +993,27 @@ export interface PersonaPoolIdsResponse {
   personaIds: string[];
   count: number;
   idsTruncated?: boolean;
+}
+
+export interface PersonaPoolGenerateResult {
+  pool: string;
+  label: string;
+  count: number;
+  dimensionCount: number;
+  source: string;
+  kind: string;
+  personaIds: string[];
+  seed: number;
+}
+
+/** NDJSON progress line from ``POST /api/persona-pool/generate?stream=1``. */
+export interface PersonaPoolGenerateProgress {
+  type: "progress";
+  stage: "prepare" | "sample" | "write" | "manifest" | "done" | string;
+  ratio: number;
+  label: string;
+  done?: number;
+  total?: number;
 }
 
 export interface PersonaPoolSampleResult {
@@ -1103,6 +1124,8 @@ export const PERSONA_BENCH_POOL = "persona/datasets/matraix-persona-dev-sample";
 /** Production 1M coreset (HF MatrAIx_Persona_1M_Public_Release). */
 export const PERSONA_PRODUCTION_1M_POOL = "persona/datasets/matraix-persona-1m";
 export const PERSONA_SAMPLE_SIZE_MAX_DEV = 500;
+export const PERSONA_GENERATE_COUNT_DEFAULT = 2000;
+export const PERSONA_GENERATE_COUNT_MAX = 5000;
 export const PERSONA_SAMPLE_SIZE_MAX_PRODUCTION = 10_000;
 
 /**

--- a/application/playground/frontend/src/lib/useHarborCockpitRun.ts
+++ b/application/playground/frontend/src/lib/useHarborCockpitRun.ts
@@ -418,9 +418,20 @@ export function useHarborCockpitRun<TJob>(options: UseHarborCockpitRunOptions) {
       await api.deleteHarborJob(jobName);
     } finally {
       setCancelBusy(false);
-      reset();
+      // Stay locked until Reset — same end-state as a failed/finished run.
+      setJob(null);
+      setHarborJobName(null);
+      setHarborTrialName(null);
+      setHarborPhase(null);
+      setVncUrl(null);
+      setSandboxId(null);
+      liveStateRef.current = EMPTY_LIVE;
+      eventOffsetRef.current = 0;
+      clearCockpitUrl();
+      setPhase("error");
+      setError("Run stopped. Reset to change setup and launch again.");
     }
-  }, [cancelBusy, harborJobName, phase, reset]);
+  }, [cancelBusy, clearCockpitUrl, harborJobName, phase]);
 
   return {
     run,

--- a/persona/synthesis/sampler/sampler.py
+++ b/persona/synthesis/sampler/sampler.py
@@ -384,10 +384,57 @@ class PersonaForwardSampler:
             [len(self.values[nid]) for nid in self.required_nodes]
         )
 
-    def sample_indices(self, n: int) -> Dict[str, np.ndarray]:
-        """Sample N personas and return integer-coded node values."""
+    def _fixed_value_indices(self, fixed: Mapping[str, str] | None) -> Dict[str, int]:
+        if not fixed:
+            return {}
+        out: Dict[str, int] = {}
+        for nid, value in fixed.items():
+            if nid not in self.vtoi:
+                raise ValueError(f"cannot clamp unknown DAG node {nid!r}")
+            if value not in self.vtoi[nid]:
+                raise ValueError(f"cannot clamp {nid}={value!r}; not in node values")
+            out[nid] = int(self.vtoi[nid][value])
+        return out
+
+    def assignment_supported(self, fixed: Mapping[str, str] | None) -> bool:
+        """Whether this partial assignment can be pinned on the DAG.
+
+        Unknown nodes/values are unsupported. A hard mask (multiplier 0) fires
+        only when every condition field is present in ``fixed`` and matches.
+        Unpinned parents stay free, so the cell is still allowed.
+        """
+        if not fixed:
+            return True
+        try:
+            fixed_idx = self._fixed_value_indices(fixed)
+        except ValueError:
+            return False
+        for target, masks in self.masks.items():
+            if target not in fixed_idx:
+                continue
+            t_idx = fixed_idx[target]
+            for mask in masks:
+                if float(mask["value_mult"][t_idx]) != 0.0:
+                    continue
+                if any(
+                    parent not in fixed_idx or not np.isin(int(fixed_idx[parent]), allowed)
+                    for parent, allowed in mask["condition"]
+                ):
+                    continue
+                return False
+        return True
+
+    def sample_indices(
+        self, n: int, *, fixed: Mapping[str, str] | None = None
+    ) -> Dict[str, np.ndarray]:
+        """Sample N personas and return integer-coded node values.
+
+        ``fixed`` pins named nodes to a value on every row. Later nodes still
+        condition on those pins.
+        """
         idx: Dict[str, np.ndarray] = {}
         rng = self.rng
+        fixed_idx = self._fixed_value_indices(fixed)
         out_dtype = self._index_dtype
         kmax = self._plan_max_k
         # All per-node work runs in reused value-major (k, n) views of these
@@ -403,6 +450,9 @@ class PersonaForwardSampler:
         sel = np.empty(n, dtype=np.int64)
 
         for plan in self._plan:
+            if plan.nid in fixed_idx:
+                idx[plan.nid] = np.full(n, fixed_idx[plan.nid], dtype=out_dtype)
+                continue
             k = plan.k
             rng.random(out=u)
 
@@ -469,7 +519,12 @@ class PersonaForwardSampler:
             idx[plan.nid] = sel.astype(out_dtype)
 
         for nid in self._prior_only_nodes:
-            idx[nid] = rng.choice(len(self.values[nid]), size=n, p=self.prior[nid]).astype(out_dtype)
+            if nid in fixed_idx:
+                idx[nid] = np.full(n, fixed_idx[nid], dtype=out_dtype)
+            else:
+                idx[nid] = rng.choice(
+                    len(self.values[nid]), size=n, p=self.prior[nid]
+                ).astype(out_dtype)
         return idx
 
     def _codes_dtype(self) -> np.dtype:
@@ -561,8 +616,10 @@ class PersonaForwardSampler:
             node_ids = [nid for nid, n in self.nodes.items() if include_hidden or n.get("emit", True) is not False]
         return {nid: self.values[nid][int(idx[nid][row])] for nid in node_ids if nid in idx}
 
-    def sample(self, n: int) -> List[Dict[str, str]]:
-        idx = self.sample_indices(n)
+    def sample(
+        self, n: int, *, fixed: Mapping[str, str] | None = None
+    ) -> List[Dict[str, str]]:
+        idx = self.sample_indices(n, fixed=fixed)
         return [self.decode_row(idx, i) for i in range(n)]
 
     def write_jsonl(self, idx: Dict[str, np.ndarray], out: str | Path) -> None:

--- a/src/matraix/persona_generator.py
+++ b/src/matraix/persona_generator.py
@@ -1,11 +1,13 @@
-"""Generate consistent synthetic persona YAML from dimensions.json."""
+"""Sample synthetic persona YAML from the Full DAG."""
 
 from __future__ import annotations
 
+import itertools
 import json
 import random
+import sys
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any, Callable
 
 import yaml
 
@@ -21,9 +23,12 @@ from matraix.persona_consistency import (
     validate_dimensions,
 )
 
+if TYPE_CHECKING:
+    from persona.synthesis.sampler import PersonaForwardSampler
+
 DEFAULT_CATALOG_PATH = "persona/schema/dimensions.json"
 DEFAULT_PERSONA_VERSION = "1.0"
-PERSONA_SOURCES = ("Nemotron", "OASIS", "PersonaHub", "PRIMEX")
+SYNTHETIC_SOURCE = "synthetic"
 
 
 def _repo_root() -> Path:
@@ -131,26 +136,27 @@ def _count_stratum(personas: list[dict[str, Any]], stratum: dict[str, str]) -> i
     return sum(1 for entry in personas if _stratum_match(entry["dimensions"], stratum))
 
 
-def _pick_source(rng: random.Random, sources: tuple[str, ...]) -> str:
-    if not sources:
-        raise ValueError("sources must not be empty")
-    return rng.choice(sources)
-
-
 def _persona_entry(
     *,
     persona_id: str,
     dimensions: dict[str, str],
     version: str,
-    source_rng: random.Random,
-    sources: tuple[str, ...],
 ) -> dict[str, Any]:
     return {
         "persona_id": persona_id,
         "version": version,
-        "source": _pick_source(source_rng, sources),
+        "source": SYNTHETIC_SOURCE,
         "dimensions": dimensions,
     }
+
+
+def _dag_sampler(*, seed: int) -> PersonaForwardSampler:
+    root = str(_repo_root())
+    if root not in sys.path:
+        sys.path.insert(0, root)
+    from persona.synthesis.sampler import DEFAULT_GRAPH_PATH, PersonaForwardSampler, SamplingConfig
+
+    return PersonaForwardSampler(DEFAULT_GRAPH_PATH, SamplingConfig(seed=seed))
 
 
 def top_up_strata(
@@ -158,45 +164,34 @@ def top_up_strata(
     *,
     strata: list[dict[str, str]],
     min_per_stratum: int,
-    rng,
-    catalog: dict[str, list[str]],
-    dev_dimension_ids: tuple[str, ...],
-    catalog_path: str,
     persona_version: str = DEFAULT_PERSONA_VERSION,
-    sources: tuple[str, ...] = PERSONA_SOURCES,
-    max_attempts_per_stratum: int = 500,
+    sampler: PersonaForwardSampler | None = None,
+    seed: int = 42,
 ) -> list[dict[str, Any]]:
-    """Append consistent personas until each stratum meets *min_per_stratum*."""
+    """Add synthetic rows until each filter cell has at least ``min_per_stratum`` matches.
+
+    Filter keys are pinned; every other field is still sampled from the DAG.
+    Cells the DAG cannot pin are skipped.
+    """
     if min_per_stratum < 1:
         return personas
 
     out = list(personas)
     next_index = max((int(entry["persona_id"]) for entry in out), default=0) + 1
+    dag = sampler or _dag_sampler(seed=seed)
 
     for stratum in strata:
-        attempts = 0
-        while _count_stratum(out, stratum) < min_per_stratum:
-            attempts += 1
-            if attempts > max_attempts_per_stratum:
-                raise RuntimeError(
-                    f"Could not top up stratum {stratum!r} to {min_per_stratum} "
-                    f"after {max_attempts_per_stratum} attempts"
-                )
-            dimensions = generate_persona_dimensions(
-                rng=rng,
-                catalog=catalog,
-                dev_dimension_ids=dev_dimension_ids,
-                catalog_path=catalog_path,
-                age_bracket=stratum.get("age_bracket"),
-                fixed_dimensions=stratum,
-            )
+        if not dag.assignment_supported(stratum):
+            continue
+        need = min_per_stratum - _count_stratum(out, stratum)
+        if need <= 0:
+            continue
+        for row in dag.sample(need, fixed=stratum):
             out.append(
                 _persona_entry(
                     persona_id=str(next_index).zfill(4),
-                    dimensions=dimensions,
+                    dimensions=dict(row),
                     version=persona_version,
-                    source_rng=rng,
-                    sources=sources,
                 )
             )
             next_index += 1
@@ -219,14 +214,10 @@ def build_filter_strata(
     *,
     max_strata: int = 2048,
 ) -> list[dict[str, str]]:
-    """Cartesian product of multi-value ``dimensionFilters`` → fixed strata cells.
+    """Cartesian product of multi-value ``dimensionFilters`` → one cell per combination.
 
-    Each cell is a ``dict[str, str]`` suitable for ``top_up_strata`` /
-    ``generate_persona_dimensions(fixed_dimensions=…)``. Empty filters yield
-    no strata (caller should require filters when generating from a strategy).
-
-    Callers should pass the result through ``filter_feasible_strata`` when
-    filters may combine constrained dimensions incompatibly (e.g. age × life_stage).
+    Pass the result through ``filter_strata_on_dag`` before pinning cells on the
+    Full DAG. ``filter_feasible_strata`` is a catalog check for existing pools.
     """
     if not dimension_filters:
         return []
@@ -265,10 +256,9 @@ def filter_feasible_strata(
     *,
     catalog_path: str | Path | None = None,
 ) -> tuple[list[dict[str, str]], list[dict[str, str]]]:
-    """Keep strata that can produce a consistency-valid persona.
+    """Drop filter cells that combine incompatible constrained dimensions.
 
-    Returns ``(feasible, dropped)``. Dropped cells are usually incompatible
-    constrained-dimension combinations from a cartesian filter expand.
+    Returns ``(kept, dropped)``.
     """
     cat_path = str(catalog_path or DEFAULT_CATALOG_PATH)
     catalog = load_catalog_values(cat_path)
@@ -293,103 +283,191 @@ def filter_feasible_strata(
     return feasible, dropped
 
 
+def filter_strata_on_dag(
+    strata: list[dict[str, str]],
+    *,
+    sampler: PersonaForwardSampler | None = None,
+    seed: int = 42,
+) -> tuple[list[dict[str, str]], list[dict[str, str]]]:
+    """Keep filter cells the Full DAG can pin.
+
+    Drops unknown dimension/value pairs and cells that hit a DAG hard mask.
+    Returns ``(kept, dropped)``.
+    """
+    dag = sampler or _dag_sampler(seed=seed)
+    kept: list[dict[str, str]] = []
+    dropped: list[dict[str, str]] = []
+    for stratum in strata:
+        if dag.assignment_supported(stratum):
+            kept.append(stratum)
+        else:
+            dropped.append(stratum)
+    return kept, dropped
+
+
+def stratified_cell_quota(
+    *,
+    allocation: str | None,
+    per_cell: int | None,
+    sample_size: int | None,
+    n_cells: int,
+    default: int = 2,
+) -> int:
+    """Rows per stratify cell so a later Playground draw will not run short.
+
+    Matches Playground stratified sampling:
+
+    * ``perCell`` — ``N`` in every cell (cohort = ``N × #cells``)
+    * ``equalTotal`` — ``ceil(sampleSize / #cells)`` then the draw clips to ``sampleSize``
+    * ``proportional`` — same floor so every cell exists and the pool is ≥ ``sampleSize``
+    """
+    if n_cells < 1:
+        raise ValueError("n_cells must be >= 1")
+    alloc = str(allocation or "").strip()
+    if alloc == "perCell":
+        if not isinstance(per_cell, int) or per_cell < 1:
+            raise ValueError('allocation "perCell" requires perCell >= 1')
+        return per_cell
+    if alloc in {"equalTotal", "proportional"}:
+        if not isinstance(sample_size, int) or sample_size < 1:
+            raise ValueError(f'allocation "{alloc}" requires sampleSize >= 1')
+        if alloc == "equalTotal" and sample_size < n_cells:
+            raise ValueError(
+                f"sampleSize={sample_size} is below the stratified cell count={n_cells} "
+                "(need ≥1 persona per combination)"
+            )
+        return max(1, (sample_size + n_cells - 1) // n_cells)
+    if isinstance(per_cell, int) and per_cell >= 1:
+        return per_cell
+    if isinstance(sample_size, int) and sample_size >= 1:
+        return max(1, (sample_size + n_cells - 1) // n_cells)
+    return default
+
+
+def extend_cells_with_allowed_filters(
+    cells: list[dict[str, str]],
+    extra_filters: dict[str, list[str]],
+    *,
+    sampler: PersonaForwardSampler,
+    max_tries_per_cell: int = 2048,
+) -> tuple[list[dict[str, str]], list[dict[str, str]]]:
+    """Pin one allowed value for each extra filter dim so rows survive ``dimensionFilters``."""
+    if not extra_filters:
+        return list(cells), []
+    extra_dims = sorted(extra_filters)
+    extra_values = [list(extra_filters[dim]) for dim in extra_dims]
+    kept: list[dict[str, str]] = []
+    dropped: list[dict[str, str]] = []
+    for cell in cells:
+        found: dict[str, str] | None = None
+        for index, combo in enumerate(itertools.product(*extra_values)):
+            if index >= max_tries_per_cell:
+                break
+            pinned = {**cell, **dict(zip(extra_dims, combo, strict=True))}
+            if sampler.assignment_supported(pinned):
+                found = pinned
+                break
+        if found is None:
+            dropped.append(cell)
+        else:
+            kept.append(found)
+    return kept, dropped
+
+
+def strategy_pin_cells(
+    *,
+    dimension_filters: dict[str, list[str]],
+    stratify_fields: list[str] | None = None,
+    sampler: PersonaForwardSampler | None = None,
+    seed: int = 42,
+    max_strata: int = 2048,
+) -> tuple[list[dict[str, str]], list[dict[str, str]]]:
+    """Pin cells Playground will bucket on, plus extra filters so rows still match.
+
+    Stratified draws use ``sampling.fields``. Other ``dimensionFilters`` are still
+    applied first, so each cell is extended with one allowed value per extra dim.
+    """
+    dag = sampler or _dag_sampler(seed=seed)
+    fields = [
+        str(field).removeprefix("dimensions.").strip()
+        for field in (stratify_fields or [])
+        if str(field).strip()
+    ]
+    if fields:
+        axes = {field: list(dimension_filters[field]) for field in fields}
+    else:
+        axes = dict(dimension_filters)
+    cells = build_filter_strata(axes, max_strata=max_strata)
+    cells, dropped = filter_strata_on_dag(cells, sampler=dag)
+    extra = {
+        key: list(values)
+        for key, values in dimension_filters.items()
+        if key not in axes
+    }
+    if extra:
+        cells, dropped_extra = extend_cells_with_allowed_filters(
+            cells, extra, sampler=dag
+        )
+        dropped.extend(dropped_extra)
+    return cells, dropped
+
+
 def generate_persona_pool(
     *,
     count: int,
     seed: int = 42,
-    catalog_path: str | Path | None = None,
     smoke_persona_id: str = "0042",
     stratum_top_up: list[dict[str, str]] | None = None,
     min_per_stratum: int = 0,
     persona_version: str = DEFAULT_PERSONA_VERSION,
-    sources: tuple[str, ...] = PERSONA_SOURCES,
     include_smoke: bool = True,
 ) -> list[dict[str, Any]]:
-    """Build *count* personas with roughly even age_bracket coverage.
+    """Sample ``count`` synthetic personas from the Full DAG.
 
-    ``count`` may be ``0`` when the caller only wants ``stratum_top_up`` cells
-    (e.g. task ``persona_strategy.json`` coverage pools).
+    ``count`` may be ``0`` to only fill ``stratum_top_up`` cells (each DAG-supported
+    cell gets at least ``min_per_stratum`` rows).
     """
     if count < 0:
         raise ValueError("count must be >= 0")
-    cat_path = str(catalog_path or DEFAULT_CATALOG_PATH)
-    catalog = load_catalog_values(cat_path)
-    dev_ids = load_dev_dimension_ids(catalog_path=cat_path)
-    rng = random.Random(seed)
-    ages = catalog["age_bracket"]
-    per_age = count // len(ages) if ages else 0
-    extra = count % len(ages) if ages else 0
-
+    dag = _dag_sampler(seed=seed)
     personas: list[dict[str, Any]] = []
-    persona_index = 1
-    for age_index, age in enumerate(ages):
-        n = per_age + (1 if age_index < extra else 0)
-        for _ in range(n):
-            persona_id = str(persona_index).zfill(4)
-            dimensions = generate_persona_dimensions(
-                rng=rng,
-                catalog=catalog,
-                dev_dimension_ids=dev_ids,
-                catalog_path=cat_path,
-                age_bracket=age,
+    for index, row in enumerate(dag.sample(count) if count else [], start=1):
+        personas.append(
+            _persona_entry(
+                persona_id=str(index).zfill(4),
+                dimensions=dict(row),
+                version=persona_version,
             )
-            personas.append(
-                _persona_entry(
-                    persona_id=persona_id,
-                    dimensions=dimensions,
-                    version=persona_version,
-                    source_rng=rng,
-                    sources=sources,
-                )
-            )
-            persona_index += 1
-
-    if stratum_top_up and min_per_stratum > 0:
-        personas = top_up_strata(
-            personas,
-            strata=stratum_top_up,
-            min_per_stratum=min_per_stratum,
-            rng=rng,
-            catalog=catalog,
-            dev_dimension_ids=dev_ids,
-            catalog_path=cat_path,
-            persona_version=persona_version,
-            sources=sources,
         )
 
-    source_rng = random.Random(seed + 7)
-    for entry in personas:
-        entry["source"] = _pick_source(source_rng, sources)
+    if stratum_top_up and min_per_stratum > 0:
+        kept, _dropped = filter_strata_on_dag(stratum_top_up, sampler=dag)
+        personas = top_up_strata(
+            personas,
+            strata=kept,
+            min_per_stratum=min_per_stratum,
+            persona_version=persona_version,
+            sampler=dag,
+            seed=seed,
+        )
 
     if not include_smoke:
         return personas
 
-    smoke_rng = random.Random(seed + 42)
-    smoke_dims = generate_persona_dimensions(
-        rng=smoke_rng,
-        catalog=catalog,
-        dev_dimension_ids=dev_ids,
-        catalog_path=cat_path,
-    )
+    if any(entry["persona_id"] == smoke_persona_id for entry in personas):
+        return personas
     smoke_entry = _persona_entry(
         persona_id=smoke_persona_id,
-        dimensions=smoke_dims,
+        dimensions=dict(dag.sample(1)[0]),
         version=persona_version,
-        source_rng=source_rng,
-        sources=sources,
     )
-    for index, entry in enumerate(personas):
-        if entry["persona_id"] == smoke_persona_id:
-            personas[index] = smoke_entry
-            return personas
     if not personas:
-        personas.append(smoke_entry)
-        return personas
+        return [smoke_entry]
     smoke_index = int(smoke_persona_id) - 1
     if 0 <= smoke_index < len(personas):
         personas[smoke_index] = smoke_entry
-    else:
-        personas.append(smoke_entry)
+        return personas
+    personas.append(smoke_entry)
     return personas
 
 
@@ -405,11 +483,23 @@ def write_persona_dataset(
     persona_version: str = DEFAULT_PERSONA_VERSION,
     manifest_name: str | None = None,
     manifest_description: str | None = None,
+    on_progress: Callable[[str, dict[str, Any]], None] | None = None,
 ) -> dict[str, Any]:
+    """Write one YAML per persona + ``manifest.json``.
+
+    ``on_progress(stage, payload)`` is optional. Stages: ``write`` (with
+    ``done``/``total``) and ``manifest``.
+    """
     out_dir.mkdir(parents=True, exist_ok=True)
-    dev_ids = load_dev_dimension_ids(catalog_path=catalog_path)
+    if personas:
+        dimension_ids = list(personas[0]["dimensions"])
+    else:
+        dimension_ids = list(load_dev_dimension_ids(catalog_path=catalog_path))
     manifest_personas: list[dict[str, Any]] = []
-    for entry in personas:
+    total = len(personas)
+    # ~40 updates max so large pools stay responsive without flooding the wire.
+    report_every = max(1, total // 40) if total else 1
+    for index, entry in enumerate(personas, start=1):
         persona_id = entry["persona_id"]
         rel_path = f"{out_dir.relative_to(repo_root)}/persona_{persona_id}.yaml"
         payload = {
@@ -429,6 +519,15 @@ def write_persona_dataset(
                 "dimensions": entry["dimensions"],
             }
         )
+        if on_progress and (index == total or index % report_every == 0):
+            on_progress(
+                "write",
+                {
+                    "done": index,
+                    "total": total,
+                    "label": f"Writing personas ({index}/{total})",
+                },
+            )
 
     source_counts: dict[str, int] = {}
     for entry in manifest_personas:
@@ -436,16 +535,19 @@ def write_persona_dataset(
         if source:
             source_counts[source] = source_counts.get(source, 0) + 1
 
+    if on_progress:
+        on_progress("manifest", {"label": "Writing manifest…"})
+
     manifest: dict[str, Any] = {
         "kind": kind,
         "count": len(manifest_personas),
         "seed": seed,
         "schema_version": persona_version,
         "smoke_persona_id": smoke_persona_id,
-        "dimension_ids": list(dev_ids),
-        "dimension_count": len(dev_ids),
+        "dimension_ids": list(dimension_ids),
+        "dimension_count": len(dimension_ids),
         "dimension_categories": "persona/schema/dimension_categories.json",
-        "persona_sources": list(PERSONA_SOURCES),
+        "persona_sources": sorted(source_counts),
         "source_counts": source_counts,
         "personas": manifest_personas,
     }

--- a/tests/persona/synthesis/test_parallel_sampling.py
+++ b/tests/persona/synthesis/test_parallel_sampling.py
@@ -243,3 +243,25 @@ def test_conditional_hard_mask_is_enforced(tmp_path: Path) -> None:
     power = idx["tool_python"] == sampler.vtoi["tool_python"]["Power user"]
     assert minors.sum() > 0
     assert not (minors & power).any()
+
+
+def test_sample_clamps_fixed_nodes(tmp_path: Path) -> None:
+    graph_path = tmp_path / "tiny_graph.json"
+    _write_tiny_graph(graph_path)
+    sampler = PersonaForwardSampler(graph_path, SamplingConfig(seed=3))
+    rows = sampler.sample(40, fixed={"age_bracket": "18-24"})
+    assert all(row["age_bracket"] == "18-24" for row in rows)
+    assert {row["tool_python"] for row in rows} == {"Never used", "Power user"}
+
+
+def test_assignment_supported_uses_hard_masks(tmp_path: Path) -> None:
+    graph_path = tmp_path / "tiny_graph.json"
+    _write_tiny_graph(graph_path)
+    sampler = PersonaForwardSampler(graph_path, SamplingConfig(seed=3))
+    assert sampler.assignment_supported({"age_bracket": "18-24", "tool_python": "Power user"})
+    assert sampler.assignment_supported({"age_bracket": "13-17", "tool_python": "Never used"})
+    assert not sampler.assignment_supported(
+        {"age_bracket": "13-17", "tool_python": "Power user"}
+    )
+    assert sampler.assignment_supported({"tool_python": "Power user"})
+    assert not sampler.assignment_supported({"age_bracket": "99-99"})

--- a/tests/unit/playground_core/test_persona_generator.py
+++ b/tests/unit/playground_core/test_persona_generator.py
@@ -92,26 +92,25 @@ def test_dev_dimension_ids_include_core_catalog_fields() -> None:
     assert len(dev_ids) == 124
 
 
-def test_generate_pool_has_no_violations() -> None:
+def test_generate_pool_is_synthetic_full_dag() -> None:
     personas = generate_persona_pool(count=50, seed=99)
     for entry in personas:
-        assert validate_dimensions(entry["dimensions"]) == []
-        assert entry.get("source") in {"Nemotron", "OASIS", "PersonaHub", "PRIMEX"}
+        assert entry.get("source") == "synthetic"
         assert entry.get("version") == "1.0"
+        assert len(entry["dimensions"]) >= 1000
+        assert "age_bracket" in entry["dimensions"]
         assert "lstyle_diet_type" in entry["dimensions"]
         assert "health_dietary_restriction" in entry["dimensions"]
         assert "habit_meal_prepping" in entry["dimensions"]
         assert any(key.startswith("cuis_") for key in entry["dimensions"])
 
 
-def test_top_up_strata_adds_consistent_personas() -> None:
+def test_top_up_strata_fills_filter_cells() -> None:
     from matraix.persona_generator import (
         build_probe_strata,
         generate_persona_pool,
         top_up_strata,
-        load_catalog_values,
     )
-    from matraix.persona_consistency import load_dev_dimension_ids
 
     confounders = {
         "socioeconomic_band": "Middle",
@@ -125,18 +124,11 @@ def test_top_up_strata_adds_consistent_personas() -> None:
         probe_values=["Cost-sensitive", "Indifferent"],
     )
     personas = generate_persona_pool(count=50, seed=1, smoke_persona_id="0001")
-    catalog = load_catalog_values()
-    dev_ids = load_dev_dimension_ids()
-    import random
-
     topped = top_up_strata(
         personas,
         strata=strata,
         min_per_stratum=2,
-        rng=random.Random(99),
-        catalog=catalog,
-        dev_dimension_ids=dev_ids,
-        catalog_path="persona/schema/dimensions.json",
+        seed=99,
     )
     assert len(topped) > len(personas)
     for stratum in strata:
@@ -147,7 +139,7 @@ def test_top_up_strata_adds_consistent_personas() -> None:
         ]
         assert len(matches) >= 2
         for entry in matches:
-            assert validate_dimensions(entry["dimensions"]) == []
+            assert entry.get("source") == "synthetic"
 
 
 def test_build_filter_strata_cartesian() -> None:
@@ -164,10 +156,55 @@ def test_build_filter_strata_cartesian() -> None:
     assert {"age_bracket": "35-44", "life_stage": "Early career"} in strata
 
 
+def test_stratified_cell_quota_matches_playground_allocations() -> None:
+    import pytest
+
+    from matraix.persona_generator import stratified_cell_quota
+
+    assert (
+        stratified_cell_quota(
+            allocation="perCell", per_cell=4, sample_size=None, n_cells=10
+        )
+        == 4
+    )
+    assert (
+        stratified_cell_quota(
+            allocation="equalTotal", per_cell=None, sample_size=8, n_cells=3
+        )
+        == 3
+    )
+    assert (
+        stratified_cell_quota(
+            allocation="proportional", per_cell=None, sample_size=8, n_cells=3
+        )
+        == 3
+    )
+    with pytest.raises(ValueError, match="below the stratified cell count"):
+        stratified_cell_quota(
+            allocation="equalTotal", per_cell=None, sample_size=2, n_cells=5
+        )
+
+
+def test_strategy_pin_cells_pins_extra_filters() -> None:
+    from matraix.persona_generator import strategy_pin_cells
+
+    cells, _dropped = strategy_pin_cells(
+        dimension_filters={
+            "age_bracket": ["25-34", "35-44"],
+            "life_stage": ["Early career", "Mid-life"],
+        },
+        stratify_fields=["life_stage"],
+        seed=1,
+    )
+    assert cells
+    for cell in cells:
+        assert cell["life_stage"] in {"Early career", "Mid-life"}
+        assert cell["age_bracket"] in {"25-34", "35-44"}
+
+
 def test_generate_pool_strategy_top_up_only() -> None:
     from matraix.persona_generator import (
         build_filter_strata,
-        filter_feasible_strata,
         generate_persona_pool,
     )
 
@@ -177,9 +214,6 @@ def test_generate_pool_strategy_top_up_only() -> None:
             "life_stage": ["Early career", "Mid-life"],
         }
     )
-    strata, dropped = filter_feasible_strata(strata)
-    assert dropped  # some age × life_stage pairs are inconsistent
-    assert strata
     personas = generate_persona_pool(
         count=0,
         seed=7,
@@ -187,16 +221,21 @@ def test_generate_pool_strategy_top_up_only() -> None:
         min_per_stratum=2,
         include_smoke=False,
     )
-    assert len(personas) >= 2 * len(strata)
+    filled = 0
     for stratum in strata:
         matches = [
             entry
             for entry in personas
             if all(entry["dimensions"].get(k) == v for k, v in stratum.items())
         ]
+        if not matches:
+            continue
+        filled += 1
         assert len(matches) >= 2
         for entry in matches:
-            assert validate_dimensions(entry["dimensions"]) == []
+            assert entry.get("source") == "synthetic"
+    assert filled >= 1
+    assert len(personas) >= 2 * filled
 
 
 def test_checked_in_sample_manifest_is_consistent() -> None:


### PR DESCRIPTION
## Summary
- Stream Full-DAG **Generation** with staged progress; strategy fill / Task-default UX; coverage hints emphasize `matraix-persona-1m`.
- Run/batch setup stays locked until Reset; **Save cohort** → `persona/datasets/saved-cohorts/`; **Save as dataset** pools get `kind: saved` and default sampling to **All**.
- Generator write progress + DAG `fixed` pins for strategy cells (needed by Playground synthesize).

Stacked on #51 (`fix/generated-persona-dev-default`).

## Test plan
- [ ] Generation tab: progress stages; Dataset switches without auto-selecting the whole draw
- [ ] Task default Synthesize selects fill cohort; coverage hint mentions 1M
- [ ] Save as dataset → mode defaults to All; saved-cohorts path used for Save cohort API
- [ ] Stop/Cancel keeps setup locked until Reset
- [ ] `pytest application/playground/backend/tests/test_persona_pool_service.py -q`
- [ ] `pytest tests/unit/playground_core/test_persona_generator.py tests/persona/synthesis/test_parallel_sampling.py -q`


Made with [Cursor](https://cursor.com)