### PR TITLE
Add ICHRA metal-tier survey (Ohio) with paired salience A/B

### DIFF
--- a/analysis/ichra-metal-tier-ohio/README.md
+++ b/analysis/ichra-metal-tier-ohio/README.md
@@ -1,0 +1,38 @@
+# ICHRA metal-tier choice — Ohio
+
+Analysis output spanning two task arms. It lives here rather than inside either
+task because it covers both.
+
+| Task | Role |
+|---|---|
+| [`survey_ichra-metal-tier-ohio`](../../application/tasks/survey_ichra-metal-tier-ohio/) | control — forfeit rule stated once, unemphasized |
+| [`survey_ichra-metal-tier-ohio-salient`](../../application/tasks/survey_ichra-metal-tier-ohio-salient/) | treatment — same rule made prominent |
+
+The write-up is [RESULTS.md](RESULTS.md).
+
+## Reproducing the underlying data
+
+Source jobs: `pg-survey-ichra-metal-tier-ohio-668679a2` (control) and
+`pg-survey-ichra-metal-tier-ohio-salient-8f156186` (treatment) — same 100
+persona ids, seed 42, `anthropic/claude-sonnet-4-6`, pool
+`persona/datasets/matraix-persona-1m`, `perCell: 25` across the four age
+brackets.
+
+Per-trial answers and free-text rationales live under
+`jobs/<job>/<trial>/artifacts/app/output/survey_result.json`, joined to persona
+attributes via `jobs/<job>/<trial>/persona_meta.json` → `persona_path`. `jobs/`
+is gitignored, so those artifacts are local to whoever ran the job.
+
+The figures in RESULTS.md come from four `askRationale` questions —
+`q_tier_choice`, `q_tier_if_more`, `q_switch_driver`, `q_subsidy_tradeoff` —
+796 rationales in total across both arms.
+
+The dominated-choice flag is derived, not recorded: map each persona's
+`age_bracket` to its midpoint (25-34 → 30, 35-44 → 40, 45-54 → 50, 55-64 → 60),
+look up the median on-exchange premium per tier at that age, and compare the
+chosen tier against the richest tier priced at or below the persona's
+allowance.
+
+A flat CSV of all 796 rationales was deliberately left out of the repo to stay
+inside the data policy on generated dumps. It is a short script away from the
+job artifacts, and available on request from whoever ran the jobs.

--- a/analysis/ichra-metal-tier-ohio/RESULTS.md
+++ b/analysis/ichra-metal-tier-ohio/RESULTS.md
@@ -76,6 +76,17 @@ covered plan, rather than showing premiums and expecting the employee to reason
 from allowance to dominance. That is a different manipulation — presentation of
 the choice set, not disclosure of a rule — and would need its own arm.
 
+## Raw rationales
+
+Every quote above is drawn from the 796 free-text rationales the two runs
+produced — 100 personas across two arms, four `askRationale` questions each,
+all non-empty. They live in the job artifacts under `jobs/`, which is
+gitignored; [README.md](README.md) documents how to reconstruct them and the
+derivation of the dominated-choice flag.
+
+A flat CSV of all 796 was deliberately not committed, to stay inside the
+repository's data policy on generated dumps.
+
 ## Scope
 
 Simulated North American working adults reasoning about a real Ohio PY2026

