### PR TITLE
fix(playground): repair two type errors blocking npm run build

### DIFF
--- a/application/playground/frontend/src/components/PersonaStoreContent.tsx
+++ b/application/playground/frontend/src/components/PersonaStoreContent.tsx
@@ -78,7 +78,7 @@ function PersonaSearchField({
 }: {
   value: string;
   onDebouncedChange: (value: string) => void;
-  inputRef?: React.RefObject<HTMLInputElement | null>;
+  inputRef?: React.RefObject<HTMLInputElement>;
   placeholder: string;
 }) {
   const [local, setLocal] = useState(value);

--- a/application/playground/frontend/src/lib/types.ts
+++ b/application/playground/frontend/src/lib/types.ts
@@ -1039,7 +1039,7 @@ export interface PersonaPoolPersonaCard {
   personaId: string;
   name?: string;
   source?: string;
-  path?: string;
+  path?: string | null;
   dimensions: Record<string, string>;
   /** Lowercased haystack of id/name/source + all YAML attribute keys/values. */
   searchText?: string;


### PR DESCRIPTION
## Module

Select the owning module:

- [ ] `persona/`
- [x] `application/`
- [ ] `environment/`
- [ ] `packages/`
- [ ] `apps/`
- [ ] docs or migration metadata only

## Summary

`npm run build` fails on `main` in a clean checkout. It dies at the `tsc` gate
before vite ever runs, so the playground frontend cannot be built from a fresh
clone:

```
src/components/PersonaStoreContent.tsx(99,9): error TS2322: Type 'RefObject<HTMLInputElement | null> | undefined'
  is not assignable to type 'LegacyRef<HTMLInputElement> | undefined'.
src/lib/types.ts(1074,18): error TS2430: Interface 'PersonaPoolPersonaDetail'
  incorrectly extends interface 'PersonaPoolPersonaCard'.
```

Two one-line fixes.

**`PersonaStoreContent.tsx`** — the `inputRef` prop is declared React 19 style
as `RefObject<HTMLInputElement | null>`. This project is on React 18, where
`RefObject<T>` already carries `current: T | null` and is covariant in `T`, so
the extra `| null` makes it unassignable to the DOM `ref` slot. Narrowed to
`RefObject<HTMLInputElement>`, which is exactly what the only caller —
`useRef<HTMLInputElement>(null)` on line 168 — produces.

**`types.ts`** — `PersonaPoolPersonaDetail` declares `path?: string | null`
while its base `PersonaPoolPersonaCard` declares `path?: string`, so the
`extends` is illegal. Widened the base rather than narrowing the detail: the
detail's nullability reads as deliberate, and both consumers already null-guard
(`BenchPersonaDetailPanel.tsx:241` uses `?.trim() ||`).

Type-only. The emitted bundle hash is unchanged (`index-CDWPQBI6.js`), so
nothing shifts at runtime.

## Validation

Commands run:

```bash
# on main — fails at the tsc gate, before vite
git checkout main
cd application/playground/frontend && npm install && npm run build
#   → the two errors quoted above

# on this branch — both typechecks pass, vite build completes
git checkout fix-playground-build-types
cd application/playground/frontend && npm run build
#   → ✓ built in 3.22s, same bundle hash
```

Playground UI additionally exercised against a live backend after the change:
Persona World loads 200 personas, the patched search input debounces and filters
correctly, Task Gallery and Runs render, no console errors.

### Application task PRs

When this PR adds or materially changes an `application/tasks/…` scenario:

- [ ] Attached the **Playground UI** batch report PDF (Runs → job → **Download PDF**
      on the persona-task batch report), not the server text `…/report.pdf` export.

Not applicable — this PR touches no `application/tasks/…` scenario.

## Data Policy

- [x] No large generated outputs or raw dumps were added.
- [x] Any fixtures are small and necessary for tests or docs.

Two lines changed across two files; nothing added.

---

Split out of #61 so the build fix can land independently of the survey task in
that PR. No dependency in this direction — #61 depends on this one to build,
not the reverse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
