### PR TITLE
refactor(playground): migrate web and os-app cockpits to useCockpitLaunch, phase 2 of #47

### DIFF
--- a/application/playground/frontend/src/components/cockpit/OsAppEvalCockpit.tsx
+++ b/application/playground/frontend/src/components/cockpit/OsAppEvalCockpit.tsx
@@ -5,7 +5,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
-import { listOsAppEvalTasks, api, ApiError, harborTrialLiveScreenshotUrl } from "@/lib/api";
+import { listOsAppEvalTasks, api, harborTrialLiveScreenshotUrl } from "@/lib/api";
 import {
   cuaPersonaModelSelectOptions,
   DEFAULT_CUA_AGENT_MODEL,
@@ -34,20 +34,17 @@ import { OsAppEvalScorecard } from "./TaskEvalScorecard";
 import { CockpitSetupShell } from "./setup/CockpitSetupShell";
 import { PersonaSamplingRail } from "./setup/PersonaSamplingRail";
 import {
-  buildPersonaLaunchFields,
-  hasLaunchableCohort,
   resolveCohortSize,
 } from "./setup/personaLaunchFields";
 import { CockpitPipelineDiagram } from "./setup/CockpitPipelineDiagram";
 import { TaskSelectionRail } from "./setup/TaskSelectionRail";
 import { CockpitRunCenter } from "./setup/CockpitRunCenter";
-import { useSetupPersonaSampling } from "./setup/useSetupPersonaSampling";
+import { useCockpitLaunch } from "./setup/useCockpitLaunch";
 import {
   batchProgressPct as computeBatchProgressPct,
   BATCH_RUN_COMPLETE_HINT,
   formatBatchProgressLabel,
   resolveRunLaunchPhase,
-  useCockpitBatchJob,
 } from "./setup/useCockpitBatchJob";
 import { useCockpitRunCancel } from "./setup/useCockpitRunCancel";
 import { useCockpitSetupLock } from "./setup/useCockpitSetupLock";
@@ -116,7 +113,6 @@ export function OsAppEvalCockpit({
   const [cuaRuntimeByTaskId, setCuaRuntimeByTaskId] = useState<Record<string, string>>({});
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [tab, setTab] = useState<InspectorTab>("evaluation");
-  const [launchError, setLaunchError] = useState<string | null>(null);
   const [exportSnapshot, setExportSnapshot] = useState<{
     persona: { id: string; name: string; source: string } | null;
     taskId: string;
@@ -137,60 +133,66 @@ export function OsAppEvalCockpit({
   const setupTaskPath =
     tasks.find((item) => item.id === taskId)?.taskPath ?? null;
   const {
-    persona,
-    personaModel,
-    setPersonaModel,
-    personaModelOptions,
-    samplingMode,
-    setSamplingMode,
-    selectedPersonaIds,
-    setSelectedPersonaIds,
-    selectedCount,
-    setSelectedCount,
-    useEntirePool,
-    setUseEntirePool,
-    groupFilters,
-    setGroupFilters,
-    fields,
-    setFields,
-    stratifiedAllocation,
-    setStratifiedAllocation,
-    sampleSize,
-    setSampleSize,
-    perCell,
-    setPerCell,
-    seed,
-    parallelTrials,
-    setParallelTrials,
-    personaPool,
-    setPersonaPool,
-    isBatchRun,
-    hasTaskStrategy,
-    taskPersonaStrategy,
-    useTaskDefaultStrategy,
-    setUseTaskDefaultStrategy,
-  } = useSetupPersonaSampling(options, "os-app", setupTaskPath, isActive);
-  const {
-    batchJobName,
-    batchTaskId,
-    batchPersonaIds,
-    batchPersonaPool,
-    setBatchJobName,
-    clearBatch,
-    cancelBatch,
-    cancelBusy,
-    batchCancelled,
-    retryFailed,
-    retryBusy,
-    retryError,
-    failedTrials,
-    isBatchActive,
-    batchComplete,
-    batchGridCells,
-    expectedTrialCount,
-    completedTrials: batchCompletedTrials,
-    batchError,
-  } = useCockpitBatchJob(selectedPersonaIds, parallelTrials, "os-app", selectedCount, personaPool);
+    sampling: {
+      persona,
+      personaModel,
+      setPersonaModel,
+      personaModelOptions,
+      samplingMode,
+      setSamplingMode,
+      selectedPersonaIds,
+      setSelectedPersonaIds,
+      selectedCount,
+      setSelectedCount,
+      useEntirePool,
+      setUseEntirePool,
+      groupFilters,
+      setGroupFilters,
+      fields,
+      setFields,
+      stratifiedAllocation,
+      setStratifiedAllocation,
+      sampleSize,
+      setSampleSize,
+      perCell,
+      setPerCell,
+      seed,
+      parallelTrials,
+      setParallelTrials,
+      personaPool,
+      setPersonaPool,
+      isBatchRun,
+      hasTaskStrategy,
+      taskPersonaStrategy,
+      useTaskDefaultStrategy,
+      setUseTaskDefaultStrategy,
+    },
+    batch: {
+      batchJobName,
+      batchTaskId,
+      batchPersonaIds,
+      batchPersonaPool,
+      clearBatch,
+      cancelBatch,
+      cancelBusy,
+      batchCancelled,
+      retryFailed,
+      retryBusy,
+      retryError,
+      failedTrials,
+      isBatchActive,
+      batchComplete,
+      batchGridCells,
+      expectedTrialCount,
+      completedTrials: batchCompletedTrials,
+      batchError,
+    },
+    launchError,
+    setLaunchError,
+    clearLaunchError,
+    canLaunchCohort,
+    launchBatch,
+  } = useCockpitLaunch(options, "os-app", setupTaskPath, isActive);
 
 
   const { setupLocked, visiblePersonaIds } = useCockpitSetupLock(
@@ -274,38 +276,6 @@ export function OsAppEvalCockpit({
 
   const taskCards = useMemo(() => osAppTaskCards(tasks), [tasks]);
 
-  const harborLaunchBody = useCallback(
-    (targetTask: OsAppEvalTask) => {
-      const personaFields = buildPersonaLaunchFields({
-        personaPool,
-        selectedPersonaIds,
-        selectedCount,
-        useEntirePool,
-        parallelTrials,
-      });
-      return {
-        taskPath: targetTask.taskPath,
-        seed,
-        personaModel,
-        agentName: "persona-computer-1",
-        osAppBackend: resolveCuaRuntime(targetTask.id, targetTask.platform),
-        ...personaFields,
-        mode: "auto" as const,
-        osAppSubmissionProfile: targetTask.osAppSubmissionProfile ?? undefined,
-      };
-    },
-    [
-      selectedPersonaIds,
-      selectedCount,
-      useEntirePool,
-      seed,
-      personaModel,
-      resolveCuaRuntime,
-      parallelTrials,
-      personaPool,
-    ],
-  );
-
   const handleRun = useCallback(() => {
     if (!persona || !task || isRunning) return;
     setExportSnapshot(null);
@@ -329,43 +299,29 @@ export function OsAppEvalCockpit({
   }, [persona, task, isRunning, run, personaModel, activeCuaRuntime]);
 
   const handleLaunch = useCallback(async () => {
-    if (
-      !hasLaunchableCohort({ selectedPersonaIds, selectedCount, useEntirePool }) ||
-      !task ||
-      isRunning
-    ) {
+    if (!canLaunchCohort || !task || isRunning) {
       return;
     }
     if (isBatchRun) {
-      setLaunchError(null);
-      try {
-        const launched = await api.launchHarborJob(harborLaunchBody(task));
-        setBatchJobName(launched.jobName, { taskId: task.id, personaPool });
-      } catch (exc) {
-        const message = exc instanceof ApiError ? exc.message : exc instanceof Error ? exc.message : String(exc);
-        setLaunchError(message);
-      }
+      await launchBatch({
+        taskPath: task.taskPath,
+        taskId: task.id,
+        overrides: {
+          agentName: "persona-computer-1",
+          osAppBackend: resolveCuaRuntime(task.id, task.platform),
+          osAppSubmissionProfile: task.osAppSubmissionProfile ?? undefined,
+        },
+      });
       return;
     }
     handleRun();
-  }, [
-    selectedPersonaIds,
-    selectedCount,
-    useEntirePool,
-    task,
-    isRunning,
-    isBatchRun,
-    harborLaunchBody,
-    handleRun,
-    personaPool,
-    setBatchJobName,
-  ]);
+  }, [canLaunchCohort, task, isRunning, isBatchRun, resolveCuaRuntime, launchBatch, handleRun]);
 
   const handleNewRun = useCallback(() => {
     reset();
     clearBatch();
-    setLaunchError(null);
-  }, [reset, clearBatch]);
+    clearLaunchError();
+  }, [reset, clearBatch, clearLaunchError]);
 
   const { onCancelRun, cancelRunBusy } = useCockpitRunCancel({
     batchJobName,
@@ -543,7 +499,7 @@ export function OsAppEvalCockpit({
             batchJobName && batchComplete ? BATCH_RUN_COMPLETE_HINT : undefined
           }
           canRun={
-            hasLaunchableCohort({ selectedPersonaIds, selectedCount, useEntirePool }) &&
+            canLaunchCohort &&
             Boolean(task) &&
             !runBusy
           }

--- a/application/playground/frontend/src/components/cockpit/WebEvalCockpit.tsx
+++ b/application/playground/frontend/src/components/cockpit/WebEvalCockpit.tsx
@@ -19,7 +19,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
-import { listWebEvalTasks, api, ApiError } from "@/lib/api";
+import { listWebEvalTasks, api } from "@/lib/api";
 import {
   findPersonaAgent,
   personaModelPipelineLabel,
@@ -51,20 +51,17 @@ import { WebEvalScorecard } from "./TaskEvalScorecard";
 import { CockpitSetupShell } from "./setup/CockpitSetupShell";
 import { PersonaSamplingRail } from "./setup/PersonaSamplingRail";
 import {
-  buildPersonaLaunchFields,
-  hasLaunchableCohort,
   resolveCohortSize,
 } from "./setup/personaLaunchFields";
 import { CockpitPipelineDiagram } from "./setup/CockpitPipelineDiagram";
 import { TaskSelectionRail } from "./setup/TaskSelectionRail";
 import { CockpitRunCenter } from "./setup/CockpitRunCenter";
-import { useSetupPersonaSampling } from "./setup/useSetupPersonaSampling";
+import { useCockpitLaunch } from "./setup/useCockpitLaunch";
 import {
   batchProgressPct as computeBatchProgressPct,
   BATCH_RUN_COMPLETE_HINT,
   formatBatchProgressLabel,
   resolveRunLaunchPhase,
-  useCockpitBatchJob,
 } from "./setup/useCockpitBatchJob";
 import { useCockpitRunCancel } from "./setup/useCockpitRunCancel";
 import { useCockpitSetupLock } from "./setup/useCockpitSetupLock";
@@ -136,7 +133,6 @@ export function WebEvalCockpit({
   const [webAgentByTaskId, setWebAgentByTaskId] = useState<Record<string, string>>({});
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [tab, setTab] = useState<InspectorTab>("evaluation");
-  const [launchError, setLaunchError] = useState<string | null>(null);
   const [exportSnapshot, setExportSnapshot] = useState<{
     persona: { id: string; name: string; source: string } | null;
     taskId: string;
@@ -158,60 +154,66 @@ export function WebEvalCockpit({
   const setupTaskPath =
     tasks.find((item) => item.id === taskId)?.taskPath ?? null;
   const {
-    persona,
-    personaModel,
-    setPersonaModel,
-    personaModelOptions,
-    samplingMode,
-    setSamplingMode,
-    selectedPersonaIds,
-    setSelectedPersonaIds,
-    selectedCount,
-    setSelectedCount,
-    useEntirePool,
-    setUseEntirePool,
-    groupFilters,
-    setGroupFilters,
-    fields,
-    setFields,
-    stratifiedAllocation,
-    setStratifiedAllocation,
-    sampleSize,
-    setSampleSize,
-    perCell,
-    setPerCell,
-    seed,
-    parallelTrials,
-    setParallelTrials,
-    personaPool,
-    setPersonaPool,
-    isBatchRun,
-    hasTaskStrategy,
-    taskPersonaStrategy,
-    useTaskDefaultStrategy,
-    setUseTaskDefaultStrategy,
-  } = useSetupPersonaSampling(options, "web", setupTaskPath, isActive);
-  const {
-    batchJobName,
-    batchTaskId,
-    batchPersonaIds,
-    batchPersonaPool,
-    setBatchJobName,
-    clearBatch,
-    cancelBatch,
-    cancelBusy,
-    batchCancelled,
-    retryFailed,
-    retryBusy,
-    retryError,
-    failedTrials,
-    isBatchActive,
-    batchComplete,
-    batchGridCells,
-    expectedTrialCount,
-    completedTrials: batchCompletedTrials,
-    batchError,
-  } = useCockpitBatchJob(selectedPersonaIds, parallelTrials, "web", selectedCount, personaPool);
+    sampling: {
+      persona,
+      personaModel,
+      setPersonaModel,
+      personaModelOptions,
+      samplingMode,
+      setSamplingMode,
+      selectedPersonaIds,
+      setSelectedPersonaIds,
+      selectedCount,
+      setSelectedCount,
+      useEntirePool,
+      setUseEntirePool,
+      groupFilters,
+      setGroupFilters,
+      fields,
+      setFields,
+      stratifiedAllocation,
+      setStratifiedAllocation,
+      sampleSize,
+      setSampleSize,
+      perCell,
+      setPerCell,
+      seed,
+      parallelTrials,
+      setParallelTrials,
+      personaPool,
+      setPersonaPool,
+      isBatchRun,
+      hasTaskStrategy,
+      taskPersonaStrategy,
+      useTaskDefaultStrategy,
+      setUseTaskDefaultStrategy,
+    },
+    batch: {
+      batchJobName,
+      batchTaskId,
+      batchPersonaIds,
+      batchPersonaPool,
+      clearBatch,
+      cancelBatch,
+      cancelBusy,
+      batchCancelled,
+      retryFailed,
+      retryBusy,
+      retryError,
+      failedTrials,
+      isBatchActive,
+      batchComplete,
+      batchGridCells,
+      expectedTrialCount,
+      completedTrials: batchCompletedTrials,
+      batchError,
+    },
+    launchError,
+    setLaunchError,
+    clearLaunchError,
+    canLaunchCohort,
+    launchBatch,
+  } = useCockpitLaunch(options, "web", setupTaskPath, isActive);
 
 
   const { setupLocked, visiblePersonaIds } = useCockpitSetupLock(
@@ -340,60 +342,25 @@ export function WebEvalCockpit({
     });
   }, [persona, task, isRunning, run, personaModel, activeWebAgent]);
   const handleLaunch = useCallback(async () => {
-    if (
-      !hasLaunchableCohort({ selectedPersonaIds, selectedCount, useEntirePool }) ||
-      !task?.taskPath ||
-      isRunning
-    ) {
+    if (!canLaunchCohort || !task?.taskPath || isRunning) {
       return;
     }
     if (isBatchRun) {
-      setLaunchError(null);
-      try {
-        const personaFields = buildPersonaLaunchFields({
-          personaPool,
-          selectedPersonaIds,
-          selectedCount,
-          useEntirePool,
-          parallelTrials,
-        });
-        const launched = await api.launchHarborJob({
-          taskPath: task.taskPath,
-          seed,
-          personaModel,
-          agentName: activeWebAgent,
-          ...personaFields,
-          mode: "auto",
-        });
-        setBatchJobName(launched.jobName, { taskId: task.id, personaPool });
-      } catch (exc) {
-        const message = exc instanceof ApiError ? exc.message : exc instanceof Error ? exc.message : String(exc);
-        setLaunchError(message);
-      }
+      await launchBatch({
+        taskPath: task.taskPath,
+        taskId: task.id,
+        overrides: { agentName: activeWebAgent },
+      });
       return;
     }
     handleRun();
-  }, [
-    selectedPersonaIds,
-    selectedCount,
-    useEntirePool,
-    task,
-    isRunning,
-    isBatchRun,
-    seed,
-    personaModel,
-    activeWebAgent,
-    parallelTrials,
-    personaPool,
-    handleRun,
-    setBatchJobName,
-  ]);
+  }, [canLaunchCohort, task, isRunning, isBatchRun, activeWebAgent, launchBatch, handleRun]);
 
   const handleNewRun = useCallback(() => {
     reset();
     clearBatch();
-    setLaunchError(null);
-  }, [reset, clearBatch]);
+    clearLaunchError();
+  }, [reset, clearBatch, clearLaunchError]);
 
   const { onCancelRun, cancelRunBusy } = useCockpitRunCancel({
     batchJobName,
@@ -575,7 +542,7 @@ export function WebEvalCockpit({
             batchJobName && batchComplete ? BATCH_RUN_COMPLETE_HINT : undefined
           }
           canRun={
-            hasLaunchableCohort({ selectedPersonaIds, selectedCount, useEntirePool }) &&
+            canLaunchCohort &&
             Boolean(task?.taskPath) &&
             !runBusy
           }


### PR DESCRIPTION
## What

Phase 2 of #47, completing the launch consolidation started in #48: migrates the web and os-app cockpits to `useCockpitLaunch`. All four cockpits now share one launch assembly.

- **WebEvalCockpit**: same recipe as survey/chat; the web agent goes through `overrides: { agentName }`.
- **OsAppEvalCockpit**: the local `harborLaunchBody` helper is folded away entirely; its os-app extras (`agentName: "persona-computer-1"`, `osAppBackend` via `resolveCuaRuntime`, `osAppSubmissionProfile`) become `CockpitLaunchOverrides`, which already carried those fields since phase 1.

Behavior-preserving: no request field changes, no UI changes. This closes the per-cockpit duplication called out in #47; the next launch-shaped change lands in one file.

## Verified

- Frontend `tsc`: 0 errors; `npm run test`: green (including the new i18n suite); `npm run build`: green — the full playground-frontend CI sequence locally.
- The migrated code paths are line-for-line the same shape phase 1 landed and was reviewed against; web/os-app launch bodies preserve their exact prior fields (compared against the pre-migration call sites).

## Note for #66

With this, the i18n rework touches one launch site instead of four, as intended by the sequencing decision in #48.