--- a/application/tasks/survey_ichra-metal-tier-ohio-salient/README.md
+++ b/application/tasks/survey_ichra-metal-tier-ohio-salient/README.md
@@ -1,0 +1,72 @@
+# ICHRA Metal Tier Choice — Ohio (salient-forfeit arm)
+
+Treatment arm of a paired A/B against
+[`survey_ichra-metal-tier-ohio`](../survey_ichra-metal-tier-ohio/README.md).
+
+## What this tests
+
+The control run produced a striking result: **28 of 100 personas chose a metal
+tier strictly worse than one their allowance also covered in full.** At age 40
+on a $1,000 allowance, gold runs $709 — fully covered — yet 11 personas took
+bronze or silver. Their rationales show they saw the option and declined it:
+
+> "Gold would also fit within the allowance at $991, but Silver strikes a
+> reasonable middle ground... without overpaying."
+
+There is no overpaying. Unused allowance is forfeited, so every plan priced at
+or below the allowance costs the persona the same: nothing. The personas
+applied a household don't-overspend heuristic to a use-it-or-lose-it benefit.
+
+Two explanations fit that result equally well, and the control run cannot
+separate them:
+
+1. **Behavioral.** People really do reason this way about an unfamiliar
+   benefit, and the same thing would happen at a real open enrollment.
+2. **Instrument artifact.** The control context states the forfeit rule once,
+   unemphasized, as the fifth of nine bullets. The personas may simply not
+   have weighted it.
+
+## The manipulation
+
+This arm changes **salience only — no new facts.** Two edits to
+`input/context.md`:
+
+- The existing forfeit bullet is bolded and spelled out ("the leftover money
+  goes back to your employer, you never see it").
+- A bolded paragraph after the allowance table restates the same rule in
+  concrete terms ("picking a $400 plan on a $1,000 allowance forfeits $600").
+
+`questionnaire.yaml`, `instruction.md`, `reporting.json`,
+`persona_strategy.json`, and `tests/` are byte-identical to the control. Verify
+before trusting any comparison:
+
+```bash
+diff -r application/tasks/survey_ichra-metal-tier-ohio \
+        application/tasks/survey_ichra-metal-tier-ohio-salient
+```
+
+Only `context.md`, `task.toml` (name and tags), and this README should differ.
+
+## Running it as a pair
+
+Launch this arm against **the same 100 persona ids and the same seed** as the
+control run. Personas carry no memory across trials, so pairing costs nothing
+and removes persona heterogeneity from the comparison entirely — each persona
+acts as its own control.
+
+The outcome measure is the **dominated-choice rate**: the share of personas
+choosing a tier when a richer tier was also fully covered by their allowance.
+Control = 28/100. Compute it by mapping each persona's age bracket to its
+midpoint premium, then comparing the chosen tier against the richest tier
+priced at or below the allowance.
+
+Read the result as follows:
+
+- **Rate drops sharply** → the control finding was largely an instrument
+  artifact. The behavioral claim does not hold, and the number to quote is
+  this arm's.
+- **Rate holds** → salience is not the constraint. The don't-overspend
+  heuristic survives being told plainly, which is a real enrollment-design
+  problem worth acting on.
+
+Either way the answer is useful; only one of them is a finding about people.

--- a/application/tasks/survey_ichra-metal-tier-ohio-salient/README.md
+++ b/application/tasks/survey_ichra-metal-tier-ohio-salient/README.md
@@ -70,3 +70,9 @@ Read the result as follows:
   problem worth acting on.
 
 Either way the answer is useful; only one of them is a finding about people.
+
+## Outcome
+
+Both arms have been run. The rate held — 28/99 control versus 27/99 treatment,
+with 92 of 99 personas choosing the identical tier in both. Salience is not the
+constraint. See [RESULTS.md](RESULTS.md).

--- a/application/tasks/survey_ichra-metal-tier-ohio-salient/README.md
+++ b/application/tasks/survey_ichra-metal-tier-ohio-salient/README.md
@@ -75,4 +75,5 @@ Either way the answer is useful; only one of them is a finding about people.
 
 Both arms have been run. The rate held — 28/99 control versus 27/99 treatment,
 with 92 of 99 personas choosing the identical tier in both. Salience is not the
-constraint. See [RESULTS.md](RESULTS.md).
+constraint. See
+[analysis/ichra-metal-tier-ohio/RESULTS.md](../../../analysis/ichra-metal-tier-ohio/RESULTS.md).

--- a/application/tasks/survey_ichra-metal-tier-ohio-salient/RESULTS.md
+++ b/application/tasks/survey_ichra-metal-tier-ohio-salient/RESULTS.md
@@ -1,0 +1,83 @@
+# A/B result: forfeit-rule salience does not move tier choice
+
+Both arms have been run. **The manipulation had no effect.** Making the
+forfeit rule prominent did not reduce the dominated-choice rate.
+
+## Runs
+
+| Arm | Job | Trials |
+|---|---|---|
+| Control (`survey_ichra-metal-tier-ohio`) | `pg-survey-ichra-metal-tier-ohio-668679a2` | 100/100 succeeded |
+| Treatment (this task) | `pg-survey-ichra-metal-tier-ohio-salient-8f156186` | 99/100 succeeded |
+
+Identical persona ids, seed 42, `anthropic/claude-sonnet-4-6`, pool
+`persona/datasets/matraix-persona-1m`, 25 per age bracket. One treatment trial
+failed on an Anthropic read timeout; that persona is dropped from **both** arms,
+so every figure below is paired on the same 99.
+
+## Outcome
+
+Dominated choice = persona picked a tier when a richer tier was also fully
+covered by its allowance, priced at the age-bracket midpoint.
+
+| Arm | Dominated | Rate |
+|---|---|---|
+| Control — rule buried as 5th of 9 bullets | 28/99 | 28% |
+| Treatment — rule bolded, restated concretely | 27/99 | 27% |
+
+Tier mix moved no further: bronze 12 → 12, silver 64 → 63, gold 23 → 24,
+declines 0 → 0.
+
+By band, flat exactly where an effect would have to appear:
+
+| Band | n | Control | Treatment |
+|---|---|---|---|
+| $500 (27-35) | 25 | 0 | 0 |
+| $1,000 (36-45) | 24 | 11 | 12 |
+| $1,500 (46-64) | 50 | 17 | 15 |
+
+The $500 band is 0 in both because nothing is dominated there — the allowance
+genuinely does not reach gold at those ages.
+
+## Paired switching
+
+92 of 99 personas chose the **identical** tier in both arms. The 7 who moved
+went both directions — 3 silver→gold, 2 gold→silver, 1 bronze→silver, 1
+silver→bronze. Symmetric movement at that scale is noise, not treatment.
+
+## Why it failed to move
+
+Treatment personas did the arithmetic correctly and chose down anyway:
+
+> "My $1,500 allowance covers it fully with $669 left over, so I pay nothing
+> out of pocket... Gold at $991 is also within reach, but Silver..."
+
+They knew gold was free. They knew the leftover was identical either way.
+
+**Zero personas in either arm used forfeit language** — "forfeit", "leftover",
+"goes back", "never see it" — anywhere in their tier rationales, including the
+27 treatment personas who chose dominated tiers with the bolded rule two
+paragraphs above the question. The rule was read and did not enter the
+decision.
+
+What these personas optimize is a felt sense of appropriate coverage
+("reasonable middle ground", "responsible for a family"), not the actual
+budget constraint. Silver reads as the sensible choice regardless of price.
+
+## What follows
+
+Per the decision rule fixed before the run: the rate held, so **salience is not
+the constraint and the control finding was not an instrument artifact.**
+Disclosure is not the lever — stating the rule harder does not change behavior.
+
+The untested alternative is removing the arithmetic instead of explaining it:
+label each covered tier "$0/month to you" and default-select the richest
+covered plan, rather than showing premiums and expecting the employee to reason
+from allowance to dominance. That is a different manipulation — presentation of
+the choice set, not disclosure of a rule — and would need its own arm.
+
+## Scope
+
+Simulated North American working adults reasoning about a real Ohio PY2026
+price sheet. This establishes that the pattern is robust to wording. It is not
+evidence that 27% of real Ohio employees behave this way.

--- a/application/tasks/survey_ichra-metal-tier-ohio-salient/input/context.md
+++ b/application/tasks/survey_ichra-metal-tier-ohio-salient/input/context.md
@@ -1,0 +1,73 @@
+# Your employer is switching to an ICHRA (Ohio)
+
+You live and work in Ohio. Starting January 1, your employer is dropping its
+group health plan and moving to an **ICHRA** — an Individual Coverage Health
+Reimbursement Arrangement.
+
+## What that means for you
+
+- Your employer no longer picks the plan. **You** buy your own individual
+  health plan on the Ohio marketplace.
+- Your employer gives you a fixed monthly allowance toward the premium. The
+  allowance is tax-free to you.
+- If the plan you pick costs more than the allowance, you pay the difference
+  yourself, usually pre-tax through payroll.
+- **If the plan costs less than the allowance, you do not pocket the
+  difference. The leftover money goes back to your employer. You never see
+  it.**
+- Taking the ICHRA money means you **cannot** also claim a premium tax credit
+  (subsidy) on the marketplace. It is one or the other.
+- You may turn the ICHRA down and go without employer help, but then you get
+  no allowance at all.
+
+## Your allowance
+
+Your employer scales the allowance by age, because older workers face higher
+premiums. Find your own age:
+
+| Your age | Your monthly allowance |
+|---|---|
+| 27-35 | **$500** |
+| 36-45 | **$1,000** |
+| 46-64 | **$1,500** |
+
+That is the number you have to work with. Answer every question using your own
+allowance from this table.
+
+**Spending less than your allowance saves you nothing.** Picking a $400 plan
+on a $1,000 allowance does not put $600 in your pocket — it forfeits $600. Any
+plan priced at or below your allowance costs you exactly the same out of
+pocket: nothing.
+
+## What you have to choose
+
+Ohio's individual market sells plans in metal tiers. Higher metal = higher
+monthly premium, lower costs when you actually use care.
+
+| Tier | What it trades | Typical deductible | Typical out-of-pocket max |
+|---|---|---|---|
+| **Bronze** | Lowest premium, highest bills when you use it | $7,500 | $10,150 |
+| **Silver** | Middle on both | $6,000 | $9,200 |
+| **Gold** | Highest premium, lowest bills when you use it | $2,000 | $8,200 |
+
+## What plans actually cost in Ohio
+
+Monthly premium for one adult, non-smoker, central Ohio. Premiums rise steeply
+with age:
+
+| Your age | Bronze | Silver | Gold |
+|---|---|---|---|
+| 27 | $373 | $487 | $581 |
+| 30 | $404 | $528 | $630 |
+| 40 | $455 | $594 | $709 |
+| 50 | $636 | $831 | $991 |
+| 55 | $795 | $1,037 | $1,237 |
+| 64 | $1,069 | $1,395 | $1,664 |
+
+Find the row closest to your age. Whatever your allowance does not cover comes
+out of your own paycheck, every month.
+
+A family plan costs substantially more than the single-adult premiums above.
+
+*Premiums and cost-sharing: Ohio plan year 2026 marketplace filings, median of
+on-exchange plans in Rating Area 11 (Columbus area), non-tobacco.*

--- a/application/tasks/survey_ichra-metal-tier-ohio-salient/input/questionnaire.yaml
+++ b/application/tasks/survey_ichra-metal-tier-ohio-salient/input/questionnaire.yaml
@@ -1,0 +1,158 @@
+schemaVersion: "1.0"
+id: ichra_metal_tier_ohio_v1
+title: "ICHRA Metal Tier Choice — Ohio"
+description: "Which metal tier a worker buys when an employer replaces its group plan with an ICHRA whose monthly allowance is scaled by age band."
+questions:
+  - id: q_allowance_band
+    prompt: "Based on your own age, which monthly allowance does your employer give you?"
+    type: single_choice
+    construct: allowance_band
+    required: true
+    options:
+      - id: "band_500"
+        label: "$500 a month (I am 27-35)."
+      - id: "band_1000"
+        label: "$1,000 a month (I am 36-45)."
+      - id: "band_1500"
+        label: "$1,500 a month (I am 46-64)."
+
+  - id: q_tier_choice
+    prompt: "With that allowance, which plan do you buy?"
+    type: single_choice
+    construct: tier_choice
+    required: true
+    askRationale: true
+    options:
+      - id: "bronze"
+        label: "Bronze — lowest premium, highest deductible."
+      - id: "silver"
+        label: "Silver — middle premium, middle deductible."
+      - id: "gold"
+        label: "Gold — highest premium, lowest deductible."
+      - id: "decline"
+        label: "I turn down the ICHRA and go without employer help."
+
+  - id: q_allowance_adequacy
+    prompt: "My allowance covers the kind of plan I actually want."
+    type: likert
+    construct: allowance_adequacy
+    required: true
+    minValue: 1
+    maxValue: 5
+
+  - id: q_tier_if_more
+    prompt: "If your employer raised your allowance by $250 a month, would you change your plan?"
+    type: single_choice
+    construct: tier_elasticity
+    required: true
+    askRationale: true
+    options:
+      - id: "move_up"
+        label: "Yes, I would move up a tier."
+      - id: "same_tier_better_plan"
+        label: "I would stay in the same tier but pick a better plan in it."
+      - id: "no_change"
+        label: "No, I would keep the same plan and pay less myself."
+      - id: "would_enroll"
+        label: "I would enroll where I otherwise would have declined."
+
+  - id: q_out_of_pocket_ceiling
+    prompt: "How much of your own money, per month, are you willing to add on top of the allowance?"
+    type: single_choice
+    construct: payroll_tolerance
+    required: true
+    options:
+      - id: "none"
+        label: "Nothing. The plan has to fit inside the allowance."
+      - id: "under_100"
+        label: "Up to $100 a month."
+      - id: "100_250"
+        label: "$100 to $250 a month."
+      - id: "250_500"
+        label: "$250 to $500 a month."
+      - id: "over_500"
+        label: "More than $500 a month if the plan is right."
+
+  - id: q_deductible_reaction
+    prompt: "A Bronze plan in Ohio carries roughly a $7,500 deductible. You pay that yourself before most coverage starts."
+    type: likert
+    construct: deductible_pain
+    required: true
+    minValue: 1
+    maxValue: 5
+
+  - id: q_switch_driver
+    prompt: "What matters most when you pick between these plans?"
+    type: single_choice
+    construct: decision_driver
+    required: true
+    askRationale: true
+    options:
+      - id: "monthly_premium"
+        label: "The monthly premium. I budget month to month."
+      - id: "deductible"
+        label: "The deductible. I do not want a big bill before coverage kicks in."
+      - id: "oop_max"
+        label: "The out-of-pocket maximum. I care about the worst case."
+      - id: "doctors"
+        label: "Whether my doctors are in the network."
+      - id: "prescriptions"
+        label: "How my prescriptions are covered."
+
+  - id: q_expected_use
+    prompt: "How much medical care do you expect to use in the next year?"
+    type: single_choice
+    construct: expected_utilization
+    required: true
+    options:
+      - id: "almost_none"
+        label: "Almost none. Maybe one checkup."
+      - id: "routine"
+        label: "Routine care and a prescription or two."
+      - id: "regular"
+        label: "Regular care for an ongoing condition."
+      - id: "heavy"
+        label: "A lot. Surgery, specialists, or a chronic condition being managed."
+
+  - id: q_subsidy_tradeoff
+    prompt: "Taking the ICHRA money means giving up any marketplace subsidy you might have qualified for. Knowing that, would you still take the employer allowance?"
+    type: single_choice
+    construct: subsidy_awareness
+    required: true
+    askRationale: true
+    options:
+      - id: "take_ichra"
+        label: "Yes, take the allowance."
+      - id: "check_subsidy_first"
+        label: "Only after I check what the subsidy would have been worth."
+      - id: "prefer_subsidy"
+        label: "No, I would rather keep my subsidy eligibility."
+      - id: "did_not_know"
+        label: "I did not know that, and it changes my answer."
+
+  - id: q_verify_before_enrolling
+    prompt: "What do you check before you actually enroll? (Select all that apply)"
+    type: multi_choice
+    construct: pre_enrollment_checks
+    required: true
+    options:
+      - id: "doctor_in_network"
+        label: "Whether my current doctors take the plan."
+      - id: "drug_formulary"
+        label: "Whether my prescriptions are on the drug list."
+      - id: "hospital"
+        label: "Which hospitals are covered."
+      - id: "total_cost"
+        label: "Premium plus deductible added together for the year."
+      - id: "carrier_reputation"
+        label: "The insurance company's reputation."
+      - id: "nothing"
+        label: "Nothing. I pick on price and move on."
+
+  - id: q_confidence_in_choice
+    prompt: "I feel confident I picked the right plan for my situation."
+    type: likert
+    construct: choice_confidence
+    required: true
+    minValue: 1
+    maxValue: 5

--- a/application/tasks/survey_ichra-metal-tier-ohio-salient/instruction.md
+++ b/application/tasks/survey_ichra-metal-tier-ohio-salient/instruction.md
@@ -1,0 +1,19 @@
+# ICHRA Metal Tier Choice Survey
+
+Answer this survey based on your demographics, health, income, and
+circumstances. Read the background in the task context, then complete every
+required question in the questionnaire.
+
+## How to answer
+
+- Read the task context before answering. It has the Ohio premium and
+  deductible figures you need.
+- Find the premium row closest to your own age before you choose a tier. The
+  gap between the allowance and the premium is money out of your own pocket.
+- Answer every required question.
+- Use the exact choice ids for single- and multi-choice questions.
+- For questions marked "(Select all that apply)", select all ids that fit.
+- Answer with the selected value only unless a question explicitly asks for
+  `askRationale` / `askConfidence`.
+
+The platform records your answers; do not invent submission file paths.

--- a/application/tasks/survey_ichra-metal-tier-ohio-salient/persona_strategy.json
+++ b/application/tasks/survey_ichra-metal-tier-ohio-salient/persona_strategy.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": "1.0",
+  "sources": [],
+  "dimensionFilters": {
+    "age_bracket": [
+      "25-34",
+      "35-44",
+      "45-54",
+      "55-64"
+    ],
+    "region": [
+      "North America"
+    ],
+    "demo_employment_status": [
+      "Full-time",
+      "Part-time"
+    ]
+  },
+  "sampling": {
+    "mode": "stratified",
+    "fields": [
+      "age_bracket"
+    ],
+    "perCell": 25,
+    "sampleSize": 100
+  }
+}

