### PR TITLE
ci: drop area auto-labels, keep documentation and migration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,14 +1,4 @@
-# Auto-label PRs by code area
-
-"area: persona":
-  - changed-files:
-      - any-glob-to-any-file:
-          - persona/**
-
-"area: application":
-  - changed-files:
-      - any-glob-to-any-file:
-          - application/**
+# Auto-label PRs
 
 "documentation":
   - changed-files:
@@ -22,17 +12,3 @@
       - any-glob-to-any-file:
           - docs/migration/**
           - migration/matraix/**
-
-"area: environment":
-  - changed-files:
-      - any-glob-to-any-file:
-          - environment/**
-          - src/**
-          - configs/**
-          - apps/**
-          - packages/**
-          - tests/**
-          - .github/**
-          - pyproject.toml
-          - uv.lock
-          - .gitignore


### PR DESCRIPTION
## Summary
- The `area: *` and `team: environment` labels were removed from the repo; this drops the corresponding labeler rules so the labeler action does not recreate them (adding a nonexistent label via the API auto-creates it in default gray).
- `documentation` and `migration` auto-labeling stays.

## Test plan
- [ ] Next PR gets no area labels; docs PRs still get `documentation`

Made with [Cursor](https://cursor.com)