### PR TITLE
fix(playground): Run Live vs Run Batch launch labels

### DIFF
--- a/application/playground/frontend/src/components/cockpit/setup/RunLaunchBar.tsx
+++ b/application/playground/frontend/src/components/cockpit/setup/RunLaunchBar.tsx
@@ -174,7 +174,7 @@ export function RunLaunchBar({
               className={`glow inline-flex w-full min-w-[200px] items-center justify-center gap-2 rounded-lg bg-primary px-6 py-3.5 font-display text-[16px] font-bold text-on-primary transition hover:bg-primary-dim disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto ${FOCUS_RING}`}
             >
               <Sym name={isBatch ? "rocket_launch" : "play_arrow"} fill={1} size={22} />
-              {isRunning ? "Launching…" : isBatch ? `Run batch (${personaCount})` : "Run simulation"}
+              {isRunning ? "Launching…" : isBatch ? `Run Batch (${personaCount})` : "Run Live"}
             </button>
             {isBatch && personaCount > 1 && (
               <CockpitInlineCount


### PR DESCRIPTION
## Summary
- Single-persona launch CTA: **Run Live** (was “Run simulation”)
- Batch launch CTA: **Run Batch (N)** (capitalized to match)

## Test plan
- [ ] Single persona → button shows Run Live
- [ ] Multi / All sampling → button shows Run Batch (N)

Made with [Cursor](https://cursor.com)