--- a/application/tasks/survey_ichra-metal-tier-ohio-salient/reporting.json
+++ b/application/tasks/survey_ichra-metal-tier-ohio-salient/reporting.json
@@ -1,0 +1,65 @@
+{
+  "schemaVersion": "1.0",
+  "contextRules": [
+    {
+      "match": {
+        "contextType": "question_response",
+        "key": "question.q_tier_choice"
+      },
+      "summaryAnalyses": [
+        {
+          "id": "tier_choice.rationale_themes",
+          "title": "Why personas landed on their tier",
+          "targetFacetKey": "rationale",
+          "groupByMode": "none",
+          "summaryKind": "llm_bucket_summary"
+        }
+      ]
+    },
+    {
+      "match": {
+        "contextType": "question_response",
+        "key": "question.q_tier_if_more"
+      },
+      "summaryAnalyses": [
+        {
+          "id": "tier_elasticity.rationale_themes",
+          "title": "What another $250 a month would change",
+          "targetFacetKey": "rationale",
+          "groupByMode": "none",
+          "summaryKind": "llm_bucket_summary"
+        }
+      ]
+    },
+    {
+      "match": {
+        "contextType": "question_response",
+        "key": "question.q_switch_driver"
+      },
+      "summaryAnalyses": [
+        {
+          "id": "switch_driver.rationale_themes",
+          "title": "What drives the tier decision",
+          "targetFacetKey": "rationale",
+          "groupByMode": "none",
+          "summaryKind": "llm_bucket_summary"
+        }
+      ]
+    },
+    {
+      "match": {
+        "contextType": "question_response",
+        "key": "question.q_subsidy_tradeoff"
+      },
+      "summaryAnalyses": [
+        {
+          "id": "subsidy_tradeoff.rationale_themes",
+          "title": "Reactions to losing subsidy eligibility",
+          "targetFacetKey": "rationale",
+          "groupByMode": "none",
+          "summaryKind": "llm_bucket_summary"
+        }
+      ]
+    }
+  ]
+}

--- a/application/tasks/survey_ichra-metal-tier-ohio-salient/task.toml
+++ b/application/tasks/survey_ichra-metal-tier-ohio-salient/task.toml
@@ -1,0 +1,25 @@
+version = "1.0"
+artifacts = [ "/app/output",]
+
+[task]
+name = "application/survey-ichra-metal-tier-ohio-salient"
+
+[metadata]
+difficulty = "easy"
+type = "survey"
+domain = "healthcare"
+tags = [ "ichra", "health insurance", "metal tier", "employer contribution", "ohio", "price sensitivity", "ab-test", "salience",]
+
+[verifier]
+timeout_sec = 120.0
+
+[agent]
+timeout_sec = 600.0
+
+[environment]
+definition = "application/shared-survey-form"
+build_timeout_sec = 600.0
+cpus = 1
+memory_mb = 2048
+storage_mb = 10240
+gpus = 0

--- a/application/tasks/survey_ichra-metal-tier-ohio-salient/tests/test.sh
+++ b/application/tasks/survey_ichra-metal-tier-ohio-salient/tests/test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck disable=SC1091
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/verifier_env.sh"
+
+if python3 "${TESTS_DIR}/test_state.py"; then
+  echo 1 > "${VERIFIER_DIR}/reward.txt"
+else
+  echo 0 > "${VERIFIER_DIR}/reward.txt"
+  exit 1
+fi

