### PR TITLE
fix(playground): compact Model picker — details only when open

### DIFF
--- a/application/playground/frontend/src/components/cockpit/setup/PersonaSamplingRail.tsx
+++ b/application/playground/frontend/src/components/cockpit/setup/PersonaSamplingRail.tsx
@@ -1138,6 +1138,7 @@ export function PersonaSamplingRail({
               options={personaModelOptions}
               disabled={disabled}
               wideMenu
+              showSelectedMeta={false}
               onChange={onPersonaModelChange}
             />
           )}

--- a/application/playground/frontend/src/components/cockpit/setup/useSetupPersonaSampling.ts
+++ b/application/playground/frontend/src/components/cockpit/setup/useSetupPersonaSampling.ts
@@ -425,12 +425,13 @@ export function useSetupPersonaSampling(
     samplingMode !== "single" || selectedCount > 1 || selectedPersonaIds.length > 1;
 
   const personaModelKnob = options?.knobs.find((k) => k.key === "personaModel");
+  // Provider meta only in the open menu (closed trigger stays label-only).
+  // Omit summary — long descriptions clutter the compact Persona rail.
   const personaModelOptions =
     personaModelKnob?.options.map((o) => ({
       value: o.value,
       label: o.label,
       meta: personaModelProviderLabel(o.value),
-      summary: o.description,
     })) ?? [{ value: personaModel, label: personaModel }];
 
   const togglePersona = useCallback(


### PR DESCRIPTION
## Summary
- Closed Model field shows only the model label (e.g. Claude Haiku 4.5).
- Provider meta (Anthropic / OpenRouter / …) appears in the open menu.
- Remove the description footer under Model.

## Test plan
- [ ] Persona rail Model closed: no “Anthropic” line, no “Lower-cost…” footer
- [ ] Open menu: options still show provider meta


Made with [Cursor](https://cursor.com)