### PR TITLE
Bound persona model request time with a configurable timeout

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -76,6 +76,7 @@ jobs:
             packages/playground/src/playground/tests/test_chatbot_sidecar_compose.py \
             packages/playground/src/playground/tests/test_model_client.py \
             packages/playground/src/playground/tests/test_model_client_openrouter.py \
+            packages/playground/src/playground/tests/test_model_request_timeout.py \
             tests/environment/test_application_task_contracts.py \
             tests/environment/test_application_tasks.py \
             tests/environment/test_harbor_runtime_foundation.py \

--- a/packages/playground/src/playground/model_client.py
+++ b/packages/playground/src/playground/model_client.py
@@ -84,7 +84,7 @@ class AnthropicJSONClient:
         *,
         api_key: Optional[str] = None,
         temperature: float = 0.7,
-        timeout_seconds: float = 180.0,
+        timeout_seconds: float = DEFAULT_REQUEST_TIMEOUT_SECONDS,
         max_tokens: int = ANTHROPIC_JSON_MAX_TOKENS,
     ) -> None:
         self.model = model

--- a/packages/playground/src/playground/model_client.py
+++ b/packages/playground/src/playground/model_client.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, Optional
 # full 1290-dim persona profile + questionnaire.
 from matraix.persona_agent_context import SURVEY_MAX_OUTPUT_TOKENS as ANTHROPIC_JSON_MAX_TOKENS
 from playground.openai_client import (
+    DEFAULT_REQUEST_TIMEOUT_SECONDS,
     OpenAIChatClient,
     coerce_json,
     openai_model_supports_custom_temperature,
@@ -174,14 +175,30 @@ def _llm_proxy_base_url() -> str:
     ).strip()
 
 
+def _llm_request_timeout_seconds() -> float:
+    """Return the configured OpenAI-compatible request timeout."""
+    value = os.environ.get("LLM_REQUEST_TIMEOUT_SECONDS")
+    if value is None:
+        return DEFAULT_REQUEST_TIMEOUT_SECONDS
+    try:
+        return float(value)
+    except ValueError:
+        return DEFAULT_REQUEST_TIMEOUT_SECONDS
+
+
 def build_json_client(model: str, *, temperature: float = 0.7) -> Any:
     """Return a JSON-mode client for a configured persona model string."""
     value = (model or "openai/gpt-4o-mini").strip()
+    timeout_seconds = _llm_request_timeout_seconds()
     if value.startswith("anthropic/"):
         if _llm_proxy_base_url():
             # Route Claude through the proxy's OpenAI-compatible endpoint; base
             # url + api key come from OPENAI_* env (proxy master key).
-            return OpenAIChatClient(model=value, temperature=temperature)
+            return OpenAIChatClient(
+                model=value,
+                temperature=temperature,
+                timeout_seconds=timeout_seconds,
+            )
         return AnthropicJSONClient(value.split("/", 1)[1], temperature=temperature)
     if value.startswith("dashscope/"):
         kwargs = dashscope_openai_client_kwargs(value)
@@ -190,6 +207,7 @@ def build_json_client(model: str, *, temperature: float = 0.7) -> Any:
             api_key=kwargs["api_key"],
             base_url=kwargs["base_url"],
             temperature=temperature,
+            timeout_seconds=timeout_seconds,
         )
     if value.startswith("openrouter/"):
         kwargs = openrouter_openai_client_kwargs(value)
@@ -198,12 +216,18 @@ def build_json_client(model: str, *, temperature: float = 0.7) -> Any:
             api_key=kwargs["api_key"],
             base_url=kwargs["base_url"],
             temperature=temperature,
+            timeout_seconds=timeout_seconds,
         )
     if value.startswith("openai/"):
         return OpenAIChatClient(
             model=value.split("/", 1)[1],
             temperature=temperature,
+            timeout_seconds=timeout_seconds,
         )
     if value.startswith("gpt-"):
-        return OpenAIChatClient(model=value, temperature=temperature)
+        return OpenAIChatClient(
+            model=value,
+            temperature=temperature,
+            timeout_seconds=timeout_seconds,
+        )
     return AnthropicJSONClient(value, temperature=temperature)

--- a/packages/playground/src/playground/openai_client.py
+++ b/packages/playground/src/playground/openai_client.py
@@ -57,7 +57,7 @@ class OpenAIChatClient:
         api_key: Optional[str] = None,
         base_url: Optional[str] = None,
         temperature: float = 0.7,
-        timeout_seconds: float = 180.0,
+        timeout_seconds: float = DEFAULT_REQUEST_TIMEOUT_SECONDS,
     ) -> None:
         self.model = model
         self.temperature = temperature

--- a/packages/playground/src/playground/openai_client.py
+++ b/packages/playground/src/playground/openai_client.py
@@ -5,6 +5,7 @@ import re
 from typing import Any, Dict, Optional, Protocol
 
 _FENCE = re.compile(r"```(?:json)?\s*(?P<body>\{.*\})\s*```", re.DOTALL)
+DEFAULT_REQUEST_TIMEOUT_SECONDS = 180.0
 
 
 def coerce_json(text: str) -> Dict[str, Any]:
@@ -56,9 +57,11 @@ class OpenAIChatClient:
         api_key: Optional[str] = None,
         base_url: Optional[str] = None,
         temperature: float = 0.7,
+        timeout_seconds: float = 180.0,
     ) -> None:
         self.model = model
         self.temperature = temperature
+        self.timeout_seconds = timeout_seconds
         if client is None:
             from openai import OpenAI  # lazy: tests inject a fake
 
@@ -78,6 +81,7 @@ class OpenAIChatClient:
                 {"role": "system", "content": system},
                 {"role": "user", "content": user},
             ],
+            "timeout": self.timeout_seconds,
         }
         if openai_model_supports_custom_temperature(self.model):
             kwargs["temperature"] = self.temperature

--- a/packages/playground/src/playground/tests/test_model_request_timeout.py
+++ b/packages/playground/src/playground/tests/test_model_request_timeout.py
@@ -1,0 +1,88 @@
+from playground import model_client
+from playground.openai_client import OpenAIChatClient
+
+
+class _FakeMessage:
+    def __init__(self, content):
+        self.content = content
+
+
+class _FakeChoice:
+    def __init__(self, content):
+        self.message = _FakeMessage(content)
+
+
+class _FakeCompletion:
+    def __init__(self, content):
+        self.choices = [_FakeChoice(content)]
+
+
+class _FakeCompletions:
+    def __init__(self):
+        self.last_kwargs = None
+
+    def create(self, **kwargs):
+        self.last_kwargs = kwargs
+        return _FakeCompletion('{"ok": true}')
+
+
+class _FakeChat:
+    def __init__(self):
+        self.completions = _FakeCompletions()
+
+
+class _FakeOpenAI:
+    def __init__(self):
+        self.chat = _FakeChat()
+
+
+def test_openai_request_uses_default_timeout():
+    fake = _FakeOpenAI()
+
+    client = OpenAIChatClient(client=fake)
+    client.complete_json("system", "user")
+
+    assert fake.chat.completions.last_kwargs["timeout"] == 180.0
+
+
+def test_openai_request_uses_explicit_timeout():
+    fake = _FakeOpenAI()
+
+    client = OpenAIChatClient(client=fake, timeout_seconds=45.5)
+    client.complete_json("system", "user")
+
+    assert fake.chat.completions.last_kwargs["timeout"] == 45.5
+
+
+def test_environment_overrides_default_timeout(monkeypatch):
+    monkeypatch.setenv("LLM_REQUEST_TIMEOUT_SECONDS", "75.25")
+    fake = _FakeOpenAI()
+    monkeypatch.setattr("openai.OpenAI", lambda **kwargs: fake)
+
+    client = model_client.build_json_client("openai/gpt-4o-mini")
+    client.complete_json("system", "user")
+
+    assert fake.chat.completions.last_kwargs["timeout"] == 75.25
+
+
+def test_malformed_environment_timeout_uses_default(monkeypatch):
+    monkeypatch.setenv("LLM_REQUEST_TIMEOUT_SECONDS", "not-a-number")
+    fake = _FakeOpenAI()
+    monkeypatch.setattr("openai.OpenAI", lambda **kwargs: fake)
+
+    client = model_client.build_json_client("openai/gpt-4o-mini")
+    client.complete_json("system", "user")
+
+    assert fake.chat.completions.last_kwargs["timeout"] == 180.0
+
+
+def test_build_json_client_propagates_timeout_for_openrouter(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-openrouter-test")
+    monkeypatch.setenv("LLM_REQUEST_TIMEOUT_SECONDS", "92.5")
+    fake = _FakeOpenAI()
+    monkeypatch.setattr("openai.OpenAI", lambda **kwargs: fake)
+
+    client = model_client.build_json_client("openrouter/z-ai/glm-4.7")
+    client.complete_json("system", "user")
+
+    assert fake.chat.completions.last_kwargs["timeout"] == 92.5


### PR DESCRIPTION
`OpenAIChatClient` never passed a timeout to the OpenAI SDK, so every call inherited the SDK default of 600 seconds plus retries.

I hit this running a batch of persona trials against an OpenRouter hosted model. One call sat for over 21 minutes: connection ESTABLISHED, 1.37 seconds of CPU burned, no data moving. With thousands of trials queued, a single stall like that holds up the whole run, and the failure is invisible while it happens.

`AnthropicJSONClient` in the same module already takes `timeout_seconds` and applies it, so this closes an asymmetry between the two clients rather than adding a new concept.

- Default 180 seconds, matching what `AnthropicJSONClient` already uses.
- `LLM_REQUEST_TIMEOUT_SECONDS` overrides it for genuinely long batches.
- A malformed value falls back to the default rather than raising. A typo in an env var should not break every model call in the process.
- `build_json_client` threads the timeout through every `OpenAIChatClient` it constructs, so the provider branches stay consistent.

Tests cover the default, the override, the malformed-value fallback, and that the timeout actually reaches the SDK client. Added to the curated list in `.github/workflows/pytest.yml`.

Verified on current `main` (58aa336): 18 passed across the new tests plus `test_model_client.py` and `test_model_client_openrouter.py`, `ruff` clean.