--- a/application/tasks/survey_ichra-metal-tier-ohio-salient/tests/test_state.py
+++ b/application/tasks/survey_ichra-metal-tier-ohio-salient/tests/test_state.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+OUTPUT_DIR = Path(
+    os.environ.get("HARBOR_OUTPUT_DIR")
+    or os.environ.get("MATRIX_OUTPUT_DIR")
+    or "/app/output"
+)
+RESULT_PATH = OUTPUT_DIR / "survey_result.json"
+EVENT_KEYS = {"timestamp", "actor", "action", "context", "outcome"}
+
+
+def _verifier_dir() -> Path:
+    base = (
+        os.environ.get("HARBOR_VERIFIER_DIR")
+        or os.environ.get("HARBOR_VERIFIER_DIR")
+        or "/logs/verifier"
+    )
+    path = Path(base)
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+    except OSError:
+        path = Path(__file__).resolve().parent.parent / "verifier"
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+
+def _write_structured_output(payload: dict[str, object]) -> None:
+    path = _verifier_dir() / "structured_output.json"
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def fail(message: str) -> int:
+    print(message, file=sys.stderr)
+    return 1
+
+
+def _question_types_from_trajectory(trajectory: list[object]) -> dict[str, str]:
+    """Map questionId -> questionnaire type from ask_question trajectory events."""
+    out: dict[str, str] = {}
+    for event in trajectory:
+        if not isinstance(event, dict):
+            continue
+        if str(event.get("action") or "") != "ask_question":
+            continue
+        context = event.get("context")
+        if not isinstance(context, dict):
+            continue
+        question_id = str(context.get("questionId") or "").strip()
+        question_type = str(context.get("questionType") or "").strip().lower()
+        if question_id and question_type:
+            out[question_id] = question_type
+    return out
+
+
+def _field_kind_for_question(question_type: str | None, value: object) -> str:
+    """Kind follows questionnaire type — not string-shape heuristics."""
+    qtype = (question_type or "").strip().lower()
+    if qtype == "likert":
+        return "numerical"
+    if qtype in {"single_choice", "multi_choice"}:
+        return "categorical"
+    if qtype == "free_text":
+        return "textual"
+    if isinstance(value, bool):
+        return "categorical"
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return "numerical"
+    if isinstance(value, list):
+        return "categorical"
+    if isinstance(value, str):
+        text = value.strip()
+        if " " in text or "\n" in text or len(text) > 64:
+            return "textual"
+        return "categorical"
+    return "textual"
+
+
+def main() -> int:
+    if not RESULT_PATH.is_file():
+        return fail("missing /app/output/survey_result.json")
+    try:
+        payload = json.loads(RESULT_PATH.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return fail("survey_result.json is not valid JSON: {}".format(exc))
+    if not isinstance(payload, dict):
+        return fail("survey_result.json must contain an object")
+    answers = payload.get("answers")
+    if not isinstance(answers, list) or not answers:
+        return fail("survey_result.answers must be a non-empty list")
+    trajectory = payload.get("trajectory")
+    if not isinstance(trajectory, list) or not trajectory:
+        return fail("survey_result.trajectory must be a non-empty list")
+    question_types = _question_types_from_trajectory(trajectory)
+    fields: list[dict[str, object]] = []
+    contexts: list[dict[str, object]] = []
+    numeric_values: list[float] = []
+    for index, answer in enumerate(answers):
+        if not isinstance(answer, dict):
+            return fail("answers[{}] must be an object".format(index))
+        question_id = str(answer.get("questionId", "")).strip()
+        if not question_id:
+            return fail("answers[{}].questionId is required".format(index))
+        if "value" not in answer:
+            return fail("answers[{}].value is required".format(index))
+        value = answer.get("value")
+        question_type = question_types.get(question_id)
+        kind = _field_kind_for_question(question_type, value)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            numeric_values.append(float(value))
+        context_key = "question.{}".format(question_id)
+        context_label = str(answer.get("prompt") or question_id)
+        facets: list[dict[str, object]] = [
+            {
+                "key": "response",
+                "label": "Selected response",
+                "role": "primary",
+                "kind": kind,
+                "value": value,
+            }
+        ]
+        fields.append(
+            {
+                "key": "{}.response".format(context_key),
+                "label": "Selected response",
+                "group": context_key,
+                "role": "primary",
+                "kind": kind,
+                "value": value,
+            }
+        )
+        rationale = str(answer.get("rationale") or "").strip()
+        if rationale:
+            facets.append(
+                {
+                    "key": "reason",
+                    "label": "Reason",
+                    "role": "explanation",
+                    "kind": "textual",
+                    "value": rationale,
+                }
+            )
+            fields.append(
+                {
+                    "key": "{}.reason".format(context_key),
+                    "label": "Reason",
+                    "group": context_key,
+                    "role": "explanation",
+                    "kind": "textual",
+                    "value": rationale,
+                }
+            )
+        confidence = answer.get("confidence")
+        if isinstance(confidence, (int, float)) and not isinstance(confidence, bool):
+            facets.append(
+                {
+                    "key": "confidence",
+                    "label": "Confidence",
+                    "role": "score",
+                    "kind": "numerical",
+                    "value": float(confidence),
+                }
+            )
+            fields.append(
+                {
+                    "key": "{}.confidence".format(context_key),
+                    "label": "Confidence",
+                    "group": context_key,
+                    "role": "score",
+                    "kind": "numerical",
+                    "value": float(confidence),
+                }
+            )
+        context_payload: dict[str, object] = {
+            "key": context_key,
+            "label": context_label,
+            "contextType": "question_response",
+            "facets": facets,
+        }
+        if question_type:
+            context_payload["questionType"] = question_type
+        contexts.append(context_payload)
+    for index, event in enumerate(trajectory):
+        if not isinstance(event, dict):
+            return fail("trajectory[{}] must be an object".format(index))
+        missing = EVENT_KEYS - set(event)
+        if missing:
+            return fail(
+                "trajectory[{}] missing keys: {}".format(index, ", ".join(sorted(missing)))
+            )
+        if not isinstance(event.get("context"), dict):
+            return fail("trajectory[{}].context must be an object".format(index))
+        if not isinstance(event.get("outcome"), dict):
+            return fail("trajectory[{}].outcome must be an object".format(index))
+    summary_facets: list[dict[str, object]] = [
+        {
+            "key": "answer_count",
+            "label": "Answer count",
+            "role": "score",
+            "kind": "numerical",
+            "value": len(answers),
+        },
+        {
+            "key": "trajectory_event_count",
+            "label": "Trajectory event count",
+            "role": "score",
+            "kind": "numerical",
+            "value": len(trajectory),
+        },
+    ]
+    fields.append(
+        {
+            "key": "survey.summary.answer_count",
+            "label": "Answer count",
+            "group": "survey.summary",
+            "role": "score",
+            "kind": "numerical",
+            "value": len(answers),
+        }
+    )
+    fields.append(
+        {
+            "key": "survey.summary.trajectory_event_count",
+            "label": "Trajectory event count",
+            "group": "survey.summary",
+            "role": "score",
+            "kind": "numerical",
+            "value": len(trajectory),
+        }
+    )
+    if numeric_values:
+        summary_facets.append(
+            {
+                "key": "mean_numeric_answer",
+                "label": "Mean numeric answer",
+                "role": "score",
+                "kind": "numerical",
+                "value": round(sum(numeric_values) / len(numeric_values), 4),
+            }
+        )
+        fields.append(
+            {
+                "key": "survey.summary.mean_numeric_answer",
+                "label": "Mean numeric answer",
+                "group": "survey.summary",
+                "role": "score",
+                "kind": "numerical",
+                "value": round(sum(numeric_values) / len(numeric_values), 4),
+            }
+        )
+    contexts.append(
+        {
+            "key": "survey.summary",
+            "label": "Survey summary",
+            "contextType": "trial_summary",
+            "facets": summary_facets,
+        }
+    )
+    _write_structured_output(
+        {
+            "schemaVersion": "1.0",
+            "artifactType": "matraix.trial_evaluation",
+            "taskType": "survey",
+            "presenceCheck": {
+                "passed": True,
+                "requiredArtifacts": ["survey_result.json"],
+                "missingArtifacts": [],
+            },
+            "sourceArtifacts": {
+                "surveyResult": str(RESULT_PATH),
+            },
+            "contexts": contexts,
+            "fields": fields,
+        }
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/application/tasks/survey_ichra-metal-tier-ohio-salient/tests/verifier_env.sh
+++ b/application/tasks/survey_ichra-metal-tier-ohio-salient/tests/verifier_env.sh
@@ -1,0 +1,22 @@
+# Shared host/docker verifier path resolution (sourced from test.sh).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TRIAL_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+IS_HOST_SNAPSHOT=0
+case "${SCRIPT_DIR}" in
+  */host_tests) IS_HOST_SNAPSHOT=1 ;;
+esac
+
+if [ "${IS_HOST_SNAPSHOT}" -eq 1 ]; then
+  TESTS_DIR="${SCRIPT_DIR}"
+  VERIFIER_DIR="${TRIAL_ROOT}/verifier"
+else
+  TESTS_DIR="${HARBOR_TESTS_DIR:-/tests}"
+  if [ ! -f "${TESTS_DIR}/test_state.py" ] && [ -f "${SCRIPT_DIR}/test_state.py" ]; then
+    TESTS_DIR="${SCRIPT_DIR}"
+  fi
+  VERIFIER_DIR="${HARBOR_VERIFIER_DIR:-/logs/verifier}"
+  if ! mkdir -p "${VERIFIER_DIR}" 2>/dev/null; then
+    VERIFIER_DIR="${TRIAL_ROOT}/verifier"
+  fi
+fi
+mkdir -p "${VERIFIER_DIR}"

--- a/application/tasks/survey_ichra-metal-tier-ohio/README.md
+++ b/application/tasks/survey_ichra-metal-tier-ohio/README.md
@@ -37,9 +37,10 @@ without a full within-subject battery.
 In the first run of this task, 28 of 100 personas chose a metal tier strictly
 worse than one their allowance also covered in full — the leftover allowance is
 forfeited, so the richer plan was free to them. A paired A/B against
-[`survey_ichra-metal-tier-ohio-salient`](../survey_ichra-metal-tier-ohio-salient/RESULTS.md)
+[`survey_ichra-metal-tier-ohio-salient`](../survey_ichra-metal-tier-ohio-salient/README.md)
 showed the rate is not an artifact of how this task words the forfeit rule:
-making the rule prominent moved it 28% → 27%.
+making the rule prominent moved it 28% → 27%. Write-up and raw rationales:
+[analysis/ichra-metal-tier-ohio/](../../../analysis/ichra-metal-tier-ohio/).
 
 ## Premium anchors
 

--- a/application/tasks/survey_ichra-metal-tier-ohio/README.md
+++ b/application/tasks/survey_ichra-metal-tier-ohio/README.md
@@ -1,0 +1,62 @@
+# ICHRA Metal Tier Choice — Ohio
+
+Measures which metal tier (bronze / silver / gold) a working-age Ohio adult
+buys when an employer replaces its group plan with an ICHRA whose monthly
+allowance is scaled by age band.
+
+## Design
+
+The employer allowance is a function of the persona's own age:
+
+| Age | Monthly allowance |
+|---|---|
+| 27-35 | $500 |
+| 36-45 | $1,000 |
+| 46-64 | $1,500 |
+
+Each persona reads that table in `input/context.md`, finds its own row, and
+answers once. `q_allowance_band` records which band the persona placed itself
+in, so allowance is a recorded variable rather than an assumption — cross-tab
+`q_tier_choice` against it to get the tier mix per allowance level.
+
+Age-scaled ICHRA contributions are permitted (the allowance may vary with age
+in line with the premium age curve), so this mirrors a design an Ohio employer
+could actually offer.
+
+**Allowance and age are confounded by construction.** A bronze skew in the
+$500 band cannot be separated into "young people buy bronze" versus "a small
+allowance buys bronze" — the design ties them together. If you need those
+pulled apart, run a second job with a flat allowance across all ages and
+difference the two.
+
+`q_tier_if_more` adds a +$250 counterfactual, giving a one-step elasticity read
+without a full within-subject battery.
+
+## Premium anchors
+
+`input/context.md` carries real Ohio plan-year-2026 figures — median
+on-exchange premium by tier at ages 27 / 30 / 40 / 50 / 55 / 64, non-tobacco,
+Rating Area 11 (Columbus area), plus median deductible and out-of-pocket max by
+tier. Premiums nearly triple from age 27 to 64 under the federal age curve, so
+the allowance bands buy very different plans: $500 covers a bronze plan outright
+at 27, while $1,500 does not reach gold at 64.
+
+## Persona targeting
+
+`persona_strategy.json` filters to age brackets 25-34 through 55-64, North
+America, employed full- or part-time, stratified evenly across the four age
+brackets at n=100.
+
+Three limits worth knowing before reading results:
+
+- **Age is bracketed, and the brackets do not line up with the allowance
+  bands.** The pool carries 25-34 / 35-44 / 45-54 / 55-64, while the bands cut
+  at 27-35 / 36-45 / 46-64. Personas in the 35-44 bracket straddle the $500 and
+  $1,000 bands and resolve it themselves in `q_allowance_band` — which is why
+  that answer is recorded rather than inferred.
+- **There is no state dimension.** `region` is continental ("North America").
+  Ohio enters through the scenario text and the premium table, not through
+  persona attributes — these are North American working adults reasoning about
+  an Ohio offer, not verified Ohio residents.
+- **n=100 requires the `matraix-persona-1m` pool.** The checked-in
+  `matraix-persona-dev-sample` holds only 65 personas matching these filters.

--- a/application/tasks/survey_ichra-metal-tier-ohio/README.md
+++ b/application/tasks/survey_ichra-metal-tier-ohio/README.md
@@ -32,6 +32,15 @@ difference the two.
 `q_tier_if_more` adds a +$250 counterfactual, giving a one-step elasticity read
 without a full within-subject battery.
 
+## Known result
+
+In the first run of this task, 28 of 100 personas chose a metal tier strictly
+worse than one their allowance also covered in full — the leftover allowance is
+forfeited, so the richer plan was free to them. A paired A/B against
+[`survey_ichra-metal-tier-ohio-salient`](../survey_ichra-metal-tier-ohio-salient/RESULTS.md)
+showed the rate is not an artifact of how this task words the forfeit rule:
+making the rule prominent moved it 28% → 27%.
+
 ## Premium anchors
 
 `input/context.md` carries real Ohio plan-year-2026 figures — median

--- a/application/tasks/survey_ichra-metal-tier-ohio/input/context.md
+++ b/application/tasks/survey_ichra-metal-tier-ohio/input/context.md
@@ -1,0 +1,66 @@
+# Your employer is switching to an ICHRA (Ohio)
+
+You live and work in Ohio. Starting January 1, your employer is dropping its
+group health plan and moving to an **ICHRA** — an Individual Coverage Health
+Reimbursement Arrangement.
+
+## What that means for you
+
+- Your employer no longer picks the plan. **You** buy your own individual
+  health plan on the Ohio marketplace.
+- Your employer gives you a fixed monthly allowance toward the premium. The
+  allowance is tax-free to you.
+- If the plan you pick costs more than the allowance, you pay the difference
+  yourself, usually pre-tax through payroll.
+- If the plan costs less than the allowance, you do not pocket the difference.
+- Taking the ICHRA money means you **cannot** also claim a premium tax credit
+  (subsidy) on the marketplace. It is one or the other.
+- You may turn the ICHRA down and go without employer help, but then you get
+  no allowance at all.
+
+## Your allowance
+
+Your employer scales the allowance by age, because older workers face higher
+premiums. Find your own age:
+
+| Your age | Your monthly allowance |
+|---|---|
+| 27-35 | **$500** |
+| 36-45 | **$1,000** |
+| 46-64 | **$1,500** |
+
+That is the number you have to work with. Answer every question using your own
+allowance from this table.
+
+## What you have to choose
+
+Ohio's individual market sells plans in metal tiers. Higher metal = higher
+monthly premium, lower costs when you actually use care.
+
+| Tier | What it trades | Typical deductible | Typical out-of-pocket max |
+|---|---|---|---|
+| **Bronze** | Lowest premium, highest bills when you use it | $7,500 | $10,150 |
+| **Silver** | Middle on both | $6,000 | $9,200 |
+| **Gold** | Highest premium, lowest bills when you use it | $2,000 | $8,200 |
+
+## What plans actually cost in Ohio
+
+Monthly premium for one adult, non-smoker, central Ohio. Premiums rise steeply
+with age:
+
+| Your age | Bronze | Silver | Gold |
+|---|---|---|---|
+| 27 | $373 | $487 | $581 |
+| 30 | $404 | $528 | $630 |
+| 40 | $455 | $594 | $709 |
+| 50 | $636 | $831 | $991 |
+| 55 | $795 | $1,037 | $1,237 |
+| 64 | $1,069 | $1,395 | $1,664 |
+
+Find the row closest to your age. Whatever your allowance does not cover comes
+out of your own paycheck, every month.
+
+A family plan costs substantially more than the single-adult premiums above.
+
+*Premiums and cost-sharing: Ohio plan year 2026 marketplace filings, median of
+on-exchange plans in Rating Area 11 (Columbus area), non-tobacco.*

--- a/application/tasks/survey_ichra-metal-tier-ohio/input/questionnaire.yaml
+++ b/application/tasks/survey_ichra-metal-tier-ohio/input/questionnaire.yaml
@@ -1,0 +1,158 @@
+schemaVersion: "1.0"
+id: ichra_metal_tier_ohio_v1
+title: "ICHRA Metal Tier Choice — Ohio"
+description: "Which metal tier a worker buys when an employer replaces its group plan with an ICHRA whose monthly allowance is scaled by age band."
+questions:
+  - id: q_allowance_band
+    prompt: "Based on your own age, which monthly allowance does your employer give you?"
+    type: single_choice
+    construct: allowance_band
+    required: true
+    options:
+      - id: "band_500"
+        label: "$500 a month (I am 27-35)."
+      - id: "band_1000"
+        label: "$1,000 a month (I am 36-45)."
+      - id: "band_1500"
+        label: "$1,500 a month (I am 46-64)."
+
+  - id: q_tier_choice
+    prompt: "With that allowance, which plan do you buy?"
+    type: single_choice
+    construct: tier_choice
+    required: true
+    askRationale: true
+    options:
+      - id: "bronze"
+        label: "Bronze — lowest premium, highest deductible."
+      - id: "silver"
+        label: "Silver — middle premium, middle deductible."
+      - id: "gold"
+        label: "Gold — highest premium, lowest deductible."
+      - id: "decline"
+        label: "I turn down the ICHRA and go without employer help."
+
+  - id: q_allowance_adequacy
+    prompt: "My allowance covers the kind of plan I actually want."
+    type: likert
+    construct: allowance_adequacy
+    required: true
+    minValue: 1
+    maxValue: 5
+
+  - id: q_tier_if_more
+    prompt: "If your employer raised your allowance by $250 a month, would you change your plan?"
+    type: single_choice
+    construct: tier_elasticity
+    required: true
+    askRationale: true
+    options:
+      - id: "move_up"
+        label: "Yes, I would move up a tier."
+      - id: "same_tier_better_plan"
+        label: "I would stay in the same tier but pick a better plan in it."
+      - id: "no_change"
+        label: "No, I would keep the same plan and pay less myself."
+      - id: "would_enroll"
+        label: "I would enroll where I otherwise would have declined."
+
+  - id: q_out_of_pocket_ceiling
+    prompt: "How much of your own money, per month, are you willing to add on top of the allowance?"
+    type: single_choice
+    construct: payroll_tolerance
+    required: true
+    options:
+      - id: "none"
+        label: "Nothing. The plan has to fit inside the allowance."
+      - id: "under_100"
+        label: "Up to $100 a month."
+      - id: "100_250"
+        label: "$100 to $250 a month."
+      - id: "250_500"
+        label: "$250 to $500 a month."
+      - id: "over_500"
+        label: "More than $500 a month if the plan is right."
+
+  - id: q_deductible_reaction
+    prompt: "A Bronze plan in Ohio carries roughly a $7,500 deductible. You pay that yourself before most coverage starts."
+    type: likert
+    construct: deductible_pain
+    required: true
+    minValue: 1
+    maxValue: 5
+
+  - id: q_switch_driver
+    prompt: "What matters most when you pick between these plans?"
+    type: single_choice
+    construct: decision_driver
+    required: true
+    askRationale: true
+    options:
+      - id: "monthly_premium"
+        label: "The monthly premium. I budget month to month."
+      - id: "deductible"
+        label: "The deductible. I do not want a big bill before coverage kicks in."
+      - id: "oop_max"
+        label: "The out-of-pocket maximum. I care about the worst case."
+      - id: "doctors"
+        label: "Whether my doctors are in the network."
+      - id: "prescriptions"
+        label: "How my prescriptions are covered."
+
+  - id: q_expected_use
+    prompt: "How much medical care do you expect to use in the next year?"
+    type: single_choice
+    construct: expected_utilization
+    required: true
+    options:
+      - id: "almost_none"
+        label: "Almost none. Maybe one checkup."
+      - id: "routine"
+        label: "Routine care and a prescription or two."
+      - id: "regular"
+        label: "Regular care for an ongoing condition."
+      - id: "heavy"
+        label: "A lot. Surgery, specialists, or a chronic condition being managed."
+
+  - id: q_subsidy_tradeoff
+    prompt: "Taking the ICHRA money means giving up any marketplace subsidy you might have qualified for. Knowing that, would you still take the employer allowance?"
+    type: single_choice
+    construct: subsidy_awareness
+    required: true
+    askRationale: true
+    options:
+      - id: "take_ichra"
+        label: "Yes, take the allowance."
+      - id: "check_subsidy_first"
+        label: "Only after I check what the subsidy would have been worth."
+      - id: "prefer_subsidy"
+        label: "No, I would rather keep my subsidy eligibility."
+      - id: "did_not_know"
+        label: "I did not know that, and it changes my answer."
+
+  - id: q_verify_before_enrolling
+    prompt: "What do you check before you actually enroll? (Select all that apply)"
+    type: multi_choice
+    construct: pre_enrollment_checks
+    required: true
+    options:
+      - id: "doctor_in_network"
+        label: "Whether my current doctors take the plan."
+      - id: "drug_formulary"
+        label: "Whether my prescriptions are on the drug list."
+      - id: "hospital"
+        label: "Which hospitals are covered."
+      - id: "total_cost"
+        label: "Premium plus deductible added together for the year."
+      - id: "carrier_reputation"
+        label: "The insurance company's reputation."
+      - id: "nothing"
+        label: "Nothing. I pick on price and move on."
+
+  - id: q_confidence_in_choice
+    prompt: "I feel confident I picked the right plan for my situation."
+    type: likert
+    construct: choice_confidence
+    required: true
+    minValue: 1
+    maxValue: 5

--- a/application/tasks/survey_ichra-metal-tier-ohio/instruction.md
+++ b/application/tasks/survey_ichra-metal-tier-ohio/instruction.md
@@ -1,0 +1,19 @@
+# ICHRA Metal Tier Choice Survey
+
+Answer this survey based on your demographics, health, income, and
+circumstances. Read the background in the task context, then complete every
+required question in the questionnaire.
+
+## How to answer
+
+- Read the task context before answering. It has the Ohio premium and
+  deductible figures you need.
+- Find the premium row closest to your own age before you choose a tier. The
+  gap between the allowance and the premium is money out of your own pocket.
+- Answer every required question.
+- Use the exact choice ids for single- and multi-choice questions.
+- For questions marked "(Select all that apply)", select all ids that fit.
+- Answer with the selected value only unless a question explicitly asks for
+  `askRationale` / `askConfidence`.
+
+The platform records your answers; do not invent submission file paths.

--- a/application/tasks/survey_ichra-metal-tier-ohio/persona_strategy.json
+++ b/application/tasks/survey_ichra-metal-tier-ohio/persona_strategy.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": "1.0",
+  "sources": [],
+  "dimensionFilters": {
+    "age_bracket": [
+      "25-34",
+      "35-44",
+      "45-54",
+      "55-64"
+    ],
+    "region": [
+      "North America"
+    ],
+    "demo_employment_status": [
+      "Full-time",
+      "Part-time"
+    ]
+  },
+  "sampling": {
+    "mode": "stratified",
+    "fields": [
+      "age_bracket"
+    ],
+    "perCell": 25,
+    "sampleSize": 100
+  }
+}

