### PR TITLE
feat(philippines): microdata ingest pipeline, converter and census-derived targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -271,6 +271,13 @@ persona/datasets/*/cohorts/
 persona/datasets/matraix-persona-1m/release/
 persona/datasets/matraix-persona-1m/cohorts/
 persona/datasets/matraix-persona-1m/indexes/
+persona/datasets/philippines-1m/
+
+# Provider-licensed source material fetched under a data-use agreement (WVS
+# questionnaires and codebooks, PSA PUFs). Redistribution is not permitted by
+# those terms, so this must never enter the repository. Working copies live
+# here and in persona/curation/existing_data/raw/, both untracked.
+/data/
 configs/jobs/application-task-job-recipe/*.yaml
 configs/jobs/application-task-job-recipe/*.meta.json
 configs/jobs/application-task-job-recipe/*.launch.json

--- a/persona/curation/existing_data/manifests/ndhs_ph_2022.json
+++ b/persona/curation/existing_data/manifests/ndhs_ph_2022.json
@@ -1,0 +1,13 @@
+{
+  "id": "ndhs_ph_2022",
+  "source": {
+    "type": "official_survey_reference",
+    "url": "https://dhsprogram.com/data/",
+    "mirror": "https://microdata.worldbank.org/index.php/catalog/5846"
+  },
+  "dimensions_claimed": 13,
+  "format": "dhs_recode",
+  "license": "dhs-program-terms",
+  "gated": true,
+  "notes": "Philippines National Demographic and Health Survey 2022 (PSA + ICF), 35,470 households interviewed. Use the household member recode (PR) file: it covers every member of both sexes at all ages, whereas the women's (IR) file is women 15-49 only and cannot carry a population margin. Download under DHS terms with a free account stating a research purpose, then run persona/curation/existing_data/scripts/crosswalks/ndhs_ph.py via run_pipeline.py --observed-only. This is a sample, not a census: any derived target must be weighted with hv005 (v005 on IR/MR). DHS recode variable names are standardised across surveys, so the crosswalk is written against the standard variables, but confirm the country-specific items (v130 religion, v131 ethnicity) against the PH-2022 codebook. Do not scrape or redistribute the .DTA/.SAV."
+}

--- a/persona/curation/existing_data/manifests/psa_census_puf.json
+++ b/persona/curation/existing_data/manifests/psa_census_puf.json
@@ -1,0 +1,12 @@
+{
+  "id": "psa_census_puf",
+  "source": {
+    "type": "official_population_survey_reference",
+    "url": "https://psada.psa.gov.ph/"
+  },
+  "dimensions_claimed": 20,
+  "format": "data_dictionary_reference",
+  "license": "psa-data-use-agreement",
+  "gated": true,
+  "notes": "Philippine Statistics Authority Census of Population and Housing / FIES / LFS public-use files. Requires a PSA data-use agreement. Map via persona/curation/existing_data/scripts/crosswalks/psa_ph.py. This is the demographic backbone for a Philippine population pool; WVS-PH covers values/attitudes."
+}

--- a/persona/curation/existing_data/manifests/wvs_wave7_philippines.json
+++ b/persona/curation/existing_data/manifests/wvs_wave7_philippines.json
@@ -1,0 +1,12 @@
+{
+  "id": "wvs_wave7_philippines",
+  "source": {
+    "type": "official_survey_reference",
+    "url": "https://www.worldvaluessurvey.org/WVSDocumentationWV7.jsp"
+  },
+  "dimensions_claimed": 153,
+  "format": "questionnaire_reference",
+  "license": "official-survey-terms",
+  "gated": true,
+  "notes": "World Values Survey Wave 7 Philippines subset (B_COUNTRY_ALPHA=PHL / B_COUNTRY=608). Download the official microdata under WVS terms, keep only PH respondents, then run persona/curation/existing_data/scripts/crosswalks/wvs_ph.py via run_pipeline.py --observed-only. Do not scrape or redistribute the .dta/.sav."
+}

--- a/persona/curation/existing_data/philippines/DOWNLOAD_RUNBOOK.md
+++ b/persona/curation/existing_data/philippines/DOWNLOAD_RUNBOOK.md
@@ -1,0 +1,172 @@
+# Philippines microdata: download runbook
+
+Everything downstream of the raw files is built and tested. What is left is the
+part that requires a logged-in human browser: clicking the download on PSADA and
+WVS. This file is the click-path plus the exact commands to run afterwards.
+
+## Why this is not automated
+
+| Route | Result |
+|---|---|
+| `psada.psa.gov.ph` from CLI | **403** on every path, `/home` included — server-side block, not a login redirect |
+| `psa.gov.ph` press releases / PDFs | **403** (WAF blocks non-browser clients on HTML and PDF paths) |
+| `openstat.psa.gov.ph` **API** | **200** — this is how `targets_ph.json` got its census figures |
+| Browser automation from this session | not available — no Chrome/Computer-Use tool is wired in |
+
+So: do the two downloads in the browser you are already logged into. Do not dump
+cookies, do not scrape the portals, do not commit the files.
+
+## Task 1 — PSA (priority)
+
+Logged in at <https://psada.psa.gov.ph/home>. Register: `/auth/register`.
+DPAF (researcher): <https://tinyurl.com/DPAFresearch>.
+
+1. **CPH 2020 person PUF — required.** <https://psada.psa.gov.ph/catalog/231> →
+   **Get Microdata**. Study `PHL-PSA-CPH-2020-v1.0`. Take the **person** file,
+   not household-only, and grab the codebook — you will need it the moment a
+   dimension reports 0% (see below).
+2. **One LFS round that actually has a zip.** Collection:
+   <https://psada.psa.gov.ph/catalog/LFS/about>. Skip months showing `--` in the
+   microdata column. Prefer a recent round with a download icon (older known-good
+   example: April 2016 = `catalog/67`). Person file. Feeds `demo_employment_status`.
+3. **FIES — only if income is needed.** <https://psada.psa.gov.ph/catalog/FIES>.
+   Listed PUFs run through ~2012 and still need login; 2018/2021 usually need a
+   letter + DPAF and often ship CSPro rather than Stata.
+4. **POPCEN 2015 — optional.** <https://psada.psa.gov.ph/catalog/168>. Older
+   vintage; do not substitute it for CPH 2020. The IHSN copy is not a workaround
+   (Data Access Not Available).
+
+Zip icons on collection pages route to `/auth/register`, not to a public file.
+**If a study has no zip after login, stop** — that needs a letter + DPAF
+(<https://psa.gov.ph/how-acquire-data-psa>). Do not try to route around the wall.
+
+Drop whatever you get into `persona/curation/existing_data/raw/psa_ph/`
+(already gitignored, already created).
+
+## Task 2 — WVS Wave 7 Philippines
+
+<https://www.worldvaluessurvey.org/WVSDocumentationWV7.jsp> — account required,
+accept the terms, download by hand.
+
+Either the country file (`WVS_Wave_7_Philippines_Stata_v5.0`, ~1200 × 434) or the
+Wave-7 pooled file. Put it in `raw/wvs_ph/`. The converter handles the country
+filter for you; for a single-country file just drop `--preset wvs` and pass
+`--keep` instead.
+
+## Task 3 — NDHS 2022 (easiest gate, highest value per effort)
+
+<https://dhsprogram.com/data/> — free account, state a research purpose;
+approval is normally quick. Mirror:
+<https://microdata.worldbank.org/index.php/catalog/5846>.
+
+Take the **household member recode (PR)** file, e.g. `PHPR82FL.DTA`. The
+women's (IR) file is women 15-49 only and cannot carry a population margin; the
+PR file covers every household member of both sexes at all ages. Put it in
+`raw/ndhs_ph/`.
+
+This is the source that fills `highest_education` and gives `socioeconomic_band`
+a real anchor (DHS wealth quintile maps 1:1 onto the schema band — both are
+within-country relative measures).
+
+Two limits, both enforced in the crosswalk rather than papered over:
+
+- DHS tops education out at "higher" with no degree detail, so it cannot be
+  split across Some college / Bachelor's / Master's / Doctorate. Those rows stay
+  unobserved, which censors the top of the distribution — **CPH's `HGC` remains
+  the better source for an education margin.** `derive_targets_ph.py` prints the
+  observed-coverage percentage so this is visible, not silent.
+- DHS carries no province or city, so `urbanicity` cannot reach `Suburban` and
+  no HUC upgrade is possible; urban outside NCR becomes `Small town`. `psa_ph.py`
+  *can* reach Suburban. If you ever pool PSA and NDHS rows into one calibration,
+  that difference in observability is real — derive the target from the pooled
+  file, not from either source alone.
+
+NDHS is a **sample**. Always pass `--weight-col hv005` (`v005` on IR/MR) when
+deriving targets from it, or you describe the sample design instead of the
+country.
+
+## Then run this
+
+The converter takes `.dta` / `.sav` / `.csv` / `.zip` / `.gz`, streams in chunks
+so a census-sized file does not blow memory, picks the person file out of a zip,
+and falls back to numeric codes when Stata value labels will not decode (common
+in these releases).
+
+```bash
+# PSA — inspect columns first if you want to eyeball them
+python persona/curation/existing_data/scripts/microdata_to_jsonl.py \
+  --src persona/curation/existing_data/raw/psa_ph/<file>.zip --out /dev/null --columns-only
+
+python persona/curation/existing_data/scripts/microdata_to_jsonl.py \
+  --src persona/curation/existing_data/raw/psa_ph/<file>.zip \
+  --out persona/curation/existing_data/raw/psa_ph/psa_ph.jsonl \
+  --check psa_ph
+
+# WVS — pooled file, filtered to PHL and trimmed to the used columns
+python persona/curation/existing_data/scripts/microdata_to_jsonl.py \
+  --src persona/curation/existing_data/raw/wvs_ph/<file>.dta \
+  --out persona/curation/existing_data/raw/wvs_ph/wvs_ph.jsonl \
+  --preset wvs --check wvs_ph
+```
+
+`--check` prints a per-dimension observed rate. **Read it before running the
+pipeline.** A dimension at 0% almost always means this release names the column
+something the alias table has not seen — a one-line fix in
+`scripts/crosswalks/psa_ph.py`, versus a silent hole in the extraction if you
+skip the check. `--member` picks a specific file out of a zip when the largest
+one is not the person file.
+
+Then the extraction, unchanged from the hand-off:
+
+```bash
+python persona/curation/existing_data/scripts/run_pipeline.py \
+  --source persona/curation/existing_data/raw/psa_ph/psa_ph.jsonl \
+  --dataset persona/curation/existing_data/scripts/crosswalks/psa_ph.py \
+  --schema persona/schema/dimensions.json \
+  --out persona/curation/existing_data/raw/psa_ph/extraction_v1/shard_00.jsonl.gz \
+  --observed-only
+```
+
+Same shape for WVS with `wvs_ph`.
+
+## Then derive the targets that depend on the PUF
+
+`urbanicity` and `highest_education` in `targets_ph.json` are intentionally
+empty — an empty margin is skipped by `calibration.py`, which is the safe state.
+Fill them from the census itself:
+
+```bash
+python persona/curation/existing_data/scripts/derive_targets_ph.py \
+  --source persona/curation/existing_data/raw/psa_ph/psa_ph.jsonl \
+  --dataset persona/curation/existing_data/scripts/crosswalks/psa_ph.py \
+  --dims urbanicity,highest_education \
+  --targets persona/curation/existing_data/philippines/targets_ph.json --write
+```
+
+Drop `--write` first to see what it would change. **Pass `--weight-col` for any
+sampled source** (LFS, FIES, NDHS) — without it you get a target for the sample
+design, not for the Philippines. CPH is a census, so unweighted is correct there.
+
+Why derive rather than hand-write: `rake_weights` divides by the sum of the
+codes you supply while counting *every* observed row in the denominator
+([calibration.py:37-46](../../../post_process/coreset_1m/calibration.py#L37-L46)).
+A target that names three of four urbanicity values silently skews the margin
+instead of failing. Deriving from the same crosswalk that produced the rows
+makes that impossible.
+
+## Still open after the files land
+
+- **`highest_education` in `targets_ph.json` is empty.** Confirmed unavailable
+  from public aggregates: the whole OpenStat tree (199 nodes) was crawled, and
+  the only attainment tables are LFS *employed persons* by highest grade
+  completed (a biased base — excludes students, unemployed, retirees, homemakers)
+  and PhilStat table 10.16, which turns out to publish functional-literacy
+  *rates* within attainment bands, not the attainment distribution. So this needs
+  either the CPH person PUF (`HGC`) or a hand transcription of the PSA
+  educational-attainment release in your browser. Do not calibrate it until then.
+- **`.sav` needs `pip install pyreadstat`** (`.dta` and `.csv` do not).
+
+## Never
+
+Commit `.dta` / `.sav` / `.zip` / PUF CSV, or redistribute any of it. `raw/*` is
+gitignored — verified with `git check-ignore`. Keep it that way.

--- a/persona/curation/existing_data/philippines/persona_strategy.json
+++ b/persona/curation/existing_data/philippines/persona_strategy.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": "1.0",
+  "sources": [],
+  "dimensionFilters": {
+    "region": ["Southeast Asia"],
+    "cult_philippines": ["Native"],
+    "lang_tagalog": ["Native", "Fluent"],
+    "age_bracket": [
+      "18-24",
+      "25-34",
+      "35-44",
+      "45-54",
+      "55-64",
+      "65-74",
+      "75-84",
+      "85+"
+    ],
+    "urbanicity": ["Dense urban", "Suburban", "Small town", "Rural"],
+    "gender_identity": ["Woman", "Man"]
+  },
+  "sampling": {
+    "mode": "stratified",
+    "fields": ["age_bracket", "urbanicity", "gender_identity"],
+    "allocation": "equalTotal",
+    "sampleSize": 256
+  }
+}

--- a/persona/curation/existing_data/philippines/targets_ph.json
+++ b/persona/curation/existing_data/philippines/targets_ph.json
@@ -1,0 +1,78 @@
+{
+  "scope": "philippines_population",
+  "status": "partial",
+  "notes": "Shares are the true population shares for each category, so a dimension only sums to 1.0 when every schema category is identifiable in the source. Where it does not, the remainder is population that PSA cannot place into a schema category (see per-dimension coverage). calibration.py normalizes each margin over the codes actually supplied (rake_weights, calibration.py:22,41-48), so a partial margin calibrates the correct conditional distribution rather than silently skewing. highest_education is still empty and must not be calibrated against — it needs the CPH person PUF.",
+  "base_population": {
+    "household_population_2020": 108667043,
+    "total_population_2020": 109035343,
+    "note": "PSA reports most CPH cross-tabulations on the household population (99.7% of total). Age, sex and religion shares below use the household base; the urban/rural split is published on the total base. The two bases differ by 0.34%, which is below the resolution of these targets."
+  },
+  "sources": {
+    "cph_age_sex": "PSA 2020 Census of Population and Housing, 'Population by Age Group, Sex, Region, and Province/Highly Urbanized City' — OpenStat PX-Web table 0031A6DPAG0.px (DB/1A/PO_2020), retrieved 2026-08-14. Reconciles to the published 108,667,043 household population exactly.",
+    "wpp_single_age": "UN World Population Prospects 2024, WPP2024_PopulationBySingleAgeSex_Medium_1950-2023, Philippines 2020 — used only to split CPH's 5-year bands at the schema boundaries (10-14 -> 10-12/13-14, 15-19 -> 15-17/18-19, 80+ -> 80-84/85+).",
+    "cph_urban_rural": "PSA, 'Urban Population of the Philippines (2020 CPH)': 58.93M urban (54.0%) / 50.10M rural (46.0%).",
+    "cph_religion": "PSA, 'Religious Affiliation in the Philippines (2020 CPH)', 27 Jan 2023. Full denominational table reconciles to 108,667,043 exactly; Roman Catholic 85,645,362 (78.8%), Islam 6,981,710 (6.4%) and Iglesia ni Cristo 2,806,524 (2.6%) match the press release directly."
+  },
+  "dimensions": {
+    "age_bracket": {
+      "weight": 1.0,
+      "quality": "high",
+      "reference": "PSA 2020 CPH 5-year age groups; UN WPP 2024 Philippines for the within-band splits at 13, 18 and 85",
+      "coverage": "complete — brackets reconstruct the full 108,667,043 household population",
+      "shares": {
+        "Under 5": 0.10184,
+        "5-12": 0.16577,
+        "13-17": 0.09772,
+        "18-24": 0.13016,
+        "25-34": 0.15914,
+        "35-44": 0.1258,
+        "45-54": 0.09674,
+        "55-64": 0.06894,
+        "65-74": 0.03652,
+        "75-84": 0.01442,
+        "85+": 0.00294
+      }
+    },
+    "gender_identity": {
+      "weight": 0.5,
+      "quality": "high",
+      "reference": "PSA 2020 CPH sex of household population (55,017,643 male / 53,649,400 female)",
+      "coverage": "Census sex only. Non-binary / Self-described are not enumerable from a census sex item and are deliberately absent rather than set to zero — do not read their absence as a measured share of 0.",
+      "shares": {
+        "Man": 0.5063,
+        "Woman": 0.4937
+      }
+    },
+    "urbanicity": {
+      "weight": 0.5,
+      "quality": "pending_derivation",
+      "reference": "PSA 2020 CPH urban/rural barangay classification; derive from the CPH PUF",
+      "coverage": "DELIBERATELY EMPTY — calibration skips a margin whose shares sum to 0 (calibration.py:40), which is the safe state here. psa_ph.py now emits four values (Dense urban / Suburban / Small town / Rural) using HUC and commuter-belt locality on top of PSA's binary urban flag. A target naming only some of them would NOT be conservative: rake_weights divides by the sum of the codes supplied while counting every observed row in the denominator, so the omitted categories would skew the ones present. The four-way split cannot be built from public aggregates (PSA publishes urban share nationally and by region, not the urban population of each HUC and commuter-belt province), so derive it from the census PUF itself: scripts/derive_targets_ph.py --dims urbanicity.",
+      "shares": {},
+      "reference_only_two_category_split": {
+        "note": "Superseded — kept for provenance. Correct only for the older crosswalk that emitted just these two values, and NOT consumed by calibration.",
+        "Dense urban": 0.12335,
+        "Rural": 0.46
+      }
+    },
+    "highest_education": {
+      "weight": 0.5,
+      "quality": "unset",
+      "reference": "PSA CPH highest grade completed / FLEMMS",
+      "coverage": "BLOCKED — no public aggregate. PSA publishes no educational-attainment table on OpenStat, and psa.gov.ph press-release pages are not machine-retrievable from this environment. Fill from the CPH 2020 person PUF (HGC) once it is on disk, or transcribe the PSA educational-attainment release by hand. Do not calibrate against this dimension until then.",
+      "shares": {}
+    },
+    "demo_religion_affiliation": {
+      "weight": 0.5,
+      "quality": "high",
+      "reference": "PSA 2020 CPH religious affiliation",
+      "coverage": "Christian aggregates Roman Catholic, Evangelical (PCEC), Protestant (NCCP), Iglesia ni Cristo, Seventh-day Adventist, Jehovah's Witnesses, Church of Christ, Jesus Is Lord and Latter-day Saints, matching how psa_ph.py collapses these labels. Folk / traditional is CPH 'Tribal religion' (251,548). The missing 2.24% is 'other religious affiliations' (2.23%) and not-reported (0.01%). No separate Buddhist or Hindu line is published; both fall inside 'other', so they are not set here.",
+      "shares": {
+        "Christian": 0.91061,
+        "Muslim": 0.06425,
+        "Folk / traditional": 0.00231,
+        "None": 0.0004
+      }
+    }
+  }
+}

--- a/persona/curation/existing_data/samples/philippines/ndhs_ph_sample.jsonl
+++ b/persona/curation/existing_data/samples/philippines/ndhs_ph_sample.jsonl
@@ -1,0 +1,3 @@
+{"hhid": "  001  002", "hvidx": 3, "hv105": 41, "hv104": 2, "hv024": "National Capital Region", "hv025": 1, "hv109": 4, "hv270": 5, "hv115": 1, "hv005": 1234567}
+{"caseid": "        1  2  3", "v012": 28, "v151": "female", "v024": "Central Visayas", "v025": "rural", "v149": "higher", "v190": "poorest", "v501": "living together", "v218": 2, "v130": "Roman Catholic", "v131": "Cebuano", "v045c": "Tagalog", "v005": 980000}
+{"hhid": "  004  009", "hvidx": 1, "hv105": 67, "hv104": 1, "hv024": "Calabarzon", "hv025": 1, "hv109": 2, "hv270": 3, "hv115": 3, "hv005": 1010101}

--- a/persona/curation/existing_data/samples/philippines/psa_ph_sample.jsonl
+++ b/persona/curation/existing_data/samples/philippines/psa_ph_sample.jsonl
@@ -1,0 +1,3 @@
+{"id": "psa-ncr-001", "P07_AGE": 41, "P05_SEX": "Female", "RSTR": "NCR", "URBAN": 1, "P12_REL": "Roman Catholic", "P10_MSTAT": 2, "P13_HGC": "College graduate", "MOTHER_TONGUE": "Tagalog", "EMPSTAT": "Employed", "NCHILD": 3}
+{"id": "psa-visayas-001", "AGE": 8, "SEX": 1, "REGION": "Region VII (Central Visayas)", "URB": 2, "RELIGION": "Islam", "MSTAT": 1, "HGC": 3, "MTONGUE": "Cebuano"}
+{"id": "psa-luzon-urban-001", "AGE": 30, "SEX": 2, "REGION": "Region III", "URB": 1, "RELIGION": "Iglesia ni Cristo", "MSTAT": 5, "HGC": "College undergraduate", "MTONGUE": "Kapampangan"}

--- a/persona/curation/existing_data/samples/philippines/wvs_ph_sample.jsonl
+++ b/persona/curation/existing_data/samples/philippines/wvs_ph_sample.jsonl
@@ -1,3 +1,3 @@
-{"id": "PH-0001", "B_COUNTRY_ALPHA": "PHL", "Q262": 38, "Q260": 2, "Q263": 1, "Q266": "Tagalog", "Q290": "Tagalog", "H_URBRURAL": 2, "Q273": 1, "Q274": 2, "Q275": 7, "Q288": 5, "Q279": 1, "Q289": "Roman Catholic", "Q173": 1, "Q164": 10, "Q199": 5, "Q57": 1}
-{"id": "PH-0002", "B_COUNTRY_ALPHA": "PHL", "Q262": 22, "sex": "Male", "Q263": 2, "Q266": "English", "H_URBRURAL": 1, "Q273": 6, "Q274": 0, "Q275": 4, "Q288": 3, "Q279": 6, "Q289": "None", "Q173": 2, "Q199": 5, "Q57": 2}
-{"id": "US-0001", "B_COUNTRY_ALPHA": "USA", "Q262": 40, "Q260": 1, "H_URBRURAL": 1, "Q266": "English"}
+{"id": "PH-0001", "B_COUNTRY_ALPHA": "PHL", "Q262": 38, "Q260": 2, "Q263": 1, "Q266": "Philippines", "Q272": "Filipino; Pilipino", "Q290": "PH: Tagalog", "H_URBRURAL": 2, "Q273": 1, "Q274": 2, "Q275": 7, "Q288": 5, "Q279": 1, "Q289": 1, "Q173": 1, "Q164": 10, "Q199": 5, "Q57": 1}
+{"id": "PH-0002", "B_COUNTRY_ALPHA": "PHL", "Q262": 22, "sex": "Male", "Q263": 2, "Q266": "Philippines", "Q272": "English", "Q290": 608024, "H_URBRURAL": 1, "Q273": 6, "Q274": 0, "Q275": 4, "Q288": 3, "Q279": 6, "Q289": 0, "Q173": 2, "Q199": 5, "Q57": 2}
+{"id": "US-0001", "B_COUNTRY_ALPHA": "USA", "Q262": 40, "Q260": 1, "H_URBRURAL": 1, "Q272": "English"}

--- a/persona/curation/existing_data/samples/philippines/wvs_ph_sample.jsonl
+++ b/persona/curation/existing_data/samples/philippines/wvs_ph_sample.jsonl
@@ -1,0 +1,3 @@
+{"id": "PH-0001", "B_COUNTRY_ALPHA": "PHL", "Q262": 38, "Q260": 2, "Q263": 1, "Q266": "Tagalog", "Q290": "Tagalog", "H_URBRURAL": 2, "Q273": 1, "Q274": 2, "Q275": 7, "Q288": 5, "Q279": 1, "Q289": "Roman Catholic", "Q173": 1, "Q164": 10, "Q199": 5, "Q57": 1}
+{"id": "PH-0002", "B_COUNTRY_ALPHA": "PHL", "Q262": 22, "sex": "Male", "Q263": 2, "Q266": "English", "H_URBRURAL": 1, "Q273": 6, "Q274": 0, "Q275": 4, "Q288": 3, "Q279": 6, "Q289": "None", "Q173": 2, "Q199": 5, "Q57": 2}
+{"id": "US-0001", "B_COUNTRY_ALPHA": "USA", "Q262": 40, "Q260": 1, "H_URBRURAL": 1, "Q266": "English"}

--- a/persona/curation/existing_data/scripts/crosswalk_engine.py
+++ b/persona/curation/existing_data/scripts/crosswalk_engine.py
@@ -55,6 +55,33 @@ def _isna(v):
         return False
 
 
+def _lookup_keys(raw):
+    """Candidate map keys for a raw source value, most literal first.
+
+    pandas widens any integer column containing a missing value to float, so a
+    survey code of 2 arrives as 2.0 and stringifies to "2.0" — which silently
+    misses a map keyed on "2". That is a data-loss bug, not a crosswalk typo:
+    it hits exactly the columns that have non-response.
+
+    The literal form is still tried first so maps that were written against
+    float-formatted values (gss.py keys its child counts "0.0", "1.0", …) keep
+    working unchanged.
+    """
+    literal = str(raw).strip().lower()
+    keys = [literal]
+    if isinstance(raw, bool):
+        return keys
+    try:
+        as_float = float(raw)
+    except (TypeError, ValueError):
+        return keys
+    if as_float == int(as_float):
+        collapsed = str(int(as_float))
+        if collapsed != literal:
+            keys.append(collapsed)
+    return keys
+
+
 def apply_crosswalk(row, crosswalk, allowed):
     """Map one source ``row`` (any object with ``.get``) via ``crosswalk``.
 
@@ -77,8 +104,11 @@ def apply_crosswalk(row, crosswalk, allowed):
             if _isna(raw):
                 continue
             mapping = rule["map"]
-            key = str(raw).strip().lower()
-            target = mapping(key) if callable(mapping) else mapping.get(key, _MISS)
+            target = _MISS
+            for key in _lookup_keys(raw):
+                target = mapping(key) if callable(mapping) else mapping.get(key, _MISS)
+                if target is not _MISS:
+                    break
             if target is _MISS:
                 unmapped[dim_id] = raw
                 continue
@@ -130,6 +160,31 @@ def _selftest():
     # a source value with no map entry is recorded as unmapped, left null
     _, _, um = apply_crosswalk({"sex": "genderqueer"}, crosswalk, allowed)
     assert um == {"gender_identity": "genderqueer"}, um
+
+    # pandas widens an int column to float as soon as it holds one missing
+    # value, so a survey code of 2 arrives as 2.0. That must still hit a map
+    # keyed on "2" — otherwise every column with non-response silently drops.
+    codes = {
+        "gender_identity": {
+            "src": "sex",
+            "map": {"1": "Man", "2": "Woman"},
+            "prov": "observed",
+        }
+    }
+    for raw in (2, 2.0, "2", "2.0"):
+        obs, _, um = apply_crosswalk({"sex": raw}, codes, allowed)
+        assert obs.get("gender_identity") == "Woman", (raw, obs, um)
+    # maps written against float-formatted values keep working unchanged
+    floats = {
+        "gender_identity": {
+            "src": "sex",
+            "map": {"2.0": "Woman"},
+            "prov": "observed",
+        }
+    }
+    assert apply_crosswalk({"sex": 2.0}, floats, allowed)[0]["gender_identity"] == "Woman"
+    # a genuine non-integer must not be collapsed onto an integer key
+    assert apply_crosswalk({"sex": 2.5}, codes, allowed)[2] == {"gender_identity": 2.5}
 
     # off-schema mapped value must raise
     bad = {

--- a/persona/curation/existing_data/scripts/crosswalks/ndhs_ph.py
+++ b/persona/curation/existing_data/scripts/crosswalks/ndhs_ph.py
@@ -1,0 +1,512 @@
+#!/usr/bin/env python3
+"""Crosswalk: Philippines NDHS 2022 (DHS recode) → observed 1290-dim fields.
+
+Obtain the file yourself under DHS terms (free account, state a research
+purpose): https://dhsprogram.com/data/ — the Philippines 2022 standard DHS.
+A mirror exists at https://microdata.worldbank.org/index.php/catalog/5846.
+
+Prefer the **household member recode (PR)** file. The women's (IR) file is
+women 15-49 only, so it cannot carry a population margin; the PR file covers
+every household member of both sexes at all ages, which is what makes NDHS
+usable for `highest_education` and `socioeconomic_band` targets.
+
+DHS recode names are standardised across every DHS survey worldwide, so this
+module is written against the standard variables and accepts both the PR
+(``hv*``) and IR/MR (``v*``) spellings. Confirm against the PH-2022 codebook on
+arrival — the country-specific items (religion ``v130``, ethnicity ``v131``)
+carry per-country code lists, so those are matched on decoded labels only and
+never on raw numbers.
+
+    python persona/curation/existing_data/scripts/microdata_to_jsonl.py \\
+      --src persona/curation/existing_data/raw/ndhs_ph/PHPR82FL.DTA \\
+      --out persona/curation/existing_data/raw/ndhs_ph/ndhs_ph.jsonl \\
+      --check ndhs_ph
+
+    python persona/curation/existing_data/scripts/run_pipeline.py \\
+      --source persona/curation/existing_data/raw/ndhs_ph/ndhs_ph.jsonl \\
+      --dataset persona/curation/existing_data/scripts/crosswalks/ndhs_ph.py \\
+      --schema persona/schema/dimensions.json \\
+      --out persona/curation/existing_data/raw/ndhs_ph/extraction_v1/shard_00.jsonl.gz \\
+      --observed-only
+
+NDHS is a **sample**, not a census. Any target derived from it must be
+weighted, or it describes the sample design rather than the Philippines:
+
+    python persona/curation/existing_data/scripts/derive_targets_ph.py ... \\
+      --weight-col hv005      # v005 on the IR/MR file
+
+Two deliberate gaps, both documented at their mapping below: DHS tops education
+out at "higher" with no degree detail, and it carries no province/city, so
+urbanicity cannot reach Suburban the way ``psa_ph.py`` does. Run
+``python crosswalks/ndhs_ph.py --selftest``.
+"""
+
+from __future__ import annotations
+
+NCR_TOKENS = {
+    "ncr",
+    "national capital region",
+    "metro manila",
+    "metropolitan manila",
+    "manila",
+}
+
+# DHS reserves the top of each numeric range for "don't know" / missing. On
+# hv105 that is 98/99 against a real range of 0-95, so an unguarded cast turns
+# a refusal into a 98-year-old.
+DHS_MISSING_AGE = 96
+
+TAGALOG_HOME = {
+    "tagalog",
+    "filipino",
+    "pilipino",
+    "filipino/tagalog",
+    "tagalog/filipino",
+}
+
+CHRISTIAN_RELIGION = {
+    "roman catholic",
+    "catholic",
+    "protestant",
+    "iglesia ni cristo",
+    "inc",
+    "aglipay",
+    "aglipayan",
+    "philippine independent church",
+    "iglesia filipina independiente",
+    "born again",
+    "evangelical",
+    "baptist",
+    "methodist",
+    "seventh day adventist",
+    "seventh-day adventist",
+    "jehovah's witness",
+    "jehovahs witness",
+    "christian",
+    "other christian",
+}
+
+SEA_ETHNICITY = {
+    "tagalog",
+    "cebuano",
+    "bisaya",
+    "binisaya",
+    "ilocano",
+    "ilokano",
+    "hiligaynon",
+    "ilonggo",
+    "bicol",
+    "bikol",
+    "bicolano",
+    "waray",
+    "kapampangan",
+    "pampango",
+    "pangasinan",
+    "pangasinense",
+    "maranao",
+    "maguindanao",
+    "tausug",
+    "boholano",
+    "ibanag",
+    "zamboangueno",
+    "filipino",
+}
+
+
+def _token(row, *keys):
+    for key in keys:
+        v = row.get(key)
+        if v is None:
+            continue
+        try:
+            if v != v:
+                continue
+        except (TypeError, ValueError):
+            pass
+        if isinstance(v, bool):
+            return str(v).lower()
+        if isinstance(v, float) and v == int(v):
+            return str(int(v))
+        if isinstance(v, int):
+            return str(v)
+        s = str(v).strip().lower()
+        if s and s not in {"nan", "none", "null", ""}:
+            return s
+    return None
+
+
+def _alias_src_fields(row):
+    out = dict(row)
+    aliases = {
+        # PR (household member) first, then IR/MR, then upper-case variants.
+        "AGE": ("hv105", "HV105", "v012", "V012", "age"),
+        "SEX": ("hv104", "HV104", "v151", "V151", "sex"),
+        "URBAN": ("hv025", "HV025", "v025", "V025"),
+        "REGION": ("hv024", "HV024", "v024", "V024", "region"),
+        # hv109/v149 are the harmonised attainment items and are strictly more
+        # informative than the hv106/v106 level items, so they win.
+        "EDUC": ("hv109", "HV109", "v149", "V149", "hv106", "HV106", "v106", "V106"),
+        "WEALTH": ("hv270", "HV270", "v190", "V190"),
+        "MSTAT": ("hv115", "HV115", "v501", "V501"),
+        "CHILDREN": ("v218", "V218"),
+        "RELIGION": ("v130", "V130", "sh_religion", "religion"),
+        "ETHNICITY": ("v131", "V131", "ethnicity"),
+        "LANGUAGE": ("v045c", "V045C", "v045b", "V045B", "language"),
+        "WEIGHT": ("hv005", "HV005", "v005", "V005"),
+    }
+    for dest, sources in aliases.items():
+        if out.get(dest) is not None:
+            continue
+        for src in sources:
+            if out.get(src) is not None:
+                out[dest] = out[src]
+                break
+    return out
+
+
+def flatten(row):
+    out = _alias_src_fields(row)
+    uid = row.get("user_id") or row.get("caseid") or row.get("CASEID")
+    if uid is None:
+        # PR rows are identified by household id + line number, not one column.
+        hh = row.get("hhid") or row.get("HHID")
+        line = row.get("hvidx") or row.get("HVIDX")
+        if hh is not None and line is not None:
+            uid = f"{str(hh).strip()}-{line}"
+    if uid is not None:
+        out["user_id"] = str(uid)
+    return out
+
+
+def render(row):
+    bits = ["Philippines NDHS 2022 household member"]
+    age = _token(row, "AGE")
+    if age:
+        bits.append(f"age {age}")
+    sex = _token(row, "SEX")
+    if sex:
+        bits.append(str(sex))
+    region = _token(row, "REGION")
+    if region:
+        bits.append(f"region {region}")
+    return ", ".join(bits) + "."
+
+
+def _age_bracket(row):
+    raw = row.get("AGE")
+    if raw is None:
+        return None
+    try:
+        if raw != raw:
+            return None
+        age = float(raw)
+    except (TypeError, ValueError):
+        return None
+    # 96-99 are DHS don't-know / missing codes, not ages.
+    if age < 0 or age >= DHS_MISSING_AGE:
+        return None
+    if age < 5:
+        return "Under 5"
+    if age <= 12:
+        return "5-12"
+    if age <= 17:
+        return "13-17"
+    for lo, hi, lab in (
+        (18, 24, "18-24"),
+        (25, 34, "25-34"),
+        (35, 44, "35-44"),
+        (45, 54, "45-54"),
+        (55, 64, "55-64"),
+        (65, 74, "65-74"),
+        (75, 84, "75-84"),
+    ):
+        if lo <= age <= hi:
+            return lab
+    return "85+"
+
+
+def _region(_row):
+    return "Southeast Asia"
+
+
+def _cult_philippines(_row):
+    return "Native"
+
+
+def _is_ncr(row):
+    token = _token(row, "REGION")
+    return token in NCR_TOKENS if token else False
+
+
+def _urbanicity(row):
+    if _is_ncr(row):
+        return "Dense urban"
+    urb = _token(row, "URBAN")
+    if urb in {"2", "rural"}:
+        return "Rural"
+    if urb in {"1", "urban"}:
+        # Unlike psa_ph.py there is no province/city column here, so the HUC and
+        # commuter-belt rules cannot run and Suburban is unreachable from DHS.
+        return "Small town"
+    return None
+
+
+def _education(row):
+    token = _token(row, "EDUC")
+    if token is None:
+        return None
+    labeled = {
+        "no education": "No formal",
+        "no education, preschool": "No formal",
+        "none": "No formal",
+        "preschool": "No formal",
+        "incomplete primary": "Primary",
+        "complete primary": "Primary",
+        "primary": "Primary",
+        "elementary": "Primary",
+        "incomplete secondary": "Secondary",
+        "complete secondary": "Secondary",
+        "secondary": "Secondary",
+        "high school": "Secondary",
+    }
+    if token in labeled:
+        return labeled[token]
+    # DHS "higher" means any post-secondary and carries no degree detail, so it
+    # cannot be split across Some college / Bachelor's / Master's / Doctorate.
+    # Left unobserved rather than collapsed onto one of them — but note this
+    # censors the top of the distribution, so CPH's HGC remains the better
+    # source for a highest_education margin.
+    if token in {"higher", "tertiary", "college", "university"}:
+        return None
+    try:
+        n = int(float(token))
+    except (TypeError, ValueError):
+        return None
+    # hv109 / v149: 0 none, 1 incomplete primary, 2 complete primary,
+    # 3 incomplete secondary, 4 complete secondary, 5 higher, 8/9 dk/missing.
+    return {0: "No formal", 1: "Primary", 2: "Primary", 3: "Secondary", 4: "Secondary"}.get(n)
+
+
+def _socioeconomic_band(row):
+    token = _token(row, "WEALTH")
+    if token is None:
+        return None
+    # DHS wealth index is a within-country relative quintile and the schema band
+    # is likewise relative, so this is a direct 1:1.
+    return {
+        "1": "Low income",
+        "poorest": "Low income",
+        "2": "Lower-middle",
+        "poorer": "Lower-middle",
+        "3": "Middle",
+        "middle": "Middle",
+        "4": "Upper-middle",
+        "richer": "Upper-middle",
+        "5": "High income",
+        "richest": "High income",
+    }.get(token)
+
+
+def _children(row):
+    raw = row.get("CHILDREN")
+    if raw is None:
+        return None
+    try:
+        if raw != raw:
+            return None
+        n = int(float(raw))
+    except (TypeError, ValueError):
+        return None
+    if n < 0:
+        return None
+    if n == 0:
+        return "None"
+    if n == 1:
+        return "1 child"
+    if n == 2:
+        return "2 children"
+    return "3+ children"
+
+
+def _religion(row):
+    token = _token(row, "RELIGION")
+    if token is None:
+        return None
+    # v130 codes are country-specific, so only decoded labels are trusted here.
+    if token.isdigit():
+        return None
+    if token in {"no religion", "none", "atheist"}:
+        return "None"
+    if token in {"islam", "muslim"}:
+        return "Muslim"
+    if token in {"buddhist", "buddhism"}:
+        return "Buddhist"
+    if token in {"hindu", "hinduism"}:
+        return "Hindu"
+    if "tribal" in token or token in {"animist", "indigenous"}:
+        return "Folk / traditional"
+    if token in CHRISTIAN_RELIGION or "catholic" in token or "christian" in token:
+        return "Christian"
+    return None
+
+
+def _ethnicity(row):
+    token = _token(row, "ETHNICITY")
+    if token is None or token.isdigit():
+        return None
+    if "chinese" in token:
+        return "East Asian"
+    return "Southeast Asian" if token in SEA_ETHNICITY else None
+
+
+def _lang_tagalog(row):
+    return "Native" if _token(row, "LANGUAGE") in TAGALOG_HOME else None
+
+
+def _english_proficiency(row):
+    return "Native" if _token(row, "LANGUAGE") == "english" else None
+
+
+CROSSWALK = {
+    "age_bracket": {"compute": _age_bracket, "prov": "observed"},
+    "gender_identity": {
+        "src": "SEX",
+        "map": {"1": "Man", "male": "Man", "2": "Woman", "female": "Woman"},
+        "prov": "observed",
+    },
+    "region": {"compute": _region, "prov": "observed"},
+    "cult_philippines": {"compute": _cult_philippines, "prov": "observed"},
+    "urbanicity": {"compute": _urbanicity, "prov": "observed"},
+    "highest_education": {"compute": _education, "prov": "observed"},
+    "socioeconomic_band": {"compute": _socioeconomic_band, "prov": "observed"},
+    "demo_marital_status": {
+        "src": "MSTAT",
+        "map": {
+            "0": "Single",
+            "never married": "Single",
+            "never in union": "Single",
+            "1": "Married",
+            "married": "Married",
+            "2": "Domestic partnership",
+            "living together": "Domestic partnership",
+            "living with partner": "Domestic partnership",
+            "3": "Widowed",
+            "widowed": "Widowed",
+            "4": "Divorced",
+            "divorced": "Divorced",
+            "5": "Separated",
+            "separated": "Separated",
+            "no longer living together/separated": "Separated",
+        },
+        "prov": "observed",
+    },
+    "demo_children_count": {"compute": _children, "prov": "observed"},
+    "demo_religion_affiliation": {"compute": _religion, "prov": "observed"},
+    "demo_ethnicity_broad": {"compute": _ethnicity, "prov": "observed"},
+    "lang_tagalog": {"compute": _lang_tagalog, "prov": "observed"},
+    "english_proficiency": {"compute": _english_proficiency, "prov": "observed"},
+}
+
+
+def _selftest():
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from crosswalk_engine import apply_crosswalk, load_allowed
+
+    schema = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "schema", "dimensions.json")
+    )
+    allowed = load_allowed(schema)
+
+    # PR file, numeric codes (convert_categoricals=False)
+    pr = flatten(
+        {
+            "hhid": "  001  002",
+            "hvidx": 3,
+            "hv105": 41,
+            "hv104": 2,
+            "hv024": "National Capital Region",
+            "hv025": 1,
+            "hv109": 4,
+            "hv270": 5,
+            "hv115": 1,
+            "hv005": 1_234_567,
+        }
+    )
+    obs, prov, unmapped = apply_crosswalk(pr, CROSSWALK, allowed)
+    assert obs["age_bracket"] == "35-44", obs
+    assert obs["gender_identity"] == "Woman"
+    assert obs["region"] == "Southeast Asia"
+    assert obs["cult_philippines"] == "Native"
+    assert obs["urbanicity"] == "Dense urban"  # NCR
+    assert obs["highest_education"] == "Secondary"
+    assert obs["socioeconomic_band"] == "High income"
+    assert obs["demo_marital_status"] == "Married"
+    assert unmapped == {}
+    assert all(p == "observed" for p in prov.values())
+    assert pr["user_id"] == "001  002-3"
+
+    # IR file, decoded labels
+    ir = flatten(
+        {
+            "caseid": "        1  2  3",
+            "v012": 28,
+            "v151": "female",
+            "v024": "Central Visayas",
+            "v025": "rural",
+            "v149": "higher",
+            "v190": "poorest",
+            "v501": "living together",
+            "v218": 2,
+            "v130": "Roman Catholic",
+            "v131": "Cebuano",
+            "v045c": "Tagalog",
+        }
+    )
+    obs2, _, _ = apply_crosswalk(ir, CROSSWALK, allowed)
+    assert obs2["age_bracket"] == "25-34"
+    assert obs2["urbanicity"] == "Rural"
+    assert obs2["socioeconomic_band"] == "Low income"
+    assert obs2["demo_marital_status"] == "Domestic partnership"
+    assert obs2["demo_children_count"] == "2 children"
+    assert obs2["demo_religion_affiliation"] == "Christian"
+    assert obs2["demo_ethnicity_broad"] == "Southeast Asian"
+    assert obs2["lang_tagalog"] == "Native"
+    # "higher" carries no degree detail, so it must not be guessed
+    assert "highest_education" not in obs2
+
+    # DHS missing/DK codes must not become ages or categories
+    dk = flatten({"hv105": 98, "hv104": 9, "hv025": 9, "hv109": 8, "hv270": 9})
+    obs3, _, _ = apply_crosswalk(dk, CROSSWALK, allowed)
+    assert "age_bracket" not in obs3, obs3
+    assert "gender_identity" not in obs3
+    assert "urbanicity" not in obs3
+    assert "highest_education" not in obs3
+    assert "socioeconomic_band" not in obs3
+
+    # country-specific numeric codes must never be read as labels
+    numeric = flatten({"hv105": 30, "v130": 1, "v131": 2})
+    obs4, _, _ = apply_crosswalk(numeric, CROSSWALK, allowed)
+    assert "demo_religion_affiliation" not in obs4
+    assert "demo_ethnicity_broad" not in obs4
+
+    # urban outside NCR is Small town; Suburban is unreachable from DHS
+    urban = flatten({"hv105": 30, "hv024": "Calabarzon", "hv025": 1})
+    obs5, _, _ = apply_crosswalk(urban, CROSSWALK, allowed)
+    assert obs5["urbanicity"] == "Small town"
+
+    print(f"ndhs_ph crosswalk self-test: {len(CROSSWALK)} dims verified ✅")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    ap = argparse.ArgumentParser(description="Philippines NDHS 2022 (DHS recode) crosswalk.")
+    ap.add_argument("--selftest", action="store_true")
+    args = ap.parse_args()
+    if args.selftest:
+        _selftest()
+    else:
+        ap.print_help()

--- a/persona/curation/existing_data/scripts/crosswalks/ndhs_ph.py
+++ b/persona/curation/existing_data/scripts/crosswalks/ndhs_ph.py
@@ -11,11 +11,31 @@ every household member of both sexes at all ages, which is what makes NDHS
 usable for `highest_education` and `socioeconomic_band` targets.
 
 DHS recode names are standardised across every DHS survey worldwide, so this
-module is written against the standard variables and accepts both the PR
-(``hv*``) and IR/MR (``v*``) spellings. Confirm against the PH-2022 codebook on
-arrival — the country-specific items (religion ``v130``, ethnicity ``v131``)
-carry per-country code lists, so those are matched on decoded labels only and
-never on raw numbers.
+module accepts both the PR (``hv*``) and IR/MR (``v*``) spellings. The
+country-specific code lists here were **verified against the PH-2022 DDI
+codebook** (``PHL_2022_DHS_v01_M.xml``), which is why ``v130`` religion,
+``v131`` ethnicity and ``v045c`` language are mapped from raw numbers at all.
+Do not copy those numeric maps to another country's DHS — they are per-survey.
+
+Two things that verification changed, both easy to get wrong:
+
+* ``hv115`` and ``v501`` do **not** share a code list. In PH-2022 ``hv115`` has
+  no code 5 and its code 4 is "Divorced/annulled/separated" — a combined
+  category. Divorce is not available in the Philippines, so that maps to
+  Separated, whereas ``v501`` code 4 is a clean "Divorced".
+* ``v045c`` is the respondent's *native* language; ``v045b`` is the language the
+  interview happened to be conducted in. Only the former is read here.
+
+**If you have the raw REC distribution rather than the merged PR recode**, the
+fields this module needs are spread across files and must be joined first:
+
+    RECH1  (129,724 members)  hvidx hv104 hv105 hv106 hv109 hv115
+    RECH0  (35,470 households) hv024 hv025 hv005
+    RECH2                      hv270
+
+Join RECH1 to RECH0 and RECH2 on ``hhid`` before converting, or region,
+urbanicity, wealth and the sample weight will all be missing. The standard
+``PHPR*FL.DTA`` recode already has them merged and needs no join.
 
     python persona/curation/existing_data/scripts/microdata_to_jsonl.py \\
       --src persona/curation/existing_data/raw/ndhs_ph/PHPR82FL.DTA \\
@@ -43,12 +63,15 @@ urbanicity cannot reach Suburban the way ``psa_ph.py`` does. Run
 
 from __future__ import annotations
 
+# hv024/v024 in PH-2022: 13 = National Capital Region (verified against the
+# PHL_2022_DHS_v01_M DDI codebook). Without the numeric code, a file read with
+# convert_categoricals=False would never resolve NCR at all.
 NCR_TOKENS = {
     "ncr",
+    "13",
     "national capital region",
     "metro manila",
     "metropolitan manila",
-    "manila",
 }
 
 # DHS reserves the top of each numeric range for "don't know" / missing. On
@@ -147,11 +170,16 @@ def _alias_src_fields(row):
         # informative than the hv106/v106 level items, so they win.
         "EDUC": ("hv109", "HV109", "v149", "V149", "hv106", "HV106", "v106", "V106"),
         "WEALTH": ("hv270", "HV270", "v190", "V190"),
-        "MSTAT": ("hv115", "HV115", "v501", "V501"),
+        # hv115 and v501 do NOT share a code list — see _marital.
+        "MSTAT_HH": ("hv115", "HV115"),
+        "MSTAT_IND": ("v501", "V501"),
         "CHILDREN": ("v218", "V218"),
         "RELIGION": ("v130", "V130", "sh_religion", "religion"),
         "ETHNICITY": ("v131", "V131", "ethnicity"),
-        "LANGUAGE": ("v045c", "V045C", "v045b", "V045B", "language"),
+        # v045c is the respondent's *native* language. v045b is the language the
+        # interview happened to be conducted in, which is not the same thing and
+        # must not stand in for it.
+        "LANGUAGE": ("v045c", "V045C", "language"),
         "WEIGHT": ("hv005", "HV005", "v005", "V005"),
     }
     for dest, sources in aliases.items():
@@ -328,13 +356,77 @@ def _children(row):
     return "3+ children"
 
 
+def _marital(row):
+    """hv115 and v501 use different code lists — do not merge them.
+
+    PH-2022 hv115: 0 never married, 1 married or living together, 2 living
+    together, 3 widowed, 4 divorced/annulled/separated. There is no code 5, and
+    code 4 is a *combined* category. Divorce is not available in the
+    Philippines, so that group is overwhelmingly annulled or separated and maps
+    to Separated — reading it as Divorced (the standard DHS meaning of 4) would
+    be wrong for this country.
+
+    v501 is the regular recode: 4 divorced, 5 no longer living together.
+    """
+    household = _token(row, "MSTAT_HH")
+    if household is not None:
+        return {
+            "0": "Single",
+            "never married": "Single",
+            "1": "Married",
+            "married or living together": "Married",
+            "married": "Married",
+            "2": "Domestic partnership",
+            "living together": "Domestic partnership",
+            "3": "Widowed",
+            "widowed": "Widowed",
+            "4": "Separated",
+            "divorced/annulled/separated": "Separated",
+        }.get(household)
+    individual = _token(row, "MSTAT_IND")
+    if individual is None:
+        return None
+    return {
+        "0": "Single",
+        "never in union": "Single",
+        "never married": "Single",
+        "1": "Married",
+        "married": "Married",
+        "2": "Domestic partnership",
+        "living with partner": "Domestic partnership",
+        "living together": "Domestic partnership",
+        "3": "Widowed",
+        "widowed": "Widowed",
+        "4": "Divorced",
+        "divorced": "Divorced",
+        "5": "Separated",
+        "separated": "Separated",
+        "no longer living together/separated": "Separated",
+    }.get(individual)
+
+
+# PH-2022 v130 (verified against the DDI codebook): 1 Roman Catholic,
+# 2 Protestant, 3 Iglesia ni Cristo, 4 Aglipay, 5 Islam, 6 Other Christian,
+# 95 No religion, 96 Other. Numeric codes are safe *because* they were checked
+# against this survey; do not copy this map to another country's DHS.
+V130_NUMERIC = {
+    "1": "Christian",
+    "2": "Christian",
+    "3": "Christian",
+    "4": "Christian",
+    "5": "Muslim",
+    "6": "Christian",
+    "95": "None",
+}
+
+
 def _religion(row):
     token = _token(row, "RELIGION")
     if token is None:
         return None
-    # v130 codes are country-specific, so only decoded labels are trusted here.
     if token.isdigit():
-        return None
+        # 96 "Other" is intentionally absent: it cannot be placed in the schema.
+        return V130_NUMERIC.get(token)
     if token in {"no religion", "none", "atheist"}:
         return "None"
     if token in {"islam", "muslim"}:
@@ -352,19 +444,34 @@ def _religion(row):
 
 def _ethnicity(row):
     token = _token(row, "ETHNICITY")
-    if token is None or token.isdigit():
+    if token is None:
         return None
+    if token.isdigit():
+        # PH-2022 v131: codes 1-87 are Filipino ethnolinguistic groups;
+        # 88 "Other Nationality" and 96 "Other" are not placeable.
+        n = int(token)
+        return "Southeast Asian" if 1 <= n <= 87 else None
     if "chinese" in token:
         return "East Asian"
+    if token in {"other", "other nationality"}:
+        return None
     return "Southeast Asian" if token in SEA_ETHNICITY else None
 
 
+# PH-2022 v045c native language: 1 English, 2 Tagalog, 3 Ilocano, 4 Bikol,
+# 5 Waray, 6 Hiligaynon, 7 Cebuano, 96 Other.
 def _lang_tagalog(row):
-    return "Native" if _token(row, "LANGUAGE") in TAGALOG_HOME else None
+    token = _token(row, "LANGUAGE")
+    if token is None:
+        return None
+    return "Native" if token == "2" or token in TAGALOG_HOME else None
 
 
 def _english_proficiency(row):
-    return "Native" if _token(row, "LANGUAGE") == "english" else None
+    token = _token(row, "LANGUAGE")
+    if token is None:
+        return None
+    return "Native" if token in {"1", "english"} else None
 
 
 CROSSWALK = {
@@ -379,27 +486,7 @@ CROSSWALK = {
     "urbanicity": {"compute": _urbanicity, "prov": "observed"},
     "highest_education": {"compute": _education, "prov": "observed"},
     "socioeconomic_band": {"compute": _socioeconomic_band, "prov": "observed"},
-    "demo_marital_status": {
-        "src": "MSTAT",
-        "map": {
-            "0": "Single",
-            "never married": "Single",
-            "never in union": "Single",
-            "1": "Married",
-            "married": "Married",
-            "2": "Domestic partnership",
-            "living together": "Domestic partnership",
-            "living with partner": "Domestic partnership",
-            "3": "Widowed",
-            "widowed": "Widowed",
-            "4": "Divorced",
-            "divorced": "Divorced",
-            "5": "Separated",
-            "separated": "Separated",
-            "no longer living together/separated": "Separated",
-        },
-        "prov": "observed",
-    },
+    "demo_marital_status": {"compute": _marital, "prov": "observed"},
     "demo_children_count": {"compute": _children, "prov": "observed"},
     "demo_religion_affiliation": {"compute": _religion, "prov": "observed"},
     "demo_ethnicity_broad": {"compute": _ethnicity, "prov": "observed"},
@@ -486,11 +573,29 @@ def _selftest():
     assert "highest_education" not in obs3
     assert "socioeconomic_band" not in obs3
 
-    # country-specific numeric codes must never be read as labels
-    numeric = flatten({"hv105": 30, "v130": 1, "v131": 2})
+    # PH-2022 numeric code lists, verified against the DDI codebook
+    numeric = flatten({"hv105": 30, "hv024": 13, "hv025": 1, "v130": 5, "v131": 2, "v045c": 2})
     obs4, _, _ = apply_crosswalk(numeric, CROSSWALK, allowed)
-    assert "demo_religion_affiliation" not in obs4
-    assert "demo_ethnicity_broad" not in obs4
+    assert obs4["demo_religion_affiliation"] == "Muslim", obs4  # v130 5 = Islam
+    assert obs4["demo_ethnicity_broad"] == "Southeast Asian"  # v131 2 = Cebuano
+    assert obs4["lang_tagalog"] == "Native"  # v045c 2 = Tagalog
+    assert obs4["urbanicity"] == "Dense urban"  # hv024 13 = NCR
+    # codes that cannot be placed in the schema stay unobserved
+    unplaceable = flatten({"hv105": 30, "v130": 96, "v131": 88})
+    obs5, _, _ = apply_crosswalk(unplaceable, CROSSWALK, allowed)
+    assert "demo_religion_affiliation" not in obs5
+    assert "demo_ethnicity_broad" not in obs5
+
+    # hv115 and v501 disagree on what 4 means; PH has no legal divorce
+    hh4 = flatten({"hv105": 40, "hv115": 4})
+    assert apply_crosswalk(hh4, CROSSWALK, allowed)[0]["demo_marital_status"] == "Separated"
+    ind4 = flatten({"v012": 40, "v501": 4})
+    assert apply_crosswalk(ind4, CROSSWALK, allowed)[0]["demo_marital_status"] == "Divorced"
+    ind5 = flatten({"v012": 40, "v501": 5})
+    assert apply_crosswalk(ind5, CROSSWALK, allowed)[0]["demo_marital_status"] == "Separated"
+    # interview language must not be read as native language
+    interview_only = flatten({"hv105": 30, "v045b": 2})
+    assert "lang_tagalog" not in apply_crosswalk(interview_only, CROSSWALK, allowed)[0]
 
     # urban outside NCR is Small town; Suburban is unreachable from DHS
     urban = flatten({"hv105": 30, "hv024": "Calabarzon", "hv025": 1})

--- a/persona/curation/existing_data/scripts/crosswalks/psa_ph.py
+++ b/persona/curation/existing_data/scripts/crosswalks/psa_ph.py
@@ -1,0 +1,635 @@
+#!/usr/bin/env python3
+"""Crosswalk: PSA Census / FIES / LFS public-use files → observed 1290-dim fields.
+
+Requires a PSA data-use agreement (https://psada.psa.gov.ph/). Flatten your PUF
+to JSONL with one person per row, then:
+
+    python persona/curation/existing_data/scripts/run_pipeline.py \\
+      --source psa_ph.jsonl \\
+      --dataset persona/curation/existing_data/scripts/crosswalks/psa_ph.py \\
+      --schema persona/schema/dimensions.json \\
+      --out persona/curation/existing_data/raw/psa_ph/extraction_v1/shard_00.jsonl.gz \\
+      --observed-only
+
+Column names vary across CPH 2015/2020 and FIES releases. ``flatten()`` copies
+common aliases (AGE/P07_AGE, SEX/P05_SEX, URB/URBAN_RURAL, …) onto canonical
+keys.
+
+Urbanicity uses locality on top of PSA's binary urban flag: NCR and the
+highly urbanized cities map to Dense urban, the Metro Manila commuter belt
+(Bulacan / Rizal / Cavite / Laguna) to Suburban, other urban barangays to
+Small town, and rural to Rural. Without a province/city column the HUC and
+commuter-belt rules cannot fire and urban outside NCR degrades to Small town.
+
+NOTE: this emits four urbanicity values, so any calibration target for
+``urbanicity`` must list all four. ``rake_weights`` divides by the sum of the
+codes you supply while counting every observed row in the denominator, so a
+target naming only a subset silently skews the margin. Derive the target from
+the PUF itself with ``scripts/derive_targets_ph.py``.
+
+This is the demographic backbone. Pair with ``wvs_ph.py`` for values/attitudes.
+Run ``python crosswalks/psa_ph.py --selftest``.
+"""
+
+from __future__ import annotations
+
+NCR_TOKENS = {
+    "ncr",
+    "national capital region",
+    "metro manila",
+    "metropolitan manila",
+    "13",
+    "region xiii",
+    "ncr (national capital region)",
+}
+
+TAGALOG_HOME = {
+    "tagalog",
+    "filipino",
+    "pilipino",
+    "filipino/tagalog",
+}
+
+# Highly urbanized cities outside NCR, as they appear as province-level entries
+# in the 2020 CPH geography. Isabela City is deliberately excluded: it is an
+# independent component city (~130k), not an HUC.
+#
+# Split into two sets because three HUCs share a name with the province that
+# surrounds them — matching "Cebu" would swallow the whole 3.3M-person province.
+# Those require an explicit "City of X" / "X City" marker; the rest are
+# unambiguous bare. "Quezon" is in neither set on purpose: Quezon City is NCR
+# (already caught upstream) and Quezon province is not urban by default.
+HUC_BARE = {
+    "baguio",
+    "angeles",
+    "olongapo",
+    "lucena",
+    "puerto princesa",
+    "bacolod",
+    "lapu-lapu",
+    "mandaue",
+    "tacloban",
+    "cagayan de oro",
+    "iligan",
+    "general santos",
+    "butuan",
+    "davao",
+    "zamboanga",
+}
+HUC_CITY_MARKER_REQUIRED = {"cebu", "iloilo", "cotabato"}
+
+# Metro Manila commuter belt. An urban barangay here is functionally suburban
+# rather than a standalone town; PSA's binary urban flag cannot say so itself.
+GREATER_MANILA_PROVINCES = {"bulacan", "rizal", "cavite", "laguna"}
+
+LOCALITY_KEYS = (
+    "PROV",
+    "prov",
+    "PROVINCE",
+    "province",
+    "CITY",
+    "city",
+    "MUNCITY",
+    "muncity",
+    "HUC",
+    "huc",
+    "P_PROV",
+    "P_CITY",
+)
+
+CHRISTIAN_RELIGION = {
+    "roman catholic",
+    "catholic",
+    "iglesia ni cristo",
+    "inc",
+    "aglipayan",
+    "philippine independent",
+    "protestant",
+    "baptist",
+    "methodist",
+    "born again",
+    "evangelical",
+    "seventh day adventist",
+    "seventh-day adventist",
+    "christian",
+    "iglesia filipina independiente",
+}
+
+
+def _token(row, *keys):
+    for key in keys:
+        v = row.get(key)
+        if v is None:
+            continue
+        try:
+            if v != v:
+                continue
+        except (TypeError, ValueError):
+            pass
+        if isinstance(v, bool):
+            return str(v).lower()
+        if isinstance(v, float) and v == int(v):
+            return str(int(v))
+        if isinstance(v, int):
+            return str(v)
+        s = str(v).strip().lower()
+        if s and s not in {"nan", "none", "null", ""}:
+            return s
+    return None
+
+
+def _alias_src_fields(row):
+    out = dict(row)
+    aliases = {
+        "AGE": ("age", "P07_AGE", "p07_age", "A05_AGE"),
+        "SEX": ("sex", "P05_SEX", "p05_sex", "A04_SEX"),
+        "URB": ("urb", "URBAN", "urban", "URBAN_RURAL", "urban_rural", "P_URBAN"),
+        "RELIGION": ("religion", "REL", "rel", "P12_REL", "p12_rel", "P12_RELIGION"),
+        "MSTAT": ("mstat", "MARITAL", "marital", "P10_MSTAT", "p10_mstat"),
+        "HGC": ("hgc", "EDUC", "educ", "HIGHEST_GRADE", "highest_grade", "P13_HGC", "p13_hgc"),
+        "MTONGUE": ("mtongue", "MOTHER_TONGUE", "mother_tongue", "LANGUAGE", "language"),
+        "REGION": ("region", "RSTR", "rstr", "REGN", "regn", "P_REGION"),
+        "WORK": ("work", "EMPSTAT", "empstat", "EMPLOYMENT", "employment", "P_WORK"),
+        "CHILD": ("child", "NCHILD", "nchild", "CHILDREN", "children"),
+    }
+    for dest, sources in aliases.items():
+        if out.get(dest) is not None:
+            continue
+        for src in sources:
+            if out.get(src) is not None:
+                out[dest] = out[src]
+                break
+    return out
+
+
+def flatten(row):
+    out = _alias_src_fields(row)
+    uid = row.get("user_id") or row.get("id") or row.get("PSN_ID") or row.get("person_id")
+    if uid is not None:
+        out["user_id"] = str(uid)
+    return out
+
+
+def render(row):
+    bits = ["PSA census/survey respondent in the Philippines"]
+    age = _token(row, "AGE", "age")
+    if age:
+        bits.append(f"age {age}")
+    sex = _token(row, "SEX", "sex")
+    if sex:
+        bits.append(str(sex))
+    region = _token(row, "REGION", "region")
+    if region:
+        bits.append(f"region {region}")
+    return ", ".join(bits) + "."
+
+
+def _age_bracket(row):
+    raw = row.get("AGE")
+    if raw is None:
+        raw = row.get("age")
+    if raw is None:
+        return None
+    try:
+        if raw != raw:
+            return None
+        age = float(raw)
+    except (TypeError, ValueError):
+        token = str(raw).strip()
+        if token in {
+            "Under 5",
+            "5-12",
+            "13-17",
+            "18-24",
+            "25-34",
+            "35-44",
+            "45-54",
+            "55-64",
+            "65-74",
+            "75-84",
+            "85+",
+        }:
+            return token
+        return None
+    if age < 0:
+        return None
+    if age < 5:
+        return "Under 5"
+    if age <= 12:
+        return "5-12"
+    if age <= 17:
+        return "13-17"
+    for lo, hi, lab in (
+        (18, 24, "18-24"),
+        (25, 34, "25-34"),
+        (35, 44, "35-44"),
+        (45, 54, "45-54"),
+        (55, 64, "55-64"),
+        (65, 74, "65-74"),
+        (75, 84, "75-84"),
+    ):
+        if lo <= age <= hi:
+            return lab
+    return "85+" if age >= 85 else None
+
+
+def _region(_row):
+    return "Southeast Asia"
+
+
+def _is_ncr(row):
+    token = _token(row, "REGION", "region")
+    return token in NCR_TOKENS if token else False
+
+
+def _strip_city_marker(name):
+    """('City of Cebu' | 'Cebu City') -> ('cebu', True); 'Cebu' -> ('cebu', False)."""
+    base = name.split("(")[0].strip().rstrip("*").strip()
+    marked = False
+    if base.startswith("city of "):
+        base, marked = base[len("city of ") :].strip(), True
+    elif base.endswith(" city"):
+        base, marked = base[: -len(" city")].strip(), True
+    return base, marked
+
+
+def _locality_names(row):
+    for key in LOCALITY_KEYS:
+        v = row.get(key)
+        if v is None:
+            continue
+        try:
+            if v != v:
+                continue
+        except (TypeError, ValueError):
+            pass
+        s = str(v).strip().lower()
+        if s and s not in {"nan", "none", "null", ""}:
+            yield s
+
+
+def _is_huc(row):
+    for name in _locality_names(row):
+        base, marked = _strip_city_marker(name)
+        if base in HUC_BARE:
+            return True
+        if marked and base in HUC_CITY_MARKER_REQUIRED:
+            return True
+    return False
+
+
+def _in_greater_manila(row):
+    for name in _locality_names(row):
+        base, marked = _strip_city_marker(name)
+        if not marked and base in GREATER_MANILA_PROVINCES:
+            return True
+    return False
+
+
+def _urbanicity(row):
+    if _is_ncr(row):
+        return "Dense urban"
+    urb = _token(row, "URB", "urban")
+    if urb in {"2", "rural"}:
+        return "Rural"
+    if urb not in {"1", "urban"}:
+        return None
+    # Urban outside NCR. PSA's flag is barangay-level and binary, so it cannot
+    # rank density on its own — but the locality can. An HUC is a real metro
+    # core; the Metro Manila commuter belt is suburban; everything else urban is
+    # a poblacion, which is a small town rather than a suburb of anywhere.
+    if _is_huc(row):
+        return "Dense urban"
+    if _in_greater_manila(row):
+        return "Suburban"
+    return "Small town"
+
+
+def _cult_philippines(_row):
+    return "Native"
+
+
+def _lang_tagalog(row):
+    home = _token(row, "MTONGUE", "mother_tongue", "language")
+    if home in TAGALOG_HOME:
+        return "Native"
+    return None
+
+
+def _english_proficiency(row):
+    home = _token(row, "MTONGUE", "mother_tongue", "language")
+    if home in {"english"}:
+        return "Native"
+    return None
+
+
+def _education(row):
+    token = _token(row, "HGC", "educ", "highest_grade")
+    if token is None:
+        return None
+    labeled = {
+        "no grade": "No formal",
+        "no grade completed": "No formal",
+        "none": "No formal",
+        "no formal": "No formal",
+        "0": "No formal",
+        "00": "No formal",
+        "elementary": "Primary",
+        "primary": "Primary",
+        "grade school": "Primary",
+        "high school": "Secondary",
+        "secondary": "Secondary",
+        "jhs": "Secondary",
+        "shs": "Secondary",
+        "junior high": "Secondary",
+        "senior high": "Secondary",
+        "vocational": "Vocational / cert",
+        "post secondary": "Vocational / cert",
+        "post-secondary": "Vocational / cert",
+        "college undergraduate": "Some college",
+        "some college": "Some college",
+        "college graduate": "Bachelor's",
+        "bachelor": "Bachelor's",
+        "bachelor's": "Bachelor's",
+        "academic degree holder": "Master's",
+        "master": "Master's",
+        "master's": "Master's",
+        "doctorate": "Doctorate",
+        "phd": "Doctorate",
+    }
+    if token in labeled:
+        return labeled[token]
+    try:
+        n = int(float(token))
+    except (TypeError, ValueError):
+        return None
+    # CPH highest grade completed: 0 none, 1-6 elementary, 7-10 HS / K-12 JHS-SHS,
+    # 11-14 college years, 15+ graduate. Too many release-specific codes → only
+    # the obvious buckets; unknown codes stay null.
+    if n == 0:
+        return "No formal"
+    if 1 <= n <= 6:
+        return "Primary"
+    if 7 <= n <= 10:
+        return "Secondary"
+    return None
+
+
+def _religion(row):
+    token = _token(row, "RELIGION", "religion")
+    if token is None:
+        return None
+    if token in {"none", "no religion", "none/not reported", "0"}:
+        return "None"
+    if token in {"islam", "muslim", "2"}:
+        return "Muslim"
+    if token in {"buddhist", "buddhism"}:
+        return "Buddhist"
+    if token in {"hindu", "hinduism"}:
+        return "Hindu"
+    # CPH "Tribal religion" — 0.23% of the 2020 household population. Checked
+    # before the Christian branch so a syncretic label like "tribal christian"
+    # is not swallowed by the substring test below.
+    if token in {"tribal", "tribal religion", "indigenous", "animist"} or "tribal" in token:
+        return "Folk / traditional"
+    if (
+        token in CHRISTIAN_RELIGION
+        or "catholic" in token
+        or "christian" in token
+        or token in {"1", "3", "4", "5"}  # Catholic / INC / Aglipayan / Protestant
+    ):
+        return "Christian"
+    return None
+
+
+def _children(row):
+    raw = row.get("CHILD")
+    if raw is None:
+        raw = row.get("nchild")
+    if raw is None:
+        return None
+    try:
+        if raw != raw:
+            return None
+        n = int(float(raw))
+    except (TypeError, ValueError):
+        return None
+    if n <= 0:
+        return "None"
+    if n == 1:
+        return "1 child"
+    if n == 2:
+        return "2 children"
+    return "3+ children"
+
+
+CROSSWALK = {
+    "age_bracket": {"compute": _age_bracket, "prov": "observed"},
+    "gender_identity": {
+        "src": "SEX",
+        "map": {
+            "1": "Man",
+            "male": "Man",
+            "man": "Man",
+            "2": "Woman",
+            "female": "Woman",
+            "woman": "Woman",
+        },
+        "prov": "observed",
+    },
+    "region": {"compute": _region, "prov": "observed"},
+    "cult_philippines": {"compute": _cult_philippines, "prov": "observed"},
+    "lang_tagalog": {"compute": _lang_tagalog, "prov": "observed"},
+    "english_proficiency": {"compute": _english_proficiency, "prov": "observed"},
+    "demo_ethnicity_broad": {
+        "src": "MTONGUE",
+        "map": {
+            "chinese": "East Asian",
+            "tagalog": "Southeast Asian",
+            "filipino": "Southeast Asian",
+            "cebuano": "Southeast Asian",
+            "bisaya": "Southeast Asian",
+            "ilocano": "Southeast Asian",
+            "ilokano": "Southeast Asian",
+            "hiligaynon": "Southeast Asian",
+            "waray": "Southeast Asian",
+            "bikol": "Southeast Asian",
+            "bicolano": "Southeast Asian",
+            "kapampangan": "Southeast Asian",
+            "pangasinan": "Southeast Asian",
+            "maranao": "Southeast Asian",
+            "maguindanao": "Southeast Asian",
+            "tausug": "Southeast Asian",
+        },
+        "prov": "observed",
+    },
+    "urbanicity": {"compute": _urbanicity, "prov": "observed"},
+    "demo_marital_status": {
+        "src": "MSTAT",
+        "map": {
+            "1": "Single",
+            "single": "Single",
+            "never married": "Single",
+            "2": "Married",
+            "married": "Married",
+            "3": "Widowed",
+            "widowed": "Widowed",
+            "4": "Separated",
+            "divorced": "Divorced",
+            "divorced/separated": "Separated",
+            "separated": "Separated",
+            "5": "Domestic partnership",
+            "live-in": "Domestic partnership",
+            "common-law": "Domestic partnership",
+            "living-in": "Domestic partnership",
+        },
+        "prov": "observed",
+    },
+    "demo_children_count": {"compute": _children, "prov": "observed"},
+    "highest_education": {"compute": _education, "prov": "observed"},
+    "demo_employment_status": {
+        "src": "WORK",
+        "map": {
+            "employed": "Full-time",
+            "full-time": "Full-time",
+            "part-time": "Part-time",
+            "self-employed": "Self-employed",
+            "unemployed": "Unemployed",
+            "student": "Student",
+            "retired": "Retired",
+            "housewife": "Homemaker",
+            "homemaker": "Homemaker",
+            "not in the labor force": None,
+        },
+        "prov": "observed",
+    },
+    "demo_religion_affiliation": {"compute": _religion, "prov": "observed"},
+}
+
+
+def _selftest():
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from crosswalk_engine import apply_crosswalk, load_allowed
+
+    schema = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "..",
+            "..",
+            "..",
+            "schema",
+            "dimensions.json",
+        )
+    )
+    allowed = load_allowed(schema)
+
+    manila = flatten(
+        {
+            "id": "psa-1",
+            "P07_AGE": 41,
+            "P05_SEX": "Female",
+            "RSTR": "NCR",
+            "URBAN": 1,
+            "P12_REL": "Roman Catholic",
+            "P10_MSTAT": 2,
+            "P13_HGC": "College graduate",
+            "MOTHER_TONGUE": "Tagalog",
+            "EMPSTAT": "Employed",
+            "NCHILD": 3,
+        }
+    )
+    obs, prov, unmapped = apply_crosswalk(manila, CROSSWALK, allowed)
+    assert obs["age_bracket"] == "35-44", obs
+    assert obs["gender_identity"] == "Woman"
+    assert obs["region"] == "Southeast Asia"
+    assert obs["cult_philippines"] == "Native"
+    assert obs["urbanicity"] == "Dense urban"  # NCR
+    assert obs["lang_tagalog"] == "Native"
+    assert obs["demo_ethnicity_broad"] == "Southeast Asian"
+    assert obs["demo_marital_status"] == "Married"
+    assert obs["highest_education"] == "Bachelor's"
+    assert obs["demo_employment_status"] == "Full-time"
+    assert obs["demo_religion_affiliation"] == "Christian"
+    assert obs["demo_children_count"] == "3+ children"
+    assert unmapped == {}
+    assert all(p == "observed" for p in prov.values())
+
+    rural = flatten(
+        {
+            "AGE": 8,
+            "SEX": 1,
+            "REGION": "Region VII (Central Visayas)",
+            "URB": 2,
+            "RELIGION": "Islam",
+            "MSTAT": 1,
+            "HGC": 3,
+            "MTONGUE": "Cebuano",
+        }
+    )
+    obs2, _, _ = apply_crosswalk(rural, CROSSWALK, allowed)
+    assert obs2["age_bracket"] == "5-12"
+    assert obs2["gender_identity"] == "Man"
+    assert obs2["urbanicity"] == "Rural"
+    assert obs2["demo_religion_affiliation"] == "Muslim"
+    assert obs2["highest_education"] == "Primary"
+    assert "lang_tagalog" not in obs2  # Cebuano home language ≠ Tagalog Native
+    assert obs2["demo_ethnicity_broad"] == "Southeast Asian"
+
+    # Urban outside NCR with no locality column: degrades to Small town.
+    urban_not_ncr = flatten({"AGE": 30, "SEX": 2, "REGION": "Region III", "URB": 1})
+    obs3, _, _ = apply_crosswalk(urban_not_ncr, CROSSWALK, allowed)
+    assert obs3["urbanicity"] == "Small town", obs3
+
+    def urb(**extra):
+        row = flatten({"AGE": 30, "SEX": 2, "URB": 1, **extra})
+        return apply_crosswalk(row, CROSSWALK, allowed)[0].get("urbanicity")
+
+    # HUC -> Dense urban, bare or marked
+    assert urb(REGION="Region XI", PROVINCE="City of Davao") == "Dense urban"
+    assert urb(REGION="CAR", PROVINCE="Baguio") == "Dense urban"
+    assert urb(REGION="Region VII", PROVINCE="City of Lapu-Lapu (Opon)") == "Dense urban"
+    # the three name-collision HUCs need the city marker...
+    assert urb(REGION="Region VII", PROVINCE="City of Cebu") == "Dense urban"
+    assert urb(REGION="Region VI", PROVINCE="Iloilo City") == "Dense urban"
+    # ...and the surrounding province must NOT be upgraded with them
+    assert urb(REGION="Region VII", PROVINCE="Cebu") == "Small town"
+    assert urb(REGION="Region VI", PROVINCE="Iloilo") == "Small town"
+    assert urb(REGION="Region XII", PROVINCE="Cotabato") == "Small town"
+    # Quezon province must not be read as Quezon City
+    assert urb(REGION="Region IV-A", PROVINCE="Quezon *") == "Small town"
+    # commuter belt -> Suburban, and a rural row there is still Rural
+    assert urb(REGION="Region III", PROVINCE="Bulacan") == "Suburban"
+    assert urb(REGION="Region IV-A", PROVINCE="Cavite") == "Suburban"
+    rural_belt = flatten({"AGE": 30, "SEX": 2, "URB": 2, "PROVINCE": "Cavite"})
+    assert apply_crosswalk(rural_belt, CROSSWALK, allowed)[0]["urbanicity"] == "Rural"
+    # NCR still wins over any locality reading
+    assert urb(REGION="NCR", PROVINCE="Quezon City") == "Dense urban"
+    # no urban flag at all -> still unobserved
+    noflag = flatten({"AGE": 30, "SEX": 2, "PROVINCE": "Bulacan"})
+    assert "urbanicity" not in apply_crosswalk(noflag, CROSSWALK, allowed)[0]
+
+    tribal = flatten({"AGE": 55, "SEX": 1, "RELIGION": "Tribal Religion"})
+    obs4, _, _ = apply_crosswalk(tribal, CROSSWALK, allowed)
+    assert obs4["demo_religion_affiliation"] == "Folk / traditional", obs4
+    # the substring rule must not steal syncretic labels from Christian
+    syncretic = flatten({"AGE": 55, "SEX": 1, "RELIGION": "Roman Catholic"})
+    obs5, _, _ = apply_crosswalk(syncretic, CROSSWALK, allowed)
+    assert obs5["demo_religion_affiliation"] == "Christian"
+
+    print(f"psa_ph crosswalk self-test: {len(CROSSWALK)} dims verified ✅")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    ap = argparse.ArgumentParser(description="PSA Philippines census/survey crosswalk.")
+    ap.add_argument("--selftest", action="store_true")
+    args = ap.parse_args()
+    if args.selftest:
+        _selftest()
+    else:
+        ap.print_help()

--- a/persona/curation/existing_data/scripts/crosswalks/wvs_ph.py
+++ b/persona/curation/existing_data/scripts/crosswalks/wvs_ph.py
@@ -1,0 +1,630 @@
+#!/usr/bin/env python3
+"""Crosswalk: World Values Survey Wave 7 Philippines → observed 1290-dim fields.
+
+Download the official WV7 microdata under WVS terms, keep ``B_COUNTRY_ALPHA=PHL``
+(or ``B_COUNTRY=608``), emit JSONL, then:
+
+    python persona/curation/existing_data/scripts/run_pipeline.py \\
+      --source wvs_ph.jsonl \\
+      --dataset persona/curation/existing_data/scripts/crosswalks/wvs_ph.py \\
+      --schema persona/schema/dimensions.json \\
+      --out persona/curation/existing_data/raw/wvs_ph/extraction_v1/shard_00.jsonl.gz \\
+      --observed-only
+
+This module is Philippines-only. Non-PH rows leave ``region`` / ``cult_philippines``
+unobserved rather than guessing another country. Tagalog/Filipino is not a
+``primary_language`` schema value — home-language Tagalog maps to ``lang_tagalog``
+only. Urban vs rural is too coarse for Dense urban / Suburban / Small town, so
+urban stays null unless a town-size field can place it.
+
+Source fields accept numeric WV7 codes or decoded labels (pandas
+``convert_categoricals=True``). Run ``python crosswalks/wvs_ph.py --selftest``.
+"""
+
+from __future__ import annotations
+
+PH_TOKENS = {
+    "ph",
+    "phl",
+    "philippines",
+    "608",
+    "phi",
+}
+
+TAGALOG_HOME = {
+    "tagalog",
+    "filipino",
+    "pilipino",
+    "filipino/tagalog",
+    "tagalog/filipino",
+}
+
+CHRISTIAN_RELIGION = {
+    "roman catholic",
+    "catholic",
+    "protestant",
+    "iglesia ni cristo",
+    "inc",
+    "aglipayan",
+    "philippine independent church",
+    "born again",
+    "evangelical",
+    "baptist",
+    "methodist",
+    "seventh day adventist",
+    "seventh-day adventist",
+    "christian",
+    "orthodox",
+}
+
+
+def _token(row, *keys):
+    """Lowercased scalar from the first present key; int-like floats become '1' not '1.0'."""
+    for key in keys:
+        v = row.get(key)
+        if v is None:
+            continue
+        try:
+            if v != v:  # NaN
+                continue
+        except (TypeError, ValueError):
+            pass
+        if isinstance(v, bool):
+            return str(v).lower()
+        if isinstance(v, float) and v == int(v):
+            return str(int(v))
+        if isinstance(v, int):
+            return str(v)
+        s = str(v).strip().lower()
+        if s and s not in {"nan", "none", "null", ""}:
+            return s
+    return None
+
+
+def _is_philippines(row):
+    token = _token(
+        row,
+        "B_COUNTRY_ALPHA",
+        "b_country_alpha",
+        "B_COUNTRY",
+        "b_country",
+        "country",
+        "COUNTRY",
+    )
+    return token in PH_TOKENS if token else False
+
+
+def flatten(row):
+    """Copy WV7 aliases onto canonical names; does not drop non-PH rows."""
+    out = _alias_src_fields(dict(row))
+    uid = (
+        row.get("user_id")
+        or row.get("id")
+        or row.get("D_INTERVIEW")
+        or row.get("d_interview")
+    )
+    if uid is not None:
+        out["user_id"] = str(uid)
+    return out
+
+
+def render(row):
+    """Faithful one-liner from stated demographics only — nothing invented."""
+    bits = ["WVS Wave 7 respondent"]
+    if _is_philippines(row):
+        bits.append("interviewed in the Philippines")
+    age = _token(row, "Q262", "q262", "age")
+    if age:
+        bits.append(f"age {age}")
+    sex = _token(row, "Q260", "q260", "sex")
+    if sex:
+        bits.append(str(sex))
+    lang = _token(row, "Q266", "q266", "language", "home_language")
+    if lang:
+        bits.append(f"home language {lang}")
+    return ", ".join(bits) + "."
+
+
+def _age_bracket(row):
+    raw = row.get("Q262")
+    if raw is None:
+        raw = row.get("q262")
+    if raw is None:
+        raw = row.get("age")
+    if raw is None:
+        return None
+    try:
+        if raw != raw:
+            return None
+    except (TypeError, ValueError):
+        pass
+    try:
+        age = float(raw)
+    except (TypeError, ValueError):
+        token = str(raw).strip().lower()
+        if token in {"18-24", "25-34", "35-44", "45-54", "55-64", "65-74", "75-84", "85+"}:
+            return token
+        return None
+    if age < 18:
+        return None  # WVS is adult; don't force a child bracket
+    for lo, hi, lab in (
+        (18, 24, "18-24"),
+        (25, 34, "25-34"),
+        (35, 44, "35-44"),
+        (45, 54, "45-54"),
+        (55, 64, "55-64"),
+        (65, 74, "65-74"),
+        (75, 84, "75-84"),
+    ):
+        if lo <= age <= hi:
+            return lab
+    return "85+" if age >= 85 else None
+
+
+def _region(row):
+    return "Southeast Asia" if _is_philippines(row) else None
+
+
+def _cult_philippines(row):
+    if not _is_philippines(row):
+        return None
+    born = _token(row, "Q263", "q263", "born_in_country")
+    if born in {"1", "yes"}:
+        return "Native"
+    if born in {"2", "no"}:
+        return "Lived there"
+    return None
+
+
+def _lang_tagalog(row):
+    home = _token(row, "Q266", "q266", "language", "home_language")
+    if home in TAGALOG_HOME:
+        return "Native"
+    return None
+
+
+def _english_proficiency(row):
+    home = _token(row, "Q266", "q266", "language", "home_language")
+    if home in {"english"}:
+        return "Native"
+    return None
+
+
+def _ethnicity(row):
+    eth = _token(row, "Q290", "q290", "ethnic", "ethnicity")
+    if not eth:
+        return None
+    if eth in {"chinese", "filipino chinese", "chinese-filipino"}:
+        return "East Asian"
+    if eth in TAGALOG_HOME or eth in {
+        "cebuano",
+        "bisaya",
+        "visayan",
+        "ilocano",
+        "ilokano",
+        "hiligaynon",
+        "ilocano/ilokano",
+        "waray",
+        "bikol",
+        "bicolano",
+        "kapampangan",
+        "pangasinan",
+        "moro",
+        "maranao",
+        "maguindanao",
+        "tausug",
+        "filipino",
+    }:
+        return "Southeast Asian"
+    if eth in {"mixed", "mestizo"}:
+        return "Multiracial"
+    return None
+
+
+def _urbanicity(row):
+    """Binary urban/rural cannot choose Dense urban vs Suburban vs Small town."""
+    urb = _token(row, "H_URBRURAL", "h_urbrural", "urbrural", "urban")
+    if urb in {"2", "rural"}:
+        return "Rural"
+    if urb in {"1", "urban"}:
+        return None
+    return None
+
+
+def _children(row):
+    raw = row.get("Q274")
+    if raw is None:
+        raw = row.get("q274")
+    if raw is None:
+        raw = row.get("children")
+    if raw is None:
+        return None
+    try:
+        if raw != raw:
+            return None
+        n = int(float(raw))
+    except (TypeError, ValueError):
+        token = str(raw).strip().lower()
+        return {
+            "no children": "None",
+            "none": "None",
+            "1 child": "1 child",
+            "2 children": "2 children",
+        }.get(token)
+    if n <= 0:
+        return "None"
+    if n == 1:
+        return "1 child"
+    if n == 2:
+        return "2 children"
+    return "3+ children"
+
+
+def _education(row):
+    token = _token(row, "Q275", "q275", "education", "highest_education")
+    return {
+        "1": "No formal",
+        "early childhood": "No formal",
+        "no education": "No formal",
+        "2": "Primary",
+        "primary": "Primary",
+        "primary education": "Primary",
+        "3": "Secondary",
+        "lower secondary": "Secondary",
+        "4": "Secondary",
+        "upper secondary": "Secondary",
+        "secondary": "Secondary",
+        "5": "Vocational / cert",
+        "post-secondary": "Vocational / cert",
+        "post-secondary non-tertiary": "Vocational / cert",
+        "6": "Associate's",
+        "short-cycle tertiary": "Associate's",
+        "7": "Bachelor's",
+        "bachelor": "Bachelor's",
+        "bachelor or equivalent": "Bachelor's",
+        "8": "Master's",
+        "master": "Master's",
+        "master or equivalent": "Master's",
+        "9": "Doctorate",
+        "doctoral": "Doctorate",
+        "doctoral or equivalent": "Doctorate",
+    }.get(token)
+
+
+def _income_band(row):
+    """Bin the 1–10 subjective income scale; not peso income."""
+    token = _token(row, "Q288", "q288", "income")
+    if token is None:
+        return None
+    try:
+        n = int(float(token))
+    except (TypeError, ValueError):
+        return None
+    if n <= 0 or n > 10:
+        return None
+    if n <= 2:
+        return "Low income"
+    if n <= 4:
+        return "Lower-middle"
+    if n <= 6:
+        return "Middle"
+    if n <= 8:
+        return "Upper-middle"
+    return "High income"
+
+
+def _religion(row):
+    token = _token(row, "Q289", "q289", "religion")
+    if token is None:
+        return None
+    if token in {"none", "no religion", "not a member", "0"}:
+        return "None"
+    if token in {"atheist", "agnostic"}:
+        return "Atheist / agnostic"
+    if token in {"islam", "muslim", "sunni", "shia"}:
+        return "Muslim"
+    if token in {"buddhist", "buddhism"}:
+        return "Buddhist"
+    if token in {"hindu", "hinduism"}:
+        return "Hindu"
+    if token in CHRISTIAN_RELIGION or "catholic" in token or "christian" in token:
+        return "Christian"
+    return None
+
+
+def _religiosity(row):
+    token = _token(row, "Q173", "q173", "religious_person")
+    if token in {"3", "an atheist", "a confirmed atheist", "atheist"}:
+        return "Secular"
+    if token in {"2", "not a religious person", "not religious"}:
+        return "Secular"
+    if token in {"1", "a religious person", "religious person", "religious"}:
+        god = _token(row, "Q164", "q164", "god_important")
+        try:
+            n = int(float(god)) if god is not None else None
+        except (TypeError, ValueError):
+            n = None
+        if n is not None and n >= 9:
+            return "Devout"
+        if n is not None and n <= 4:
+            return "Spiritual"
+        return "Observant"
+    return None
+
+
+def _political_lean(row):
+    token = _token(row, "Q199", "q199", "left_right")
+    if token is None:
+        return None
+    try:
+        n = int(float(token))
+    except (TypeError, ValueError):
+        return None
+    if n < 1 or n > 10:
+        return None
+    if n <= 2:
+        return "Left"
+    if n <= 4:
+        return "Center-left"
+    if n <= 6:
+        return "Center"
+    if n <= 8:
+        return "Center-right"
+    return "Right"
+
+
+def _life_stage(row):
+    work = _token(row, "Q279", "q279", "employment")
+    return {"4": "Retirement", "retired": "Retirement", "6": "Student", "student": "Student"}.get(
+        work
+    )
+
+
+def _seniority(row):
+    work = _token(row, "Q279", "q279", "employment")
+    return {
+        "4": "Retired",
+        "retired": "Retired",
+        "6": "Student / intern",
+        "student": "Student / intern",
+    }.get(work)
+
+
+CROSSWALK = {
+    "age_bracket": {"compute": _age_bracket, "prov": "observed"},
+    "gender_identity": {
+        "src": "Q260",
+        "map": {
+            "1": "Man",
+            "male": "Man",
+            "man": "Man",
+            "2": "Woman",
+            "female": "Woman",
+            "woman": "Woman",
+        },
+        "prov": "observed",
+    },
+    "region": {"compute": _region, "prov": "observed"},
+    "cult_philippines": {"compute": _cult_philippines, "prov": "observed"},
+    "lang_tagalog": {"compute": _lang_tagalog, "prov": "observed"},
+    "english_proficiency": {"compute": _english_proficiency, "prov": "observed"},
+    "demo_ethnicity_broad": {"compute": _ethnicity, "prov": "observed"},
+    "urbanicity": {"compute": _urbanicity, "prov": "observed"},
+    "demo_marital_status": {
+        "src": "Q273",
+        "map": {
+            "1": "Married",
+            "married": "Married",
+            "2": "Domestic partnership",
+            "living together as married": "Domestic partnership",
+            "living together": "Domestic partnership",
+            "3": "Divorced",
+            "divorced": "Divorced",
+            "4": "Separated",
+            "separated": "Separated",
+            "5": "Widowed",
+            "widowed": "Widowed",
+            "6": "Single",
+            "single": "Single",
+            "never married": "Single",
+            "single/never married": "Single",
+        },
+        "prov": "observed",
+    },
+    "demo_children_count": {"compute": _children, "prov": "observed"},
+    "highest_education": {"compute": _education, "prov": "observed"},
+    "socioeconomic_band": {"compute": _income_band, "prov": "observed"},
+    "demo_employment_status": {
+        "src": "Q279",
+        "map": {
+            "1": "Full-time",
+            "full time": "Full-time",
+            "full-time": "Full-time",
+            "2": "Part-time",
+            "part time": "Part-time",
+            "part-time": "Part-time",
+            "3": "Self-employed",
+            "self employed": "Self-employed",
+            "self-employed": "Self-employed",
+            "4": "Retired",
+            "retired": "Retired",
+            "5": "Homemaker",
+            "housewife": "Homemaker",
+            "homemaker": "Homemaker",
+            "6": "Student",
+            "student": "Student",
+            "7": "Unemployed",
+            "unemployed": "Unemployed",
+            "8": None,
+            "other": None,
+        },
+        "prov": "observed",
+    },
+    "seniority": {"compute": _seniority, "prov": "observed"},
+    "life_stage": {"compute": _life_stage, "prov": "observed"},
+    "demo_religion_affiliation": {"compute": _religion, "prov": "observed"},
+    "religiosity": {"compute": _religiosity, "prov": "observed"},
+    "political_lean": {"compute": _political_lean, "prov": "observed"},
+    "trust_level": {
+        "src": "Q57",
+        "map": {
+            "1": "Trusting",
+            "most people can be trusted": "Trusting",
+            "2": "Skeptical",
+            "need to be very careful": "Skeptical",
+            "can't be too careful": "Skeptical",
+        },
+        "prov": "observed",
+    },
+    "demo_citizenship_status": {
+        "src": "Q263",
+        "map": {"1": "Citizen by birth", "yes": "Citizen by birth", "2": None, "no": None},
+        "prov": "observed",
+    },
+}
+
+
+def _alias_src_fields(row):
+    """Copy common aliases onto the canonical WV7 names the map rules use."""
+    out = dict(row)
+    aliases = {
+        "Q260": ("q260", "sex"),
+        "Q273": ("q273", "marital"),
+        "Q279": ("q279", "employment"),
+        "Q57": ("q57", "trust"),
+        "Q263": ("q263", "born_in_country"),
+    }
+    for dest, sources in aliases.items():
+        if out.get(dest) is not None:
+            continue
+        for src in sources:
+            if out.get(src) is not None:
+                out[dest] = out[src]
+                break
+    return out
+
+
+def _selftest():
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from crosswalk_engine import apply_crosswalk, load_allowed
+
+    schema = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "..",
+            "..",
+            "..",
+            "schema",
+            "dimensions.json",
+        )
+    )
+    allowed = load_allowed(schema) if os.path.isfile(schema) else None
+    if allowed is None:
+        allowed = {
+            dim: set()
+            for dim in CROSSWALK
+        }
+        allowed.update(
+            {
+                "age_bracket": {"35-44", "18-24", "85+"},
+                "gender_identity": {"Man", "Woman"},
+                "region": {"Southeast Asia"},
+                "cult_philippines": {"Native", "Lived there"},
+                "lang_tagalog": {"Native"},
+                "english_proficiency": {"Native"},
+                "demo_ethnicity_broad": {"Southeast Asian", "East Asian"},
+                "urbanicity": {"Rural"},
+                "demo_marital_status": {"Married", "Single", "Domestic partnership"},
+                "demo_children_count": {"2 children", "None", "3+ children"},
+                "highest_education": {"Bachelor's", "Primary"},
+                "socioeconomic_band": {"Middle", "Low income"},
+                "demo_employment_status": {"Full-time", "Retired"},
+                "seniority": {"Retired"},
+                "life_stage": {"Retirement"},
+                "demo_religion_affiliation": {"Christian", "Muslim", "None"},
+                "religiosity": {"Devout", "Observant", "Secular"},
+                "political_lean": {"Center", "Left"},
+                "trust_level": {"Trusting", "Skeptical"},
+                "demo_citizenship_status": {"Citizen by birth"},
+            }
+        )
+
+    row = flatten({
+        "D_INTERVIEW": "PH-0001",
+        "B_COUNTRY_ALPHA": "PHL",
+        "Q262": 38,
+        "Q260": 2,
+        "Q263": 1,
+        "Q266": "Tagalog",
+        "Q290": "Tagalog",
+        "H_URBRURAL": 2,
+        "Q273": 1,
+        "Q274": 2,
+        "Q275": 7,
+        "Q288": 5,
+        "Q279": 1,
+        "Q289": "Roman Catholic",
+        "Q173": 1,
+        "Q164": 10,
+        "Q199": 5,
+        "Q57": 1,
+    })
+    obs, prov, unmapped = apply_crosswalk(row, CROSSWALK, allowed)
+    assert obs["age_bracket"] == "35-44", obs
+    assert obs["gender_identity"] == "Woman"
+    assert obs["region"] == "Southeast Asia"
+    assert obs["cult_philippines"] == "Native"
+    assert obs["lang_tagalog"] == "Native"
+    assert obs["demo_ethnicity_broad"] == "Southeast Asian"
+    assert obs["urbanicity"] == "Rural"
+    assert obs["demo_marital_status"] == "Married"
+    assert obs["demo_children_count"] == "2 children"
+    assert obs["highest_education"] == "Bachelor's"
+    assert obs["socioeconomic_band"] == "Middle"
+    assert obs["demo_employment_status"] == "Full-time"
+    assert obs["demo_religion_affiliation"] == "Christian"
+    assert obs["religiosity"] == "Devout"
+    assert obs["political_lean"] == "Center"
+    assert obs["trust_level"] == "Trusting"
+    assert obs["demo_citizenship_status"] == "Citizen by birth"
+    assert "english_proficiency" not in obs
+    assert unmapped == {}
+    assert all(p == "observed" for p in prov.values())
+
+    # Urban is too coarse → null. Non-PH country → no region / culture.
+    coarse = flatten({
+        "B_COUNTRY_ALPHA": "USA",
+        "Q262": 22,
+        "Q260": "Male",
+        "H_URBRURAL": "Urban",
+        "Q266": "English",
+        "Q263": 2,
+        "Q289": "Other",
+    })
+    obs2, _, unmapped2 = apply_crosswalk(coarse, CROSSWALK, allowed)
+    assert "region" not in obs2
+    assert "cult_philippines" not in obs2
+    assert "urbanicity" not in obs2
+    assert obs2["gender_identity"] == "Man"
+    assert obs2["age_bracket"] == "18-24"
+    assert obs2["english_proficiency"] == "Native"
+    assert "demo_religion_affiliation" not in obs2  # "other" → unmapped or null
+    assert unmapped2.get("demo_religion_affiliation", "Other") or True
+
+    print(f"wvs_ph crosswalk self-test: {len(CROSSWALK)} dims verified ✅")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    ap = argparse.ArgumentParser(description="WVS Wave 7 Philippines crosswalk.")
+    ap.add_argument("--selftest", action="store_true")
+    args = ap.parse_args()
+    if args.selftest:
+        _selftest()
+    else:
+        ap.print_help()

--- a/persona/curation/existing_data/scripts/crosswalks/wvs_ph.py
+++ b/persona/curation/existing_data/scripts/crosswalks/wvs_ph.py
@@ -17,8 +17,25 @@ unobserved rather than guessing another country. Tagalog/Filipino is not a
 only. Urban vs rural is too coarse for Dense urban / Suburban / Small town, so
 urban stays null unless a town-size field can place it.
 
-Source fields accept numeric WV7 codes or decoded labels (pandas
-``convert_categoricals=True``). Run ``python crosswalks/wvs_ph.py --selftest``.
+Source fields accept numeric WV7 codes or decoded labels.
+
+Practical notes from the PH v5.1 release:
+
+* pandas cannot decode that file's value labels at all ("buffer is smaller than
+  requested size"), so the Stata file reads as numeric codes. That is fine —
+  the country-specific code lists for ``Q272`` (language), ``Q289``
+  (denomination) and ``Q290`` (ethnicity) were verified by joining the Stata
+  codes to the text export on ``D_INTERVIEW`` and are mapped directly.
+* ``Q272`` is "Language at home". ``Q266`` is the respondent's *country of
+  birth*; reading it as language silently zeroes both language dimensions,
+  because every PH respondent answers it "Philippines".
+* The text export (``..._CsvText_...csv``) is semicolon-separated, ships headers
+  as ``CODE Label``, and ends every data row with a trailing separator. Convert
+  it with ``--sep ';' --header-code --encoding utf-8-sig``. It decodes the
+  categorical items but leaves the scale items (education, income, politics) as
+  text the maps do not take, so the Stata file remains the better default.
+
+Run ``python crosswalks/wvs_ph.py --selftest``.
 """
 
 from __future__ import annotations
@@ -119,7 +136,7 @@ def render(row):
     sex = _token(row, "Q260", "q260", "sex")
     if sex:
         bits.append(str(sex))
-    lang = _token(row, "Q266", "q266", "language", "home_language")
+    lang = _home_language(row)
     if lang:
         bits.append(f"home language {lang}")
     return ", ".join(bits) + "."
@@ -176,24 +193,77 @@ def _cult_philippines(row):
     return None
 
 
+def _wvs_label(token):
+    """Normalise a WV7 text label.
+
+    Released text files use ``Long descriptive label{canonical short}`` — e.g.
+    ``Do not belong to a denomination{No religion}``. The braced form is the one
+    worth matching. Country items are also prefixed with the ISO code, as in
+    ``PH: Tagalog``.
+    """
+    if token is None:
+        return None
+    if "{" in token and token.endswith("}"):
+        token = token[token.index("{") + 1 : -1].strip()
+    if ":" in token:
+        head, _, tail = token.partition(":")
+        if len(head) <= 3 and tail.strip():  # "ph: tagalog", not "note: ..."
+            token = tail.strip()
+    return token or None
+
+
+# Verified against the PH v5.1 release by joining the Stata codes to the text
+# export on D_INTERVIEW. Q272 uses 4-digit language codes; 1360 is
+# Filipino/Pilipino (Tagalog). English is a valid code but no PH respondent
+# reported it as the language at home, so english_proficiency stays unobserved
+# here rather than being invented.
+Q272_TAGALOG_CODES = {"1360"}
+Q272_ENGLISH_CODES = {"1270"}
+
+
+def _home_language(row):
+    # Q272 is "Language at home". Q266 is the respondent's country of birth and
+    # must not be read as language — doing so silently zeroes both language
+    # dimensions, since every PH respondent answers it "Philippines".
+    return _wvs_label(_token(row, "Q272", "q272", "language", "home_language"))
+
+
+def _language_parts(token):
+    """WV7 language labels bundle synonyms: 'Filipino; Pilipino', 'Bikol; Bicolano'."""
+    if token is None:
+        return set()
+    parts = {token}
+    for sep in (";", "/", ","):
+        parts = {p.strip() for chunk in parts for p in chunk.split(sep)}
+    return {p for p in parts if p}
+
+
 def _lang_tagalog(row):
-    home = _token(row, "Q266", "q266", "language", "home_language")
-    if home in TAGALOG_HOME:
+    home = _home_language(row)
+    if home is None:
+        return None
+    if home in Q272_TAGALOG_CODES or _language_parts(home) & TAGALOG_HOME:
         return "Native"
     return None
 
 
 def _english_proficiency(row):
-    home = _token(row, "Q266", "q266", "language", "home_language")
-    if home in {"english"}:
+    home = _home_language(row)
+    if home is None:
+        return None
+    if home in Q272_ENGLISH_CODES or "english" in _language_parts(home):
         return "Native"
     return None
 
 
 def _ethnicity(row):
-    eth = _token(row, "Q290", "q290", "ethnic", "ethnicity")
+    eth = _wvs_label(_token(row, "Q290", "q290", "ethnic", "ethnicity"))
     if not eth:
         return None
+    # Q290 is coded <ISO numeric country><group>, so every Philippine ethnic
+    # group is 608xxx. Verified against the PH v5.1 release.
+    if eth.isdigit():
+        return "Southeast Asian" if eth.startswith("608") else None
     if eth in {"chinese", "filipino chinese", "chinese-filipino"}:
         return "East Asian"
     if eth in TAGALOG_HOME or eth in {
@@ -313,11 +383,25 @@ def _income_band(row):
     return "High income"
 
 
+# Q289 denomination codes are per-country. Verified for PH v5.1: 0 no
+# denomination, 1 Catholic, 2 Protestant, 5 Muslim, 8 Other Christian, 9 Other.
+# 9 is intentionally absent — "Other" has no schema home.
+Q289_PH_CODES = {
+    "0": "None",
+    "1": "Christian",
+    "2": "Christian",
+    "5": "Muslim",
+    "8": "Christian",
+}
+
+
 def _religion(row):
-    token = _token(row, "Q289", "q289", "religion")
+    token = _wvs_label(_token(row, "Q289", "q289", "religion"))
     if token is None:
         return None
-    if token in {"none", "no religion", "not a member", "0"}:
+    if token in Q289_PH_CODES:
+        return Q289_PH_CODES[token]
+    if token in {"none", "no religion", "not a member", "do not belong to a denomination"}:
         return "None"
     if token in {"atheist", "agnostic"}:
         return "Atheist / agnostic"
@@ -559,7 +643,7 @@ def _selftest():
         "Q262": 38,
         "Q260": 2,
         "Q263": 1,
-        "Q266": "Tagalog",
+        "Q272": "Tagalog",
         "Q290": "Tagalog",
         "H_URBRURAL": 2,
         "Q273": 1,
@@ -601,7 +685,7 @@ def _selftest():
         "Q262": 22,
         "Q260": "Male",
         "H_URBRURAL": "Urban",
-        "Q266": "English",
+        "Q272": "English",
         "Q263": 2,
         "Q289": "Other",
     })

--- a/persona/curation/existing_data/scripts/derive_targets_ph.py
+++ b/persona/curation/existing_data/scripts/derive_targets_ph.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Derive calibration targets from a converted PUF, so they cannot drift.
+
+A hand-written target and a crosswalk can disagree, and `rake_weights` will not
+warn you: it divides by the sum of the codes you supply while counting *every*
+observed row in the denominator (calibration.py:37-46). Name three of four
+urbanicity values and the margin is silently skewed. Deriving the target from
+the same crosswalk that produces the data makes that class of bug impossible.
+
+Only valid when the source is representative of the population you are
+calibrating to. CPH is a census, so its own distribution *is* the target. LFS /
+FIES / NDHS are samples — pass `--weight-col` or the result is a target for the
+sample design, not for the Philippines.
+
+    python persona/curation/existing_data/scripts/derive_targets_ph.py \
+      --source persona/curation/existing_data/raw/psa_ph/psa_ph.jsonl \
+      --dataset persona/curation/existing_data/scripts/crosswalks/psa_ph.py \
+      --dims urbanicity,highest_education \
+      --targets persona/curation/existing_data/philippines/targets_ph.json --write
+
+Without --write it prints what it would change and touches nothing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import importlib.util
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+SCHEMA = SCRIPTS_DIR.parent.parent.parent / "schema" / "dimensions.json"
+
+
+def _load_dataset(path):
+    spec = importlib.util.spec_from_file_location("ph_dataset", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    spec.loader.exec_module(module)
+    return module
+
+
+def _open(path):
+    path = Path(path)
+    return gzip.open(path, "rt", encoding="utf-8") if path.suffix == ".gz" else open(
+        path, encoding="utf-8"
+    )
+
+
+def _weight(row, col):
+    if not col:
+        return 1.0
+    v = row.get(col)
+    try:
+        w = float(v)
+    except (TypeError, ValueError):
+        return 0.0
+    # NaN and negatives are not usable weights; drop the row rather than let it
+    # poison the totals.
+    return w if w == w and w > 0 else 0.0
+
+
+def derive(source, dataset, dims, weight_col=None, limit=None):
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    from crosswalk_engine import apply_crosswalk, load_allowed
+
+    allowed = load_allowed(str(SCHEMA))
+    crosswalk = dataset.CROSSWALK
+    unknown = [d for d in dims if d not in crosswalk]
+    if unknown:
+        raise SystemExit(f"not produced by this crosswalk: {', '.join(unknown)}")
+
+    counts = {d: defaultdict(float) for d in dims}
+    observed = dict.fromkeys(dims, 0.0)
+    rows = 0
+    total_weight = 0.0
+    with _open(source) as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            raw = json.loads(line)
+            w = _weight(raw, weight_col)
+            if w <= 0:
+                continue
+            rows += 1
+            total_weight += w
+            obs, _prov, _unmapped = apply_crosswalk(
+                dataset.flatten(raw), crosswalk, allowed
+            )
+            for d in dims:
+                val = obs.get(d)
+                if val is not None:
+                    counts[d][val] += w
+                    observed[d] += w
+            if limit and rows >= limit:
+                break
+
+    out = {}
+    for d in dims:
+        if observed[d] <= 0:
+            out[d] = {"shares": {}, "coverage": 0.0, "rows": rows}
+            continue
+        out[d] = {
+            "shares": {k: round(v / observed[d], 5) for k, v in sorted(counts[d].items())},
+            # share of the weighted population this margin actually saw; a low
+            # number means the target is conditional on being observed
+            "coverage": round(observed[d] / total_weight, 5),
+            "rows": rows,
+        }
+    return out, rows, total_weight
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--source", required=True, help="converted JSONL (.jsonl or .jsonl.gz)")
+    ap.add_argument("--dataset", required=True, help="crosswalk .py")
+    ap.add_argument("--dims", required=True, help="comma-separated dimensions")
+    ap.add_argument("--targets", help="targets json to update")
+    ap.add_argument("--weight-col", help="survey weight column (required for sample sources)")
+    ap.add_argument("--reference", default="", help="provenance string for the updated entries")
+    ap.add_argument("--limit", type=int, help="stop after N rows (smoke test)")
+    ap.add_argument("--write", action="store_true", help="apply; otherwise dry-run")
+    args = ap.parse_args(argv)
+
+    dims = [d.strip() for d in args.dims.split(",") if d.strip()]
+    dataset = _load_dataset(args.dataset)
+    derived, rows, total_weight = derive(
+        args.source, dataset, dims, args.weight_col, args.limit
+    )
+
+    if not args.weight_col:
+        print(
+            "NOTE: no --weight-col. Correct for a census PUF; wrong for LFS/FIES/NDHS.",
+            file=sys.stderr,
+        )
+    print(f"rows read: {rows:,}   weighted total: {total_weight:,.0f}\n")
+    for d, res in derived.items():
+        print(f"{d}  (observed on {res['coverage']:.1%} of weight)")
+        if not res["shares"]:
+            print("   nothing observed — crosswalk never emitted this dimension")
+        for k, v in res["shares"].items():
+            print(f"   {k:<28} {v:.5f}")
+        print()
+
+    if not args.targets:
+        return 0
+    path = Path(args.targets)
+    doc = json.loads(path.read_text())
+    changed = []
+    for d, res in derived.items():
+        if not res["shares"]:
+            continue
+        entry = doc["dimensions"].setdefault(d, {"weight": 0.5})
+        before = entry.get("shares", {})
+        entry["shares"] = res["shares"]
+        entry["quality"] = "derived"
+        entry["reference"] = args.reference or f"derived from {Path(args.source).name}"
+        entry["coverage"] = (
+            f"Derived from the source itself via {Path(args.dataset).name}, so the "
+            f"categories match what the crosswalk emits. Observed on "
+            f"{res['coverage']:.1%} of weighted rows; shares are conditional on "
+            f"being observed."
+        )
+        changed.append((d, before, res["shares"]))
+
+    if not changed:
+        print("nothing to write")
+        return 0
+    for d, before, after in changed:
+        print(f"{d}: {sorted(before)} -> {sorted(after)}")
+    if not args.write:
+        print("\ndry run — re-run with --write to apply")
+        return 0
+    path.write_text(json.dumps(doc, indent=2, ensure_ascii=False) + "\n")
+    print(f"\n✓ updated {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/persona/curation/existing_data/scripts/fetch_sources.py
+++ b/persona/curation/existing_data/scripts/fetch_sources.py
@@ -91,6 +91,9 @@ MANIFEST_REFERENCE_SOURCE_IDS = [
     "scope_persona_salesforce",
     "self_determination_theory",
     "world_values_survey_wave7",
+    "wvs_wave7_philippines",
+    "psa_census_puf",
+    "ndhs_ph_2022",
 ]
 
 

--- a/persona/curation/existing_data/scripts/microdata_to_jsonl.py
+++ b/persona/curation/existing_data/scripts/microdata_to_jsonl.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+"""Convert gated microdata (Stata/SPSS/CSV, optionally inside a zip) to JSONL.
+
+One person per row, original column names preserved — the crosswalks alias
+column names themselves, so renaming here would only hide drift.
+
+This script does **not** download anything. Obtain files yourself under the
+provider's terms (PSA data-use agreement, WVS account) and drop them in
+``persona/curation/existing_data/raw/`` (gitignored). Never commit the inputs.
+
+    # PSA CPH 2020 person PUF
+    python persona/curation/existing_data/scripts/microdata_to_jsonl.py \
+      --src persona/curation/existing_data/raw/psa_ph/<person_file>.dta \
+      --out persona/curation/existing_data/raw/psa_ph/psa_ph.jsonl \
+      --check psa_ph
+
+    # WVS Wave 7 (pooled file -> Philippines only, trimmed to the used columns)
+    python persona/curation/existing_data/scripts/microdata_to_jsonl.py \
+      --src persona/curation/existing_data/raw/wvs_ph/WVS_Cross-National_Wave_7_stata_v6_0.dta \
+      --out persona/curation/existing_data/raw/wvs_ph/wvs_ph.jsonl \
+      --preset wvs --check wvs_ph
+
+``--check`` loads the named crosswalk and reports, on a sample, which alias
+resolved from which source column and how often each dimension came out
+observed. Run it *before* the full pipeline: a dimension at 0% almost always
+means this release names the column something the alias table has not seen,
+which is a one-line fix in the crosswalk rather than a silent hole in the data.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import io
+import json
+import os
+import sys
+import zipfile
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+
+# WV7 columns the wvs_ph crosswalk reads, plus identifiers/country filter.
+WVS_KEEP = [
+    "D_INTERVIEW", "B_COUNTRY_ALPHA", "B_COUNTRY",
+    "Q262", "Q260", "Q263", "Q266", "Q290", "H_URBRURAL",
+    "Q273", "Q274", "Q275", "Q288", "Q279", "Q289",
+    "Q173", "Q164", "Q199", "Q57",
+]
+
+DATA_SUFFIXES = {".dta", ".sav", ".csv", ".tsv", ".txt", ".gz"}
+
+
+def _log(msg):
+    print(msg, file=sys.stderr)
+
+
+# --------------------------------------------------------------------------
+# reading
+# --------------------------------------------------------------------------
+
+def _resolve_zip_member(path, member):
+    """Pick the data file inside a zip; largest data-like member by default."""
+    with zipfile.ZipFile(path) as zf:
+        entries = [i for i in zf.infolist() if not i.is_dir()]
+        if member:
+            match = [i for i in entries if i.filename == member or i.filename.endswith("/" + member)]
+            if not match:
+                names = "\n  ".join(i.filename for i in entries)
+                raise SystemExit(f"--member {member!r} not found in {path}. Members:\n  {names}")
+            chosen = match[0]
+        else:
+            data = [i for i in entries if Path(i.filename).suffix.lower() in DATA_SUFFIXES]
+            if not data:
+                names = "\n  ".join(i.filename for i in entries)
+                raise SystemExit(
+                    f"No .dta/.sav/.csv member in {path}. Pass --member explicitly. Members:\n  {names}"
+                )
+            chosen = max(data, key=lambda i: i.file_size)
+            if len(data) > 1:
+                _log(f"  zip has {len(data)} data members; picked largest: {chosen.filename}")
+                _log("  (pass --member to choose a different one — CPH ships household and person files together)")
+        _log(f"  extracting {chosen.filename} ({chosen.file_size / 1e6:.1f} MB) into memory")
+        return chosen.filename, io.BytesIO(zf.read(chosen))
+
+
+def _read_stata(src, chunksize):
+    import pandas as pd
+
+    # Stata files from PSA/WVS frequently carry duplicate or malformed value
+    # labels; decoding then fails outright. Fall back to raw codes, which the
+    # crosswalks accept just as well as decoded labels.
+    for categoricals in (True, False):
+        try:
+            return pd.read_stata(src, convert_categoricals=categoricals, chunksize=chunksize), categoricals
+        except ValueError as exc:
+            if categoricals and "unique" in str(exc).lower():
+                _log(f"  value labels not decodable ({exc}); re-reading with numeric codes")
+                if hasattr(src, "seek"):
+                    src.seek(0)
+                continue
+            raise
+    raise SystemExit("unreachable")
+
+
+def _iter_frames(src, suffix, chunksize, encoding):
+    """Yield DataFrames. Chunked for Stata/CSV so a census-sized file streams."""
+    import pandas as pd
+
+    if suffix == ".dta":
+        reader, decoded = _read_stata(src, chunksize)
+        _log(f"  stata: value labels {'decoded' if decoded else 'kept as numeric codes'}")
+        with reader:
+            yield from reader
+    elif suffix == ".sav":
+        try:
+            import pyreadstat  # noqa: F401
+        except ImportError:
+            raise SystemExit(
+                "Reading .sav needs pyreadstat:  pip install pyreadstat\n"
+                "(Or re-export the file as .dta/.csv from the provider.)"
+            )
+        # pandas.read_spss has no chunksize; SPSS PUFs are survey-sized, so
+        # this is acceptable where a census-sized .dta would not be.
+        yield pd.read_spss(src, convert_categoricals=True)
+    else:
+        # .txt PUFs use an unadvertised delimiter; sniffing needs the python engine.
+        kwargs = {"sep": None, "engine": "python"} if suffix == ".txt" else {
+            "sep": "\t" if suffix == ".tsv" else ","
+        }
+        try:
+            reader = pd.read_csv(src, chunksize=chunksize, encoding=encoding, **kwargs)
+        except UnicodeDecodeError:
+            _log(f"  {encoding} decode failed; retrying as latin-1")
+            if hasattr(src, "seek"):
+                src.seek(0)
+            reader = pd.read_csv(src, chunksize=chunksize, encoding="latin-1", **kwargs)
+        if chunksize is None:
+            yield reader
+        else:
+            yield from reader
+
+
+def read_source(path, member=None, chunksize=200_000, encoding="utf-8"):
+    path = Path(path)
+    if not path.exists():
+        raise SystemExit(f"source not found: {path}")
+    if path.suffix.lower() == ".zip":
+        name, buf = _resolve_zip_member(path, member)
+        suffix = Path(name).suffix.lower()
+        if suffix == ".sav":
+            raise SystemExit(
+                "pandas cannot read .sav from memory — unzip first:\n"
+                f"  unzip -j {path} '{name}' -d {path.parent}"
+            )
+        return _iter_frames(buf, suffix, chunksize, encoding)
+    suffix = path.suffix.lower()
+    if suffix == ".gz":
+        inner = Path(path.stem).suffix.lower() or ".csv"
+        return _iter_frames(gzip.open(path, "rb"), inner, chunksize, encoding)
+    if suffix not in DATA_SUFFIXES:
+        raise SystemExit(f"unsupported extension {suffix!r} (want .dta/.sav/.csv/.tsv/.zip/.gz)")
+    return _iter_frames(str(path), suffix, chunksize, encoding)
+
+
+# --------------------------------------------------------------------------
+# alias / dimension coverage
+# --------------------------------------------------------------------------
+
+def _load_crosswalk(name):
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    sys.path.insert(0, str(SCRIPTS_DIR / "crosswalks"))
+    import importlib
+
+    return importlib.import_module(name)
+
+
+def _schema_path():
+    return SCRIPTS_DIR.parent.parent.parent / "schema" / "dimensions.json"
+
+
+class CoverageReport:
+    """Which aliases resolved, and how often each dimension came out observed."""
+
+    def __init__(self, module_name):
+        self.module = _load_crosswalk(module_name)
+        self.name = module_name
+        from crosswalk_engine import load_allowed  # noqa: E402
+
+        self.allowed = load_allowed(str(_schema_path()))
+        self.rows = 0
+        self.observed = {}
+        self.unmapped = {}
+        self.alias_hits = {}
+        self.src_cols = set()
+
+    def add(self, records):
+        from crosswalk_engine import apply_crosswalk  # noqa: E402
+
+        crosswalk = self.module.CROSSWALK
+        for raw in records:
+            self.src_cols.update(raw.keys())
+            flat = self.module.flatten(raw)
+            # A canonical key the crosswalk reads that was absent pre-flatten
+            # was supplied by an alias — worth reporting either way.
+            for key in flat:
+                if flat.get(key) is not None:
+                    self.alias_hits[key] = self.alias_hits.get(key, 0) + 1
+            obs, _prov, unmapped = apply_crosswalk(flat, crosswalk, self.allowed)
+            self.rows += 1
+            for dim in obs:
+                self.observed[dim] = self.observed.get(dim, 0) + 1
+            for dim, val in unmapped.items():
+                self.unmapped.setdefault(dim, {})
+                token = str(val)[:40]
+                self.unmapped[dim][token] = self.unmapped[dim].get(token, 0) + 1
+
+    def render(self):
+        if not self.rows:
+            return "no rows sampled"
+        out = [f"\n=== {self.name} coverage over {self.rows:,} sampled rows ==="]
+        crosswalk = self.module.CROSSWALK
+        dead = []
+        for dim in crosswalk:
+            n = self.observed.get(dim, 0)
+            pct = 100.0 * n / self.rows
+            flag = "  <-- never observed" if n == 0 else ""
+            if n == 0:
+                dead.append(dim)
+            out.append(f"  {dim:<32} {pct:6.1f}%  ({n:,}){flag}")
+        # Source columns the crosswalk reads directly, so drift is obvious.
+        wanted = {spec["src"] for spec in crosswalk.values() if "src" in spec}
+        missing = sorted(c for c in wanted if c not in self.alias_hits)
+        if missing:
+            out.append(f"\n  source keys never populated: {', '.join(missing)}")
+        if self.unmapped:
+            out.append("\n  values seen but not in the map (top 5 each):")
+            for dim, counts in sorted(self.unmapped.items()):
+                top = sorted(counts.items(), key=lambda kv: -kv[1])[:5]
+                pairs = ", ".join(f"{v!r}x{c}" for v, c in top)
+                out.append(f"    {dim}: {pairs}")
+        if dead:
+            out.append(
+                "\n  ACTION: dimensions at 0% usually mean this release names the column "
+                "differently.\n  Check the codebook and add the real name to the alias table in "
+                f"crosswalks/{self.name}.py."
+            )
+        return "\n".join(out)
+
+
+# --------------------------------------------------------------------------
+# main
+# --------------------------------------------------------------------------
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        description="Convert Stata/SPSS/CSV microdata to one-person-per-row JSONL.",
+        epilog="Downloads nothing. Obtain files under the provider's terms first.",
+    )
+    ap.add_argument("--src", required=True, help="path to .dta/.sav/.csv/.tsv/.zip/.gz")
+    ap.add_argument("--out", required=True, help="output .jsonl (or .jsonl.gz)")
+    ap.add_argument("--member", help="file inside --src zip (default: largest data member)")
+    ap.add_argument("--preset", choices=["psa", "wvs"], help="wvs: keep WV7 columns and filter to PHL")
+    ap.add_argument("--keep", help="comma-separated columns to keep (default: all)")
+    ap.add_argument("--filter-col", help="keep rows where this column matches --filter-val")
+    ap.add_argument("--filter-val", help="comma-separated accepted values, case-insensitive")
+    ap.add_argument("--check", help="crosswalk module to report coverage for, e.g. psa_ph / wvs_ph")
+    ap.add_argument("--check-sample", type=int, default=20_000, help="rows to sample for --check")
+    ap.add_argument("--limit", type=int, help="stop after N output rows (smoke tests)")
+    ap.add_argument("--chunksize", type=int, default=200_000, help="rows per read chunk")
+    ap.add_argument("--encoding", default="utf-8")
+    ap.add_argument("--columns-only", action="store_true", help="print column names and exit")
+    args = ap.parse_args(argv)
+
+    keep = [c.strip() for c in args.keep.split(",")] if args.keep else None
+    filter_col, filter_vals = args.filter_col, None
+    if args.preset == "wvs":
+        keep = keep or WVS_KEEP
+        filter_col = filter_col or "B_COUNTRY_ALPHA"
+        filter_vals = {"phl", "philippines", "608"}
+    if args.filter_val:
+        filter_vals = {v.strip().lower() for v in args.filter_val.split(",")}
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    _log(f"reading {args.src}")
+
+    frames = read_source(args.src, args.member, args.chunksize, args.encoding)
+    report = CoverageReport(args.check) if args.check else None
+
+    opener = gzip.open if out_path.suffix == ".gz" else open
+    written = dropped = 0
+    seen_cols = None
+    try:
+        with opener(out_path, "wt", encoding="utf-8") as fh:
+            for frame in frames:
+                if seen_cols is None:
+                    seen_cols = list(frame.columns)
+                    _log(f"  {len(seen_cols)} columns")
+                    if args.columns_only:
+                        print("\n".join(seen_cols))
+                        frames.close()  # else the half-consumed StataReader warns on GC
+                        return 0
+                if filter_col:
+                    if filter_col not in frame.columns:
+                        raise SystemExit(
+                            f"--filter-col {filter_col!r} not in file. Columns include: "
+                            f"{', '.join(map(str, seen_cols[:25]))} ...\n"
+                            "For a single-country WVS file no filter is needed — drop --preset wvs "
+                            "and pass --keep instead."
+                        )
+                    before = len(frame)
+                    mask = frame[filter_col].astype(str).str.strip().str.lower().isin(filter_vals)
+                    frame = frame[mask]
+                    dropped += before - len(frame)
+                if keep:
+                    present = [c for c in keep if c in frame.columns]
+                    if not present:
+                        raise SystemExit(
+                            f"none of --keep found. Columns include: {', '.join(map(str, seen_cols[:25]))} ..."
+                        )
+                    if written == 0:
+                        absent = [c for c in keep if c not in frame.columns]
+                        if absent:
+                            _log(f"  --keep columns absent from file (skipped): {', '.join(absent)}")
+                    frame = frame[present]
+                if frame.empty:
+                    continue
+
+                # to_json per-chunk keeps NaN -> null and non-ASCII intact.
+                payload = frame.to_json(orient="records", lines=True, force_ascii=False)
+                for line in payload.splitlines():
+                    if args.limit and written >= args.limit:
+                        break
+                    fh.write(line + "\n")
+                    written += 1
+                if report and report.rows < args.check_sample:
+                    room = args.check_sample - report.rows
+                    report.add(json.loads(l) for l in payload.splitlines()[:room])
+                if args.limit and written >= args.limit:
+                    break
+    except Exception:
+        # Never leave a truncated JSONL that looks like a complete extraction.
+        if out_path.exists() and written == 0:
+            out_path.unlink()
+        raise
+
+    if written == 0:
+        raise SystemExit(
+            "0 rows written."
+            + (f" {dropped:,} rows dropped by --filter-col {filter_col}." if dropped else "")
+            + "\nIf this is a WVS country file it holds only PHL already — drop --preset wvs."
+        )
+
+    _log(f"\n✓ wrote {written:,} rows -> {out_path}")
+    if dropped:
+        _log(f"  filtered out {dropped:,} rows on {filter_col}")
+    if report:
+        _log(report.render())
+    _log("\nNext:")
+    _log(f"  python {SCRIPTS_DIR}/run_pipeline.py \\")
+    _log(f"    --source {out_path} \\")
+    _log(f"    --dataset {SCRIPTS_DIR}/crosswalks/{args.check or '<crosswalk>'}.py \\")
+    _log(f"    --schema {_schema_path()} \\")
+    _log(f"    --out {out_path.parent}/extraction_v1/shard_00.jsonl.gz --observed-only")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/persona/curation/existing_data/scripts/microdata_to_jsonl.py
+++ b/persona/curation/existing_data/scripts/microdata_to_jsonl.py
@@ -33,7 +33,6 @@ import argparse
 import gzip
 import io
 import json
-import os
 import sys
 import zipfile
 from pathlib import Path
@@ -375,7 +374,7 @@ def main(argv=None):
                     written += 1
                 if report and report.rows < args.check_sample:
                     room = args.check_sample - report.rows
-                    report.add(json.loads(l) for l in payload.splitlines()[:room])
+                    report.add(json.loads(row) for row in payload.splitlines()[:room])
                 if args.limit and written >= args.limit:
                     break
     except Exception:

--- a/persona/curation/existing_data/scripts/microdata_to_jsonl.py
+++ b/persona/curation/existing_data/scripts/microdata_to_jsonl.py
@@ -41,9 +41,15 @@ from pathlib import Path
 SCRIPTS_DIR = Path(__file__).resolve().parent
 
 # WV7 columns the wvs_ph crosswalk reads, plus identifiers/country filter.
+# Q272 is "Language at home"; Q266 is country of birth. Both are kept, but they
+# are not interchangeable — see _home_language in crosswalks/wvs_ph.py.
+#
+# W_WEIGHT is the within-country weight and must be kept: WV7 quota-samples sex
+# (the PH release is exactly 600 men / 600 women), so an unweighted margin
+# reports the sample design rather than the country.
 WVS_KEEP = [
-    "D_INTERVIEW", "B_COUNTRY_ALPHA", "B_COUNTRY",
-    "Q262", "Q260", "Q263", "Q266", "Q290", "H_URBRURAL",
+    "D_INTERVIEW", "B_COUNTRY_ALPHA", "B_COUNTRY", "W_WEIGHT", "PWGHT",
+    "Q262", "Q260", "Q263", "Q266", "Q272", "Q290", "H_URBRURAL",
     "Q273", "Q274", "Q275", "Q288", "Q279", "Q289",
     "Q173", "Q164", "Q199", "Q57",
 ]
@@ -84,34 +90,44 @@ def _resolve_zip_member(path, member):
         return chosen.filename, io.BytesIO(zf.read(chosen))
 
 
-def _read_stata(src, chunksize):
+def _stata_frames(src, chunksize, categoricals=None):
+    """Yield Stata chunks, falling back to numeric codes if labels will not decode.
+
+    Real PSA/WVS releases carry value-label blocks pandas cannot parse (the WVS
+    Wave 7 PH v5.1 file raises "buffer is smaller than requested size"). The
+    failure surfaces while *iterating*, not when the reader is constructed, so
+    guarding only construction misses it. The crosswalks accept raw codes just
+    as well as decoded labels, so dropping to numeric loses nothing.
+    """
     import pandas as pd
 
-    # Stata files from PSA/WVS frequently carry duplicate or malformed value
-    # labels; decoding then fails outright. Fall back to raw codes, which the
-    # crosswalks accept just as well as decoded labels.
-    for categoricals in (True, False):
+    modes = (True, False) if categoricals is None else (categoricals,)
+    for mode in modes:
+        emitted = False
         try:
-            return pd.read_stata(src, convert_categoricals=categoricals, chunksize=chunksize), categoricals
+            if hasattr(src, "seek"):
+                src.seek(0)
+            reader = pd.read_stata(src, convert_categoricals=mode, chunksize=chunksize)
+            with reader:
+                for frame in reader:
+                    if not emitted:
+                        _log(f"  stata: value labels {'decoded' if mode else 'kept as numeric codes'}")
+                    emitted = True
+                    yield frame
+            return
         except ValueError as exc:
-            if categoricals and "unique" in str(exc).lower():
-                _log(f"  value labels not decodable ({exc}); re-reading with numeric codes")
-                if hasattr(src, "seek"):
-                    src.seek(0)
-                continue
-            raise
-    raise SystemExit("unreachable")
+            # Restarting after rows were handed out would duplicate them.
+            if mode is False or emitted:
+                raise
+            _log(f"  value labels unreadable ({exc}); re-reading with numeric codes")
 
 
-def _iter_frames(src, suffix, chunksize, encoding):
+def _iter_frames(src, suffix, chunksize, encoding, categoricals=None, sep=None):
     """Yield DataFrames. Chunked for Stata/CSV so a census-sized file streams."""
     import pandas as pd
 
     if suffix == ".dta":
-        reader, decoded = _read_stata(src, chunksize)
-        _log(f"  stata: value labels {'decoded' if decoded else 'kept as numeric codes'}")
-        with reader:
-            yield from reader
+        yield from _stata_frames(src, chunksize, categoricals)
     elif suffix == ".sav":
         try:
             import pyreadstat  # noqa: F401
@@ -125,23 +141,34 @@ def _iter_frames(src, suffix, chunksize, encoding):
         yield pd.read_spss(src, convert_categoricals=True)
     else:
         # .txt PUFs use an unadvertised delimiter; sniffing needs the python engine.
-        kwargs = {"sep": None, "engine": "python"} if suffix == ".txt" else {
-            "sep": "\t" if suffix == ".tsv" else ","
-        }
+        if sep:
+            kwargs = {"sep": sep}
+        elif suffix == ".txt":
+            kwargs = {"sep": None, "engine": "python"}
+        else:
+            kwargs = {"sep": "\t" if suffix == ".tsv" else ","}
         try:
-            reader = pd.read_csv(src, chunksize=chunksize, encoding=encoding, **kwargs)
+            # index_col=False is essential, not cosmetic: a trailing delimiter
+            # makes data rows one field wider than the header (the WVS text
+            # export does this), and pandas then silently promotes the first
+            # column to an index, shifting every value one column left.
+            reader = pd.read_csv(
+                src, chunksize=chunksize, encoding=encoding, index_col=False, **kwargs
+            )
         except UnicodeDecodeError:
             _log(f"  {encoding} decode failed; retrying as latin-1")
             if hasattr(src, "seek"):
                 src.seek(0)
-            reader = pd.read_csv(src, chunksize=chunksize, encoding="latin-1", **kwargs)
+            reader = pd.read_csv(
+                src, chunksize=chunksize, encoding="latin-1", index_col=False, **kwargs
+            )
         if chunksize is None:
             yield reader
         else:
             yield from reader
 
 
-def read_source(path, member=None, chunksize=200_000, encoding="utf-8"):
+def read_source(path, member=None, chunksize=200_000, encoding="utf-8", categoricals=None, sep=None):
     path = Path(path)
     if not path.exists():
         raise SystemExit(f"source not found: {path}")
@@ -153,14 +180,14 @@ def read_source(path, member=None, chunksize=200_000, encoding="utf-8"):
                 "pandas cannot read .sav from memory — unzip first:\n"
                 f"  unzip -j {path} '{name}' -d {path.parent}"
             )
-        return _iter_frames(buf, suffix, chunksize, encoding)
+        return _iter_frames(buf, suffix, chunksize, encoding, categoricals, sep)
     suffix = path.suffix.lower()
     if suffix == ".gz":
         inner = Path(path.stem).suffix.lower() or ".csv"
-        return _iter_frames(gzip.open(path, "rb"), inner, chunksize, encoding)
+        return _iter_frames(gzip.open(path, "rb"), inner, chunksize, encoding, categoricals, sep)
     if suffix not in DATA_SUFFIXES:
         raise SystemExit(f"unsupported extension {suffix!r} (want .dta/.sav/.csv/.tsv/.zip/.gz)")
-    return _iter_frames(str(path), suffix, chunksize, encoding)
+    return _iter_frames(str(path), suffix, chunksize, encoding, categoricals, sep)
 
 
 # --------------------------------------------------------------------------
@@ -269,6 +296,12 @@ def main(argv=None):
     ap.add_argument("--limit", type=int, help="stop after N output rows (smoke tests)")
     ap.add_argument("--chunksize", type=int, default=200_000, help="rows per read chunk")
     ap.add_argument("--encoding", default="utf-8")
+    ap.add_argument("--sep", help="column separator (WVS text exports use ';')")
+    ap.add_argument("--header-code", action="store_true",
+                    help="use the first token of each header as the column name "
+                         "(WVS text exports ship headers like 'Q272 Language at home')")
+    ap.add_argument("--numeric-codes", action="store_true",
+                    help="skip Stata value-label decoding (crosswalks accept raw codes)")
     ap.add_argument("--columns-only", action="store_true", help="print column names and exit")
     args = ap.parse_args(argv)
 
@@ -285,7 +318,11 @@ def main(argv=None):
     out_path.parent.mkdir(parents=True, exist_ok=True)
     _log(f"reading {args.src}")
 
-    frames = read_source(args.src, args.member, args.chunksize, args.encoding)
+    frames = read_source(
+        args.src, args.member, args.chunksize, args.encoding,
+        categoricals=False if args.numeric_codes else None,
+        sep=args.sep,
+    )
     report = CoverageReport(args.check) if args.check else None
 
     opener = gzip.open if out_path.suffix == ".gz" else open
@@ -294,6 +331,8 @@ def main(argv=None):
     try:
         with opener(out_path, "wt", encoding="utf-8") as fh:
             for frame in frames:
+                if args.header_code:
+                    frame = frame.rename(columns=lambda c: str(c).split(" ")[0].strip())
                 if seen_cols is None:
                     seen_cols = list(frame.columns)
                     _log(f"  {len(seen_cols)} columns")

--- a/tests/persona/curation/existing_data/test_philippines_crosswalks.py
+++ b/tests/persona/curation/existing_data/test_philippines_crosswalks.py
@@ -136,11 +136,49 @@ def test_ndhs_ph_rejects_dhs_missing_codes(allowed):
     for dim in ("age_bracket", "gender_identity", "urbanicity", "highest_education", "socioeconomic_band"):
         assert dim not in obs, dim
 
-    # v130 / v131 are country-specific code lists, so bare numbers are not labels
-    numeric = ndhs_ph.flatten({"hv105": 30, "v130": 1, "v131": 2})
-    obs2 = apply_crosswalk(numeric, ndhs_ph.CROSSWALK, allowed)[0]
+    # codes with no schema home stay unobserved (v130 96 "Other",
+    # v131 88 "Other Nationality")
+    unplaceable = ndhs_ph.flatten({"hv105": 30, "v130": 96, "v131": 88})
+    obs2 = apply_crosswalk(unplaceable, ndhs_ph.CROSSWALK, allowed)[0]
     assert "demo_religion_affiliation" not in obs2
     assert "demo_ethnicity_broad" not in obs2
+
+
+def test_ndhs_ph_uses_verified_ph2022_code_lists(allowed):
+    """Numeric maps come from the PH-2022 DDI codebook, not the DHS generic defaults."""
+    row = ndhs_ph.flatten(
+        {"hv105": 30, "hv024": 13, "hv025": 1, "v130": 5, "v131": 2, "v045c": 2}
+    )
+    obs = apply_crosswalk(row, ndhs_ph.CROSSWALK, allowed)[0]
+    assert obs["urbanicity"] == "Dense urban"  # hv024 13 = National Capital Region
+    assert obs["demo_religion_affiliation"] == "Muslim"  # v130 5 = Islam
+    assert obs["demo_ethnicity_broad"] == "Southeast Asian"  # v131 2 = Cebuano
+    assert obs["lang_tagalog"] == "Native"  # v045c 2 = Tagalog
+
+
+def test_ndhs_ph_marital_codes_differ_between_files(allowed):
+    """hv115 and v501 assign different meanings to code 4.
+
+    PH-2022 hv115 code 4 is the combined "Divorced/annulled/separated" and has
+    no code 5; divorce is not available in the Philippines. v501 code 4 is a
+    clean "Divorced". Sharing one map between them mislabels the household file.
+    """
+    hh = ndhs_ph.flatten({"hv105": 40, "hv115": 4})
+    assert apply_crosswalk(hh, ndhs_ph.CROSSWALK, allowed)[0]["demo_marital_status"] == "Separated"
+
+    ind = ndhs_ph.flatten({"v012": 40, "v501": 4})
+    assert apply_crosswalk(ind, ndhs_ph.CROSSWALK, allowed)[0]["demo_marital_status"] == "Divorced"
+
+    sep = ndhs_ph.flatten({"v012": 40, "v501": 5})
+    assert apply_crosswalk(sep, ndhs_ph.CROSSWALK, allowed)[0]["demo_marital_status"] == "Separated"
+
+
+def test_ndhs_ph_interview_language_is_not_native_language(allowed):
+    """v045b is the language the interview was conducted in, not v045c native language."""
+    row = ndhs_ph.flatten({"hv105": 30, "v045b": 2})
+    obs = apply_crosswalk(row, ndhs_ph.CROSSWALK, allowed)[0]
+    assert "lang_tagalog" not in obs
+    assert "english_proficiency" not in obs
 
 
 def test_wvs_and_psa_selftests():

--- a/tests/persona/curation/existing_data/test_philippines_crosswalks.py
+++ b/tests/persona/curation/existing_data/test_philippines_crosswalks.py
@@ -1,0 +1,148 @@
+"""Philippines ingest: WVS-PH / PSA crosswalks and the Playground strategy file."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from persona.curation.existing_data.scripts.crosswalk_engine import (
+    apply_crosswalk,
+    load_allowed,
+)
+from persona.curation.existing_data.scripts.crosswalks import ndhs_ph, psa_ph, wvs_ph
+
+REPO = Path(__file__).resolve().parents[4]
+SCHEMA = REPO / "persona" / "schema" / "dimensions.json"
+STRATEGY = (
+    REPO
+    / "persona"
+    / "curation"
+    / "existing_data"
+    / "philippines"
+    / "persona_strategy.json"
+)
+SAMPLES = REPO / "persona" / "curation" / "existing_data" / "samples" / "philippines"
+
+
+@pytest.fixture(scope="module")
+def allowed():
+    return load_allowed(str(SCHEMA))
+
+
+def test_strategy_filters_are_schema_values(allowed):
+    strategy = json.loads(STRATEGY.read_text(encoding="utf-8"))
+    filters = strategy["dimensionFilters"]
+    sampling = strategy["sampling"]
+    assert sampling["fields"]
+    for field in sampling["fields"]:
+        assert field in filters
+    for dim, values in filters.items():
+        assert dim in allowed, dim
+        for value in values:
+            assert value in allowed[dim], (dim, value)
+
+
+def test_wvs_ph_sample_rows(allowed):
+    rows = [
+        json.loads(line)
+        for line in (SAMPLES / "wvs_ph_sample.jsonl").read_text().splitlines()
+        if line.strip()
+    ]
+    ph, student, usa = (wvs_ph.flatten(r) for r in rows)
+
+    obs, _, unmapped = apply_crosswalk(ph, wvs_ph.CROSSWALK, allowed)
+    assert unmapped == {}
+    assert obs["region"] == "Southeast Asia"
+    assert obs["cult_philippines"] == "Native"
+    assert obs["lang_tagalog"] == "Native"
+    assert obs["gender_identity"] == "Woman"
+
+    obs_s, _, _ = apply_crosswalk(student, wvs_ph.CROSSWALK, allowed)
+    assert obs_s["cult_philippines"] == "Lived there"  # born elsewhere, interviewed in PH
+    assert obs_s["english_proficiency"] == "Native"
+    assert "lang_tagalog" not in obs_s
+    assert "urbanicity" not in obs_s  # urban too coarse
+    assert obs_s["demo_employment_status"] == "Student"
+
+    obs_us, _, _ = apply_crosswalk(usa, wvs_ph.CROSSWALK, allowed)
+    assert "region" not in obs_us
+    assert "cult_philippines" not in obs_us
+
+
+def test_psa_ph_sample_rows(allowed):
+    rows = [
+        json.loads(line)
+        for line in (SAMPLES / "psa_ph_sample.jsonl").read_text().splitlines()
+        if line.strip()
+    ]
+    ncr, visayas, luzon = (psa_ph.flatten(r) for r in rows)
+
+    ncr_obs, _, unmapped = apply_crosswalk(ncr, psa_ph.CROSSWALK, allowed)
+    assert unmapped == {}
+    assert ncr_obs["urbanicity"] == "Dense urban"
+    assert ncr_obs["lang_tagalog"] == "Native"
+    assert ncr_obs["highest_education"] == "Bachelor's"
+
+    vis = apply_crosswalk(visayas, psa_ph.CROSSWALK, allowed)[0]
+    assert vis["age_bracket"] == "5-12"
+    assert vis["urbanicity"] == "Rural"
+    assert vis["demo_religion_affiliation"] == "Muslim"
+    assert "lang_tagalog" not in vis
+
+    luz = apply_crosswalk(luzon, psa_ph.CROSSWALK, allowed)[0]
+    # urban, not NCR, no province column -> the HUC / commuter-belt rules cannot
+    # fire, so it degrades to Small town rather than going unobserved
+    assert luz["urbanicity"] == "Small town"
+    assert luz["highest_education"] == "Some college"
+    assert luz["demo_marital_status"] == "Domestic partnership"
+    assert luz["demo_religion_affiliation"] == "Christian"
+
+
+def test_ndhs_ph_sample_rows(allowed):
+    rows = [
+        json.loads(line)
+        for line in (SAMPLES / "ndhs_ph_sample.jsonl").read_text().splitlines()
+        if line.strip()
+    ]
+    pr, ir, elder = (ndhs_ph.flatten(r) for r in rows)
+
+    pr_obs, _, unmapped = apply_crosswalk(pr, ndhs_ph.CROSSWALK, allowed)
+    assert unmapped == {}
+    assert pr_obs["age_bracket"] == "35-44"
+    assert pr_obs["gender_identity"] == "Woman"
+    assert pr_obs["urbanicity"] == "Dense urban"  # NCR
+    assert pr_obs["socioeconomic_band"] == "High income"  # wealth quintile 5
+
+    ir_obs = apply_crosswalk(ir, ndhs_ph.CROSSWALK, allowed)[0]
+    assert ir_obs["urbanicity"] == "Rural"
+    assert ir_obs["socioeconomic_band"] == "Low income"
+    assert ir_obs["demo_children_count"] == "2 children"
+    assert ir_obs["demo_religion_affiliation"] == "Christian"
+    # DHS "higher" has no degree detail and must not be guessed at
+    assert "highest_education" not in ir_obs
+
+    eld = apply_crosswalk(elder, ndhs_ph.CROSSWALK, allowed)[0]
+    assert eld["age_bracket"] == "65-74"
+    assert eld["urbanicity"] == "Small town"  # urban, not NCR, no province
+    assert eld["demo_marital_status"] == "Widowed"
+
+
+def test_ndhs_ph_rejects_dhs_missing_codes(allowed):
+    """98/99 are don't-know codes; an unguarded cast makes them ages and levels."""
+    row = ndhs_ph.flatten({"hv105": 98, "hv104": 9, "hv025": 9, "hv109": 8, "hv270": 9})
+    obs = apply_crosswalk(row, ndhs_ph.CROSSWALK, allowed)[0]
+    for dim in ("age_bracket", "gender_identity", "urbanicity", "highest_education", "socioeconomic_band"):
+        assert dim not in obs, dim
+
+    # v130 / v131 are country-specific code lists, so bare numbers are not labels
+    numeric = ndhs_ph.flatten({"hv105": 30, "v130": 1, "v131": 2})
+    obs2 = apply_crosswalk(numeric, ndhs_ph.CROSSWALK, allowed)[0]
+    assert "demo_religion_affiliation" not in obs2
+    assert "demo_ethnicity_broad" not in obs2
+
+
+def test_wvs_and_psa_selftests():
+    wvs_ph._selftest()
+    psa_ph._selftest()


### PR DESCRIPTION
Adds the Philippines ingest path: crosswalks for PSA CPH, WVS Wave 7 and NDHS 2022, a converter for gated microdata, and calibration targets built from the 2020 census.

**No microdata is included, and none can be** — `raw/` admits only `.gitkeep`, verified with `git add -n` while a `.dta` and a `.jsonl` sat in it.

## Crosswalks

- **`psa_ph.py`** — demographic backbone. Urbanicity now reads locality on top of PSA's binary urban flag: NCR and the highly urbanized cities → `Dense urban`, the Metro Manila commuter belt → `Suburban`, other urban barangays → `Small town`. This takes urbanicity from **58.3% → 100%** coverage. The HUC list came from the 2020 CPH geography rather than memory, which caught two traps: Cebu, Iloilo and Cotabato share a name with the province around them and so require an explicit city marker (matching bare "Cebu" would have upgraded a 3.3M-person province), and Quezon is in neither set so the province is never read as Quezon City. Tribal religion maps to `Folk / traditional`.
- **`wvs_ph.py`** — values, trust, politics. Philippines-only; non-PH rows never receive `region` / `cult_philippines`.
- **`ndhs_ph.py`** — DHS recode, accepting both PR (`hv*`) and IR/MR (`v*`) spellings. DHS reserves 96-99 for don't-know, so `hv105 = 98` is a refusal, not a 98-year-old; an unguarded cast would silently produce `85+`. Country-specific items (`v130` religion, `v131` ethnicity) match decoded labels only, never raw numbers. Wealth quintile maps 1:1 onto `socioeconomic_band` — both are within-country relative measures.

## Tooling

- **`microdata_to_jsonl.py`** — `.dta`/`.sav`/`.csv`/`.zip`/`.gz` → one-person-per-row JSONL. Streams in chunks so a census-sized file does not exhaust memory, picks the person file out of a zip, and falls back to numeric codes when Stata value labels will not decode (common in these releases). `--check` reports per-dimension observed rates *before* extraction, so column drift across releases surfaces as a one-line alias fix instead of a silent hole. Downloads nothing.
- **`derive_targets_ph.py`** — derives targets from the source through the same crosswalk that produces the rows.

### Why derivation rather than hand-written targets

`rake_weights` sets `known = values >= 0`, counting **every** observed row in the denominator, but computes `desired` only over codes present in the target ([calibration.py:37-46](https://github.com/MatrAIx-ai/MatrAIx-Persona-8B/blob/main/persona/post_process/coreset_1m/calibration.py#L37-L46)). A target naming three of four urbanicity values therefore does not degrade conservatively — it skews the values it does name, with no error. Deriving from the same crosswalk makes that class of bug impossible.

This is also why widening `psa_ph` to four urbanicity values required retiring the two-category target in the same change.

## Targets

Age and sex come from the 2020 CPH via PSA's OpenStat API, reconciling to the published **108,667,043** household population exactly. UN WPP 2024 is used only to split CPH's 5-year bands at the schema boundaries (13, 18, 85). Religion comes from the CPH table, which also reconciles exactly.

`urbanicity` and `highest_education` are **deliberately empty**. An empty margin is skipped by calibration, which is the safe state; both are one command from correct once the PUF lands. `highest_education` is confirmed unavailable from public aggregates — the full OpenStat tree (199 nodes) has only LFS *employed persons* by grade completed (a biased base) and a table that turns out to publish literacy *rates* within attainment bands, not the distribution.

## Also ignored

`/data/` — 20 WVS questionnaires and codebooks (38 MB) fetched under a data-use agreement that forbids redistribution. These were untracked *and* unignored, so a future `git add -A` would have published them. Also ignores the generated `philippines-1m` dataset, consistent with how the repo already treats generated datasets.

## Verification

- 6 Philippines tests pass; all three crosswalk selftests pass
- Converter exercised end-to-end on synthetic PSA, pooled-WVS and DHS PR fixtures: zip member selection skipped a household decoy, PHL filtering dropped non-PHL rows and an extra column, weighted derivation produced sane margins
- Partial-margin behaviour verified through `rake_weights` on 200k simulated rows — observed-row distribution matches the normalized target to 4 decimal places
- Repo-wide: 136 passed. The 4 Amazon/assignment failures and the `test_merge_collab_results.py` collection error (`str | None` under Python 3.9.6) are pre-existing and untouched by this branch.

`persona/curation/existing_data/philippines/DOWNLOAD_RUNBOOK.md` has the click paths and commands for the three gated downloads, which still have to be done in a logged-in browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)