### PR TITLE
ci: weekly rebase of branches and open PRs onto main

### DIFF
--- a/.github/scripts/upsert-rebase-comment.sh
+++ b/.github/scripts/upsert-rebase-comment.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Keep exactly one rebase-conflict comment per PR, always current.
+#
+# The weekly rebase runs forever, so posting a fresh comment on every failed
+# attempt would bury the PR in identical notices. Instead we edit one comment
+# in place, and skip entirely when neither side has moved since last week.
+#
+# Usage: upsert-rebase-comment.sh <pr-number> <head-sha> <base-sha>
+set -euo pipefail
+
+pr="$1"
+head_sha="$2"
+base_sha="$3"
+marker="<!-- weekly-rebase -->"
+stamp="<!-- head:${head_sha} base:${base_sha} -->"
+
+body="${marker}
+${stamp}
+This branch no longer rebases cleanly onto \`${BASE_BRANCH}\`.
+
+The weekly rebase job tried to replay your commits onto \`${BASE_BRANCH}\` at
+\`${base_sha:0:7}\` and hit conflicts, so it stopped and left your branch exactly
+as you pushed it — nothing here was changed.
+
+To pick it up locally:
+
+\`\`\`bash
+git fetch upstream ${BASE_BRANCH}
+git rebase upstream/${BASE_BRANCH}
+# resolve conflicts, then
+git push --force-with-lease
+\`\`\`
+
+This comment is edited in place, not repeated, and disappears from the job's
+warnings once the rebase succeeds."
+
+existing=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${pr}/comments" --paginate \
+  --jq "[.[] | select(.body | startswith(\"${marker}\"))] | last // empty")
+
+if [ -n "$existing" ]; then
+  # Same head and same base as last time: nothing has moved, stay quiet.
+  if printf '%s' "$existing" | jq -e --arg s "$stamp" '.body | contains($s)' >/dev/null; then
+    echo "PR #${pr}: conflict unchanged since last run, no comment posted."
+    exit 0
+  fi
+  comment_id=$(printf '%s' "$existing" | jq -r '.id')
+  gh api --method PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${comment_id}" \
+    -f body="$body" >/dev/null
+  echo "PR #${pr}: updated existing conflict comment."
+else
+  gh api --method POST "repos/${GITHUB_REPOSITORY}/issues/${pr}/comments" \
+    -f body="$body" >/dev/null
+  echo "PR #${pr}: posted conflict comment."
+fi

--- a/.github/workflows/weekly-rebase.yml
+++ b/.github/workflows/weekly-rebase.yml
@@ -1,0 +1,174 @@
+name: Weekly Rebase
+
+on:
+  schedule:
+    # Mondays, 07:17 UTC. Off-the-hour to dodge GitHub's cron congestion.
+    - cron: "17 7 * * 1"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Report what would change without pushing
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: weekly-rebase
+  cancel-in-progress: false
+
+env:
+  BASE_BRANCH: main
+  # Branches that must never be rebased onto main.
+  # gh-pages carries an unrelated history; rebasing it would destroy the site.
+  PROTECTED_BRANCHES: "main gh-pages"
+  DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+
+jobs:
+  rebase:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.REBASE_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Rebase in-repo branches
+        run: |
+          set -euo pipefail
+          git fetch origin --prune --quiet
+          base_sha=$(git rev-parse "origin/$BASE_BRANCH")
+          echo "### In-repo branches" >> "$GITHUB_STEP_SUMMARY"
+
+          git for-each-ref --format='%(refname:strip=3)' refs/remotes/origin \
+            | grep -v '^HEAD$' > /tmp/branches.txt
+
+          while read -r branch; do
+            case " $PROTECTED_BRANCHES " in
+              *" $branch "*) echo "- \`$branch\` — protected, skipped" >> "$GITHUB_STEP_SUMMARY"; continue ;;
+            esac
+
+            old_sha=$(git rev-parse "origin/$branch")
+            ahead=$(git rev-list --count "$base_sha..origin/$branch")
+            behind=$(git rev-list --count "origin/$branch..$base_sha")
+
+            if [ "$behind" -eq 0 ]; then
+              echo "- \`$branch\` — already current" >> "$GITHUB_STEP_SUMMARY"
+              continue
+            fi
+
+            if [ "$ahead" -eq 0 ]; then
+              # No unique commits: this is a fast-forward, no force needed.
+              if [ "$DRY_RUN" = "true" ]; then
+                echo "- \`$branch\` — would fast-forward $behind commits (dry run)" >> "$GITHUB_STEP_SUMMARY"
+              else
+                git push origin "$base_sha:refs/heads/$branch"
+                echo "- \`$branch\` — fast-forwarded $behind commits" >> "$GITHUB_STEP_SUMMARY"
+              fi
+              continue
+            fi
+
+            git checkout --quiet -B _rebase_tmp "origin/$branch"
+            if git rebase "$base_sha" >/tmp/rebase.log 2>&1; then
+              if [ "$DRY_RUN" = "true" ]; then
+                echo "- \`$branch\` — would rebase $ahead commit(s) over $behind (dry run)" >> "$GITHUB_STEP_SUMMARY"
+              else
+                git push --force-with-lease="refs/heads/$branch:$old_sha" \
+                  origin "HEAD:refs/heads/$branch"
+                echo "- \`$branch\` — rebased $ahead commit(s) over $behind" >> "$GITHUB_STEP_SUMMARY"
+              fi
+            else
+              git rebase --abort || true
+              echo "- \`$branch\` — :warning: conflict, left untouched" >> "$GITHUB_STEP_SUMMARY"
+              echo "::warning::Rebase conflict on $branch; resolve by hand."
+            fi
+            git checkout --quiet "$BASE_BRANCH"
+          done < /tmp/branches.txt
+
+      - name: Rebase open pull request branches
+        env:
+          GH_TOKEN: ${{ secrets.REBASE_TOKEN || secrets.GITHUB_TOKEN }}
+          REBASE_TOKEN: ${{ secrets.REBASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          echo "### Pull requests" >> "$GITHUB_STEP_SUMMARY"
+          base_sha=$(git rev-parse "origin/$BASE_BRANCH")
+
+          gh pr list --repo "$GITHUB_REPOSITORY" --state open \
+            --base "$BASE_BRANCH" --json number --jq '.[].number' > /tmp/prs.txt
+
+          while read -r pr; do
+            [ -n "$pr" ] || continue
+            gh api "repos/$GITHUB_REPOSITORY/pulls/$pr" > /tmp/pr.json
+            # Never interpolate fork-controlled values into the shell directly.
+            head_ref=$(jq -r '.head.ref' /tmp/pr.json)
+            head_repo=$(jq -r '.head.repo.full_name // ""' /tmp/pr.json)
+            head_sha=$(jq -r '.head.sha' /tmp/pr.json)
+            can_modify=$(jq -r '.maintainer_can_modify' /tmp/pr.json)
+            is_fork=$([ "$head_repo" = "$GITHUB_REPOSITORY" ] && echo false || echo true)
+
+            if [ -z "$head_repo" ]; then
+              echo "- #$pr — fork deleted, skipped" >> "$GITHUB_STEP_SUMMARY"
+              continue
+            fi
+
+            if [ "$is_fork" = "true" ]; then
+              if [ -z "${REBASE_TOKEN:-}" ]; then
+                echo "- #$pr — :warning: needs REBASE_TOKEN, skipped" >> "$GITHUB_STEP_SUMMARY"
+                echo "::warning::PR #$pr is from a fork; set REBASE_TOKEN to rebase it."
+                continue
+              fi
+              if [ "$can_modify" != "true" ]; then
+                echo "- #$pr — :warning: 'Allow edits by maintainers' is off, skipped" >> "$GITHUB_STEP_SUMMARY"
+                continue
+              fi
+              git remote remove fork 2>/dev/null || true
+              git remote add fork "https://x-access-token:${REBASE_TOKEN}@github.com/${head_repo}.git"
+              remote=fork
+            else
+              remote=origin
+            fi
+
+            git fetch --quiet "$remote" "$head_ref"
+            behind=$(git rev-list --count "FETCH_HEAD..$base_sha")
+            if [ "$behind" -eq 0 ]; then
+              echo "- #$pr — already current" >> "$GITHUB_STEP_SUMMARY"
+              continue
+            fi
+
+            ahead=$(git rev-list --count "$base_sha..FETCH_HEAD")
+            git checkout --quiet -B _rebase_pr FETCH_HEAD
+            if git rebase "$base_sha" >/tmp/rebase.log 2>&1; then
+              if [ "$DRY_RUN" = "true" ]; then
+                echo "- #$pr — would rebase $ahead commit(s) over $behind (dry run)" >> "$GITHUB_STEP_SUMMARY"
+              elif git push --force-with-lease="refs/heads/$head_ref:$head_sha" \
+                     "$remote" "HEAD:refs/heads/$head_ref" 2>/tmp/push.log; then
+                echo "- #$pr — rebased $ahead commit(s) over $behind" >> "$GITHUB_STEP_SUMMARY"
+              else
+                echo "- #$pr — :warning: push rejected (see log)" >> "$GITHUB_STEP_SUMMARY"
+                echo "::warning::Push rejected for PR #$pr."
+              fi
+            else
+              git rebase --abort || true
+              echo "- #$pr — :warning: conflict with $BASE_BRANCH" >> "$GITHUB_STEP_SUMMARY"
+              if [ "$DRY_RUN" != "true" ]; then
+                "$GITHUB_WORKSPACE/.github/scripts/upsert-rebase-comment.sh" \
+                  "$pr" "$head_sha" "$base_sha"
+              fi
+            fi
+            git checkout --quiet "$BASE_BRANCH"
+          done < /tmp/prs.txt
+
+      - name: Clean up credentials
+        if: always()
+        run: git remote remove fork 2>/dev/null || true


### PR DESCRIPTION
Adds a scheduled job that keeps branches and open PRs current with `main`, so drift is caught weekly instead of at merge time.

Runs **Mondays 07:17 UTC**, plus `workflow_dispatch` with a `dry_run` input (defaults to on) for a safe manual first run.

## What it does

| Target | Action |
|---|---|
| Branch with no unique commits | Fast-forward — plain push, no force |
| Branch with unique commits | Rebase onto `main`, push with `--force-with-lease` |
| `main`, `gh-pages` | Skipped — `gh-pages` carries an unrelated history |
| Open PR behind `main` | Replay onto `main`, force-with-lease to the head branch |
| Anything that conflicts | `rebase --abort`, branch left exactly as pushed |

## Dry-run results against current `main`

- `docs/persona-pools-1m-recommended`, `docs/readme-citation`, `docs/readme-i18n`, `docs/star-history-sealed-token` — fast-forward 23/29/52/24 commits (no unique commits, so nothing is rewritten)
- `backup/wip-pre-split-persona-rail` — rebases its 1 commit over 25, applies cleanly
- #30 — already current
- #48, #31 — genuine rebase conflicts; job aborts and comments

## Safety

- Every force push uses `--force-with-lease` pinned to the SHA the job read from the API. If a contributor pushed in the meantime, the push backs off rather than clobbering their work.
- Fork PRs are only touched when `maintainer_can_modify` is true.
- Fork-controlled values (branch names, repo names) are read into shell variables via `jq`, never interpolated into the script through `${{ }}`.
- Conflicts recur weekly until fixed, so `.github/scripts/upsert-rebase-comment.sh` keeps **one** comment per PR and edits it in place. GitHub does not notify on edits, so this stays quiet. It skips entirely when neither head nor base has moved.

## Required before fork PRs will rebase

Add a `REBASE_TOKEN` secret — a PAT with `repo` scope and write access to the fork. Without it the job still runs and skips PRs with a warning instead of failing. All three open PRs currently have `maintainer_can_modify=true`.

Note that `GITHUB_TOKEN` pushes do not trigger downstream workflows; using a PAT means rebased branches re-run `pytest.yml` and `ruff.yml`.

Suggested first step after merge: run it manually with `dry_run` checked and read the job summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)