--- a/application/tasks/survey_ichra-metal-tier-ohio/reporting.json
+++ b/application/tasks/survey_ichra-metal-tier-ohio/reporting.json
@@ -1,0 +1,65 @@
+{
+  "schemaVersion": "1.0",
+  "contextRules": [
+    {
+      "match": {
+        "contextType": "question_response",
+        "key": "question.q_tier_choice"
+      },
+      "summaryAnalyses": [
+        {
+          "id": "tier_choice.rationale_themes",
+          "title": "Why personas landed on their tier",
+          "targetFacetKey": "rationale",
+          "groupByMode": "none",
+          "summaryKind": "llm_bucket_summary"
+        }
+      ]
+    },
+    {
+      "match": {
+        "contextType": "question_response",
+        "key": "question.q_tier_if_more"
+      },
+      "summaryAnalyses": [
+        {
+          "id": "tier_elasticity.rationale_themes",
+          "title": "What another $250 a month would change",
+          "targetFacetKey": "rationale",
+          "groupByMode": "none",
+          "summaryKind": "llm_bucket_summary"
+        }
+      ]
+    },
+    {
+      "match": {
+        "contextType": "question_response",
+        "key": "question.q_switch_driver"
+      },
+      "summaryAnalyses": [
+        {
+          "id": "switch_driver.rationale_themes",
+          "title": "What drives the tier decision",
+          "targetFacetKey": "rationale",
+          "groupByMode": "none",
+          "summaryKind": "llm_bucket_summary"
+        }
+      ]
+    },
+    {
+      "match": {
+        "contextType": "question_response",
+        "key": "question.q_subsidy_tradeoff"
+      },
+      "summaryAnalyses": [
+        {
+          "id": "subsidy_tradeoff.rationale_themes",
+          "title": "Reactions to losing subsidy eligibility",
+          "targetFacetKey": "rationale",
+          "groupByMode": "none",
+          "summaryKind": "llm_bucket_summary"
+        }
+      ]
+    }
+  ]
+}

