### PR TITLE
ci: add Playground frontend typecheck/test/build workflow

### DIFF
--- a/.github/workflows/playground-frontend.yml
+++ b/.github/workflows/playground-frontend.yml
@@ -1,0 +1,33 @@
+name: Playground Frontend
+
+on:
+  pull_request:
+    paths:
+      - "application/playground/frontend/**"
+      - ".github/workflows/playground-frontend.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "application/playground/frontend/**"
+      - ".github/workflows/playground-frontend.yml"
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: application/playground/frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: application/playground/frontend/package-lock.json
+      - run: npm ci
+      - run: npm run typecheck
+      # No test script exists yet; this activates automatically once one lands.
+      - run: npm run test --if-present
+      - run: npm run build

--- a/application/playground/frontend/src/components/PersonaStoreContent.tsx
+++ b/application/playground/frontend/src/components/PersonaStoreContent.tsx
@@ -78,7 +78,7 @@ function PersonaSearchField({
 }: {
   value: string;
   onDebouncedChange: (value: string) => void;
-  inputRef?: React.RefObject<HTMLInputElement | null>;
+  inputRef?: React.RefObject<HTMLInputElement>;
   placeholder: string;
 }) {
   const [local, setLocal] = useState(value);

--- a/application/playground/frontend/src/lib/types.ts
+++ b/application/playground/frontend/src/lib/types.ts
@@ -1039,7 +1039,7 @@ export interface PersonaPoolPersonaCard {
   personaId: string;
   name?: string;
   source?: string;
-  path?: string;
+  path?: string | null;
   dimensions: Record<string, string>;
   /** Lowercased haystack of id/name/source + all YAML attribute keys/values. */
   searchText?: string;


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow gating `application/playground/frontend` with `npm ci` + typecheck + test (`--if-present`, activates once a test script lands) + build.
- Maintainer-side prep for the i18n PR sequence tracked in #66, so every replacement PR for #30 is covered from day one.

## Test plan
- [x] Workflow only triggers on frontend/workflow path changes
- [ ] CI runs green on this PR (touches the workflow path itself)

Made with [Cursor](https://cursor.com)