### PR TITLE
docs: first-class Windows (WSL2) support + enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,21 @@
+# Normalize all text files to LF, everywhere.
+#
+# Shell scripts, task verifiers, and Dockerfile COPY'd files are executed
+# inside Linux containers; a CRLF checkout on Windows (core.autocrlf=true)
+# would break them with "\r: command not found". Forcing LF keeps clones
+# working on every platform, including Windows (WSL2 or Git Bash).
+* text=auto eol=lf
+
+# Binary assets — never touch line endings.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary
+*.ico binary
+*.pdf binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.zip binary
+*.gz binary

--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ people**.
 - Node.js 20+ (Playground / viewer frontends only)
 - Model API keys for persona-agent examples — see [agents.md](docs/environment/agents.md)
 
+> **Windows users**: run everything inside
+> [WSL2](https://learn.microsoft.com/windows/wsl/install) — open PowerShell,
+> run `wsl --install` (installs Ubuntu), then clone this repo **inside the WSL
+> filesystem** (e.g. `~/MatrAIx`, not `/mnt/c/…`, which is much slower) and
+> enable *WSL integration* in Docker Desktop → Settings → Resources. Every
+> command in this README then works exactly as written. Native
+> PowerShell/cmd is not supported (the task verifiers require `bash`).
+
 ## Installation
 
 ```bash

--- a/docs/i18n/README.es.md
+++ b/docs/i18n/README.es.md
@@ -75,6 +75,15 @@ de personas reales**.
 - Node.js 20+ (solo frontends de Playground / viewer)
 - Claves de API de modelo para ejemplos de agentes de persona — ver [agents.md](../environment/agents.md)
 
+> **Usuarios de Windows**: ejecuten todo dentro de
+> [WSL2](https://learn.microsoft.com/windows/wsl/install) — abran PowerShell,
+> ejecuten `wsl --install` (instala Ubuntu), luego clonen este repositorio
+> **dentro del sistema de archivos de WSL** (p. ej. `~/MatrAIx`, no
+> `/mnt/c/…`, que es mucho más lento) y activen *WSL integration* en Docker
+> Desktop → Settings → Resources. Después, todos los comandos de este README
+> funcionan tal cual. No se admite PowerShell/cmd nativo (los verificadores de
+> tareas requieren `bash`).
+
 ## Instalación
 
 ```bash

--- a/docs/i18n/README.ja.md
+++ b/docs/i18n/README.ja.md
@@ -70,6 +70,15 @@
 - Node.js 20+（Playground / viewer フロントエンドのみ）
 - ペルソナエージェント例用のモデル API キー — [agents.md](../environment/agents.md) を参照
 
+> **Windows をお使いの方へ**：すべてのコマンドは
+> [WSL2](https://learn.microsoft.com/windows/wsl/install) 内で実行してください。
+> PowerShell で `wsl --install` を実行（Ubuntu がインストールされます）した後、
+> リポジトリは **WSL ファイルシステム内**（例：`~/MatrAIx`。`/mnt/c/…` は大幅に
+> 遅くなるため避けてください）に clone し、Docker Desktop → Settings → Resources
+> で *WSL integration* を有効にしてください。以降、本 README のコマンドは
+> そのまま動作します。ネイティブの PowerShell/cmd はサポートしていません
+> （タスク検証スクリプトが `bash` を必要とするため）。
+
 ## インストール
 
 ```bash

--- a/docs/i18n/README.ko.md
+++ b/docs/i18n/README.ko.md
@@ -70,6 +70,14 @@
 - Node.js 20+ (Playground / viewer 프론트엔드만)
 - 페르소나 에이전트 예제용 모델 API 키 — [agents.md](../environment/agents.md) 참고
 
+> **Windows 사용자**: 모든 명령은
+> [WSL2](https://learn.microsoft.com/windows/wsl/install) 안에서 실행하세요.
+> PowerShell에서 `wsl --install`을 실행하면 Ubuntu가 설치됩니다. 그다음 저장소를
+> **WSL 파일시스템 안**(예: `~/MatrAIx`, `/mnt/c/…`는 훨씬 느리므로 피하세요)에
+> clone하고, Docker Desktop → Settings → Resources에서 *WSL integration*을
+> 활성화하세요. 이후 이 README의 모든 명령이 그대로 동작합니다. 네이티브
+> PowerShell/cmd는 지원하지 않습니다(작업 검증 스크립트가 `bash`를 필요로 합니다).
+
 ## 설치
 
 ```bash

--- a/docs/i18n/README.pt-BR.md
+++ b/docs/i18n/README.pt-BR.md
@@ -74,6 +74,15 @@ reais**.
 - Node.js 20+ (apenas frontends do Playground / viewer)
 - Chaves de API de modelo para exemplos de agentes de persona — veja [agents.md](../environment/agents.md)
 
+> **Usuários de Windows**: execute tudo dentro do
+> [WSL2](https://learn.microsoft.com/windows/wsl/install) — abra o PowerShell,
+> execute `wsl --install` (instala o Ubuntu), depois clone este repositório
+> **dentro do sistema de arquivos do WSL** (ex.: `~/MatrAIx`, não `/mnt/c/…`,
+> que é muito mais lento) e ative a *WSL integration* em Docker Desktop →
+> Settings → Resources. A partir daí, todos os comandos deste README funcionam
+> exatamente como estão. PowerShell/cmd nativo não é suportado (os
+> verificadores de tarefas exigem `bash`).
+
 ## Instalação
 
 ```bash

--- a/docs/i18n/README.zh-CN.md
+++ b/docs/i18n/README.zh-CN.md
@@ -61,6 +61,13 @@
 - Node.js 20+（仅 Playground / viewer 前端需要）
 - 人格 Agent 示例所需的模型 API Key —— 见 [agents.md](../environment/agents.md)
 
+> **Windows 用户**：请在
+> [WSL2](https://learn.microsoft.com/windows/wsl/install) 中运行全部命令——打开
+> PowerShell 执行 `wsl --install`（会安装 Ubuntu），然后把仓库 clone 到 **WSL
+> 文件系统内**（如 `~/MatrAIx`，不要放在 `/mnt/c/…`，后者慢得多），并在 Docker
+> Desktop → Settings → Resources 中开启 *WSL integration*。之后本 README 中的所有
+> 命令均可原样运行。不支持原生 PowerShell/cmd（任务验证脚本依赖 `bash`）。
+
 ## 安装
 
 ```bash

--- a/docs/i18n/README.zh-TW.md
+++ b/docs/i18n/README.zh-TW.md
@@ -61,6 +61,13 @@
 - Node.js 20+（僅 Playground / viewer 前端需要）
 - 人格 Agent 範例所需的模型 API Key —— 見 [agents.md](../environment/agents.md)
 
+> **Windows 使用者**：請在
+> [WSL2](https://learn.microsoft.com/windows/wsl/install) 中執行全部指令——開啟
+> PowerShell 執行 `wsl --install`（會安裝 Ubuntu），接著把儲存庫 clone 到 **WSL
+> 檔案系統內**（如 `~/MatrAIx`，不要放在 `/mnt/c/…`，後者慢得多），並在 Docker
+> Desktop → Settings → Resources 中啟用 *WSL integration*。之後本 README 中的所有
+> 指令皆可照原樣執行。不支援原生 PowerShell/cmd（任務驗證腳本依賴 `bash`）。
+
 ## 安裝
 
 ```bash

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -29,6 +29,26 @@ persona **`0042`**). **Recommended** for real cohorts: import **Persona 1M** —
 
 ---
 
+## 0. Windows users: set up WSL2 first
+
+Everything below assumes a Linux/macOS shell. On Windows, use
+[WSL2](https://learn.microsoft.com/windows/wsl/install) — it takes ~5 minutes
+and then every command in this guide works exactly as written:
+
+1. Open **PowerShell as Administrator** and run `wsl --install` (installs
+   Ubuntu). Reboot if prompted, then create your Linux username/password.
+2. Install [Docker Desktop](https://docs.docker.com/get-docker/) and enable
+   **Settings → Resources → WSL integration** for your Ubuntu distro.
+3. Do all remaining steps **inside the Ubuntu terminal** (search “Ubuntu” in
+   the Start menu). Clone the repo into the WSL filesystem — e.g. `~/MatrAIx`,
+   **not** `/mnt/c/…` — Windows-mounted paths are dramatically slower and can
+   cause file-watching issues with the Playground dev server.
+
+Native PowerShell/cmd is not supported: task verifiers and dev scripts
+require `bash`.
+
+---
+
 ## 1. Install Docker and confirm it works
 
 1. Install [Docker Desktop](https://docs.docker.com/get-docker/) (or Docker Engine on Linux).


### PR DESCRIPTION
## Summary

Makes the repo safe and easy to use for Windows users — written from the user's point of view (copy-paste steps, no assumed Linux knowledge).

- **`.gitattributes`**: force LF for all text files. Without this, a Windows clone with `core.autocrlf=true` checks out shell scripts / task verifiers with CRLF, which break inside Linux containers (`\r: command not found`). Verified with `git add --renormalize .` that this causes **zero churn** on the current tree (everything is already LF). Binary assets exempted.
- **README → Requirements**: a compact step-by-step Windows note — `wsl --install`, clone **inside the WSL filesystem** (not `/mnt/c/…`), enable Docker Desktop WSL integration. States explicitly that native PowerShell/cmd is not supported.
- **quickstart → new "Step 0. Windows users: set up WSL2 first"**: the same walkthrough in numbered steps, placed before step 1 so Windows users hit it before anything else.
- **All six translated READMEs** (`zh-CN`, `zh-TW`, `ja`, `ko`, `es`, `pt-BR`): the same note, translated.

## Test plan

- [x] `git add --renormalize .` after adding `.gitattributes` → no file changes (no renormalization diff for existing contributors)
- [x] Verified all requirement sections across the 6 locales received the note

Made with [Cursor](https://cursor.com)