--- a/application/tasks/survey_ichra-metal-tier-ohio/task.toml
+++ b/application/tasks/survey_ichra-metal-tier-ohio/task.toml
@@ -1,0 +1,25 @@
+version = "1.0"
+artifacts = [ "/app/output",]
+
+[task]
+name = "application/survey-ichra-metal-tier-ohio"
+
+[metadata]
+difficulty = "easy"
+type = "survey"
+domain = "healthcare"
+tags = [ "ichra", "health insurance", "metal tier", "employer contribution", "ohio", "price sensitivity",]
+
+[verifier]
+timeout_sec = 120.0
+
+[agent]
+timeout_sec = 600.0
+
+[environment]
+definition = "application/shared-survey-form"
+build_timeout_sec = 600.0
+cpus = 1
+memory_mb = 2048
+storage_mb = 10240
+gpus = 0

--- a/application/tasks/survey_ichra-metal-tier-ohio/tests/test.sh
+++ b/application/tasks/survey_ichra-metal-tier-ohio/tests/test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck disable=SC1091
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/verifier_env.sh"
+
+if python3 "${TESTS_DIR}/test_state.py"; then
+  echo 1 > "${VERIFIER_DIR}/reward.txt"
+else
+  echo 0 > "${VERIFIER_DIR}/reward.txt"
+  exit 1
+fi

