### PR TITLE
ci: restore module auto-labels without the area prefix

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,28 @@
-# Auto-label PRs
+# Auto-label PRs by module
+
+"persona":
+  - changed-files:
+      - any-glob-to-any-file:
+          - persona/**
+
+"application":
+  - changed-files:
+      - any-glob-to-any-file:
+          - application/**
+
+"environment":
+  - changed-files:
+      - any-glob-to-any-file:
+          - environment/**
+          - src/**
+          - configs/**
+          - apps/**
+          - packages/**
+          - tests/**
+          - .github/**
+          - pyproject.toml
+          - uv.lock
+          - .gitignore
 
 "documentation":
   - changed-files:


### PR DESCRIPTION
## Summary
- Restores the module auto-label rules dropped in #70, now as plain `persona` / `application` / `environment` (the intent was to drop the `area: ` prefix, not the labels).
- The unprefixed labels already exist with distinct colors (purple/green/blue).

## Test plan
- [ ] Next PR touching e.g. `docs/**` + `.github/**` gets `documentation` + `environment`

Made with [Cursor](https://cursor.com)