### PR TITLE
docs: pause community contributions of application tasks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,7 +23,11 @@ Commands run:
 
 ### Application task PRs
 
-When this PR adds or materially changes an `application/tasks/…` scenario:
+**We are not accepting new community contributions of `application/tasks/…`
+scenarios for now.** See [application/tasks/README.md](../application/tasks/README.md).
+
+When this PR adds or materially changes an `application/tasks/…` scenario
+(maintainers / invited only):
 
 - [ ] Attached the **Playground UI** batch report PDF (Runs → job → **Download PDF**
       on the persona-task batch report), not the server text `…/report.pdf` export.

--- a/application/tasks/README.md
+++ b/application/tasks/README.md
@@ -3,6 +3,12 @@
 Task definitions for **application product research**. These were migrated from
 MatrAIx and organized under the MatrAIx `application/` module.
 
+> **Contribution status:** We are **not accepting new community contributions** of
+> application tasks under `application/tasks/` for now (new survey / chat / web /
+> os-app scenarios, or insight-driven A/B task pairs). Existing tasks remain
+> supported; platform, docs, and other non-task PRs are still welcome. If you are
+> unsure whether a change counts as a task contribution, open an issue first.
+
 This import contains application task folders, tests, and reference solutions.
 Runtime build contexts live under `environment/task-environments/application/`.
 Generated job recipes land under `configs/jobs/` (see [quickstart.md](../../docs/quickstart.md)).


### PR DESCRIPTION
## Summary
- State in `application/tasks/README.md` that we are not accepting new community contributions of application tasks for now.
- Mirror the same notice in the PR template so it is visible when opening a PR.

## Test plan
- [ ] README notice is visible at the top of `application/tasks/README.md`
- [ ] PR template Application task section mentions the pause

Made with [Cursor](https://cursor.com)