--- a/application/tasks/survey_ichra-metal-tier-ohio/tests/test_state.py
+++ b/application/tasks/survey_ichra-metal-tier-ohio/tests/test_state.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+OUTPUT_DIR = Path(
+    os.environ.get("HARBOR_OUTPUT_DIR")
+    or os.environ.get("MATRIX_OUTPUT_DIR")
+    or "/app/output"
+)
+RESULT_PATH = OUTPUT_DIR / "survey_result.json"
+EVENT_KEYS = {"timestamp", "actor", "action", "context", "outcome"}
+
+
+def _verifier_dir() -> Path:
+    base = (
+        os.environ.get("HARBOR_VERIFIER_DIR")
+        or os.environ.get("HARBOR_VERIFIER_DIR")
+        or "/logs/verifier"
+    )
+    path = Path(base)
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+    except OSError:
+        path = Path(__file__).resolve().parent.parent / "verifier"
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+
+def _write_structured_output(payload: dict[str, object]) -> None:
+    path = _verifier_dir() / "structured_output.json"
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def fail(message: str) -> int:
+    print(message, file=sys.stderr)
+    return 1
+
+
+def _question_types_from_trajectory(trajectory: list[object]) -> dict[str, str]:
+    """Map questionId -> questionnaire type from ask_question trajectory events."""
+    out: dict[str, str] = {}
+    for event in trajectory:
+        if not isinstance(event, dict):
+            continue
+        if str(event.get("action") or "") != "ask_question":
+            continue
+        context = event.get("context")
+        if not isinstance(context, dict):
+            continue
+        question_id = str(context.get("questionId") or "").strip()
+        question_type = str(context.get("questionType") or "").strip().lower()
+        if question_id and question_type:
+            out[question_id] = question_type
+    return out
+
+
+def _field_kind_for_question(question_type: str | None, value: object) -> str:
+    """Kind follows questionnaire type — not string-shape heuristics."""
+    qtype = (question_type or "").strip().lower()
+    if qtype == "likert":
+        return "numerical"
+    if qtype in {"single_choice", "multi_choice"}:
+        return "categorical"
+    if qtype == "free_text":
+        return "textual"
+    if isinstance(value, bool):
+        return "categorical"
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return "numerical"
+    if isinstance(value, list):
+        return "categorical"
+    if isinstance(value, str):
+        text = value.strip()
+        if " " in text or "\n" in text or len(text) > 64:
+            return "textual"
+        return "categorical"
+    return "textual"
+
+
+def main() -> int:
+    if not RESULT_PATH.is_file():
+        return fail("missing /app/output/survey_result.json")
+    try:
+        payload = json.loads(RESULT_PATH.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return fail("survey_result.json is not valid JSON: {}".format(exc))
+    if not isinstance(payload, dict):
+        return fail("survey_result.json must contain an object")
+    answers = payload.get("answers")
+    if not isinstance(answers, list) or not answers:
+        return fail("survey_result.answers must be a non-empty list")
+    trajectory = payload.get("trajectory")
+    if not isinstance(trajectory, list) or not trajectory:
+        return fail("survey_result.trajectory must be a non-empty list")
+    question_types = _question_types_from_trajectory(trajectory)
+    fields: list[dict[str, object]] = []
+    contexts: list[dict[str, object]] = []
+    numeric_values: list[float] = []
+    for index, answer in enumerate(answers):
+        if not isinstance(answer, dict):
+            return fail("answers[{}] must be an object".format(index))
+        question_id = str(answer.get("questionId", "")).strip()
+        if not question_id:
+            return fail("answers[{}].questionId is required".format(index))
+        if "value" not in answer:
+            return fail("answers[{}].value is required".format(index))
+        value = answer.get("value")
+        question_type = question_types.get(question_id)
+        kind = _field_kind_for_question(question_type, value)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            numeric_values.append(float(value))
+        context_key = "question.{}".format(question_id)
+        context_label = str(answer.get("prompt") or question_id)
+        facets: list[dict[str, object]] = [
+            {
+                "key": "response",
+                "label": "Selected response",
+                "role": "primary",
+                "kind": kind,
+                "value": value,
+            }
+        ]
+        fields.append(
+            {
+                "key": "{}.response".format(context_key),
+                "label": "Selected response",
+                "group": context_key,
+                "role": "primary",
+                "kind": kind,
+                "value": value,
+            }
+        )
+        rationale = str(answer.get("rationale") or "").strip()
+        if rationale:
+            facets.append(
+                {
+                    "key": "reason",
+                    "label": "Reason",
+                    "role": "explanation",
+                    "kind": "textual",
+                    "value": rationale,
+                }
+            )
+            fields.append(
+                {
+                    "key": "{}.reason".format(context_key),
+                    "label": "Reason",
+                    "group": context_key,
+                    "role": "explanation",
+                    "kind": "textual",
+                    "value": rationale,
+                }
+            )
+        confidence = answer.get("confidence")
+        if isinstance(confidence, (int, float)) and not isinstance(confidence, bool):
+            facets.append(
+                {
+                    "key": "confidence",
+                    "label": "Confidence",
+                    "role": "score",
+                    "kind": "numerical",
+                    "value": float(confidence),
+                }
+            )
+            fields.append(
+                {
+                    "key": "{}.confidence".format(context_key),
+                    "label": "Confidence",
+                    "group": context_key,
+                    "role": "score",
+                    "kind": "numerical",
+                    "value": float(confidence),
+                }
+            )
+        context_payload: dict[str, object] = {
+            "key": context_key,
+            "label": context_label,
+            "contextType": "question_response",
+            "facets": facets,
+        }
+        if question_type:
+            context_payload["questionType"] = question_type
+        contexts.append(context_payload)
+    for index, event in enumerate(trajectory):
+        if not isinstance(event, dict):
+            return fail("trajectory[{}] must be an object".format(index))
+        missing = EVENT_KEYS - set(event)
+        if missing:
+            return fail(
+                "trajectory[{}] missing keys: {}".format(index, ", ".join(sorted(missing)))
+            )
+        if not isinstance(event.get("context"), dict):
+            return fail("trajectory[{}].context must be an object".format(index))
+        if not isinstance(event.get("outcome"), dict):
+            return fail("trajectory[{}].outcome must be an object".format(index))
+    summary_facets: list[dict[str, object]] = [
+        {
+            "key": "answer_count",
+            "label": "Answer count",
+            "role": "score",
+            "kind": "numerical",
+            "value": len(answers),
+        },
+        {
+            "key": "trajectory_event_count",
+            "label": "Trajectory event count",
+            "role": "score",
+            "kind": "numerical",
+            "value": len(trajectory),
+        },
+    ]
+    fields.append(
+        {
+            "key": "survey.summary.answer_count",
+            "label": "Answer count",
+            "group": "survey.summary",
+            "role": "score",
+            "kind": "numerical",
+            "value": len(answers),
+        }
+    )
+    fields.append(
+        {
+            "key": "survey.summary.trajectory_event_count",
+            "label": "Trajectory event count",
+            "group": "survey.summary",
+            "role": "score",
+            "kind": "numerical",
+            "value": len(trajectory),
+        }
+    )
+    if numeric_values:
+        summary_facets.append(
+            {
+                "key": "mean_numeric_answer",
+                "label": "Mean numeric answer",
+                "role": "score",
+                "kind": "numerical",
+                "value": round(sum(numeric_values) / len(numeric_values), 4),
+            }
+        )
+        fields.append(
+            {
+                "key": "survey.summary.mean_numeric_answer",
+                "label": "Mean numeric answer",
+                "group": "survey.summary",
+                "role": "score",
+                "kind": "numerical",
+                "value": round(sum(numeric_values) / len(numeric_values), 4),
+            }
+        )
+    contexts.append(
+        {
+            "key": "survey.summary",
+            "label": "Survey summary",
+            "contextType": "trial_summary",
+            "facets": summary_facets,
+        }
+    )
+    _write_structured_output(
+        {
+            "schemaVersion": "1.0",
+            "artifactType": "matraix.trial_evaluation",
+            "taskType": "survey",
+            "presenceCheck": {
+                "passed": True,
+                "requiredArtifacts": ["survey_result.json"],
+                "missingArtifacts": [],
+            },
+            "sourceArtifacts": {
+                "surveyResult": str(RESULT_PATH),
+            },
+            "contexts": contexts,
+            "fields": fields,
+        }
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/application/tasks/survey_ichra-metal-tier-ohio/tests/verifier_env.sh
+++ b/application/tasks/survey_ichra-metal-tier-ohio/tests/verifier_env.sh
@@ -1,0 +1,22 @@
+# Shared host/docker verifier path resolution (sourced from test.sh).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TRIAL_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+IS_HOST_SNAPSHOT=0
+case "${SCRIPT_DIR}" in
+  */host_tests) IS_HOST_SNAPSHOT=1 ;;
+esac
+
+if [ "${IS_HOST_SNAPSHOT}" -eq 1 ]; then
+  TESTS_DIR="${SCRIPT_DIR}"
+  VERIFIER_DIR="${TRIAL_ROOT}/verifier"
+else
+  TESTS_DIR="${HARBOR_TESTS_DIR:-/tests}"
+  if [ ! -f "${TESTS_DIR}/test_state.py" ] && [ -f "${SCRIPT_DIR}/test_state.py" ]; then
+    TESTS_DIR="${SCRIPT_DIR}"
+  fi
+  VERIFIER_DIR="${HARBOR_VERIFIER_DIR:-/logs/verifier}"
+  if ! mkdir -p "${VERIFIER_DIR}" 2>/dev/null; then
+    VERIFIER_DIR="${TRIAL_ROOT}/verifier"
+  fi
+fi
+mkdir -p "${VERIFIER_DIR}"

--- a/apps/viewer/vite.config.ts
+++ b/apps/viewer/vite.config.ts
@@ -5,4 +5,12 @@ import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
   plugins: [tailwindcss(), reactRouter(), tsconfigPaths()],
+  server: {
+    proxy: {
+      "/api": {
+        target: process.env.HARBOR_API_URL ?? "http://127.0.0.1:8080",
+        changeOrigin: true,
+      },
+    },
+  },
 });


### PR DESCRIPTION
## Module

Select the owning module:

- [ ] `persona/`
- [x] `application/`
- [ ] `environment/`
- [ ] `packages/`
- [x] `apps/`
- [ ] docs or migration metadata only

Also adds a new top-level `analysis/` directory, which the list above does not
cover — happy to relocate it if there is a preferred home for cross-task
analysis output.

## Summary

Two independent changes. The two type fixes that were originally in this
branch are split out into #62 — that PR is what makes `npm run build` pass;
this branch does not touch the frontend and does not build without it.

**1. New survey task pair + analysis (`application/tasks/`, `analysis/`)**

`survey_ichra-metal-tier-ohio` measures which metal tier a working-age Ohio
adult buys when an employer replaces its group plan with an ICHRA. The employer
allowance is scaled by age band ($500 for 27-35, $1,000 for 36-45, $1,500 for
46-64), which ICHRA rules permit. Premium and cost-sharing anchors are real
Ohio PY2026 marketplace figures, median on-exchange by tier, non-tobacco,
Rating Area 11.

`survey_ichra-metal-tier-ohio-salient` is a paired A/B arm differing only in
the salience of one rule.

The result is the reason both arms are here. In the control run, **28 of 100
personas chose a metal tier strictly worse than one their allowance also
covered in full** — unused allowance is forfeited, so the richer plan was free
to them. Personas named the dominated option and declined it:

> "Gold at $991 is also within reach, but Silver strikes a reasonable middle
> ground... without overpaying."

The A/B tested whether that was an instrument artifact. Making the forfeit rule
prominent moved the rate 28/99 → 27/99, with 92 of 99 personas choosing the
identical tier in both arms. Salience is not the constraint.

This may be of interest beyond the scenario itself: it is a case where personas
perform the arithmetic correctly in their stated rationale and then choose
against it, and the behavior survives a direct instructional fix.

**2. Dev proxy for the viewer (`apps/viewer/vite.config.ts`)**

`harbor view --dev` shells out to `npm ci`, which fails because
`apps/viewer/package-lock.json` is out of sync with `package.json` (missing the
platform-optional `@tailwindcss/oxide-*` and `@esbuild/*` entries), so the two
halves have to be started separately. The backend's CORS allowlist is hardcoded
to `:5173`, which a separately-started vite may not get. Proxying `/api` makes
the API same-origin.

The underlying lockfile drift is not fixed here — regenerating it felt out of
scope for this PR, but it is the real bug behind both `harbor view` code paths.

## Validation

Commands run:

```bash
# task definitions parse; reporting keys resolve to real question ids
uv run python -c "import yaml,json; ..."   # questionnaire, reporting, task.toml

# the two arms differ only in context.md, task.toml, README.md
diff -r application/tasks/survey_ichra-metal-tier-ohio \
        application/tasks/survey_ichra-metal-tier-ohio-salient

# both arms executed end to end against matraix-persona-1m
# control:   pg-survey-ichra-metal-tier-ohio-668679a2          100/100 trials
# treatment: pg-survey-ichra-metal-tier-ohio-salient-8f156186   99/100 trials
#            (1 Anthropic read timeout; that persona dropped from both arms)
```

Viewer verified in-browser against a live `harbor.viewer` backend: task list
renders, `/api/*` returns 200 through the proxy, no console errors.

`npm run build` for the playground frontend is verified in #62, not here — this
branch leaves those files untouched.

### Application task PRs

When this PR adds or materially changes an `application/tasks/…` scenario:

- [ ] Attached the **Playground UI** batch report PDF (Runs → job → **Download PDF**
      on the persona-task batch report), not the server text `…/report.pdf` export.

Both reports are exported and will be attached to this PR directly — control,
6 pages, from `pg-survey-ichra-metal-tier-ohio-668679a2`; treatment, 5 pages,
from `pg-survey-ichra-metal-tier-ohio-salient-8f156186`.

Note for reviewers when they land: the treatment job is badged **FAILED** at the
job level because one of its 100 trials hit an Anthropic read timeout. The other
99 produced valid results, and the paired analysis drops that persona from both
arms, so every figure in `RESULTS.md` is n=99 on both sides.

Note for reviewers: the Runs list badges the treatment job **FAILED** because 1
of its 100 trials hit an Anthropic read timeout. The other 99 produced valid
results, and the paired analysis drops that persona from both arms.

## Data Policy

- [x] No large generated outputs or raw dumps were added.
- [x] Any fixtures are small and necessary for tests or docs.

An earlier revision of this branch carried a 294 KB CSV of all 796 persona
rationales. It has been removed — and removed from the branch history, not
deleted in a follow-up commit, so merging does not pull the blob into the
repository either way. `analysis/ichra-metal-tier-ohio/README.md` documents the
two job names and the derivation instead, so the numbers in `RESULTS.md` are
reconstructible from the job artifacts without shipping a dump.

Largest files added are now the two 285-line `test_state.py` verifier copies,
both taken verbatim from `survey_annual-checkup-habits`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
