### PR TITLE
feat(cli): matraix results export + result.json docs fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,10 @@ uv pip install -e packages/rewardkit
 ```
 
 Run jobs and tasks with **`uv run matraix run …`** — it sets up the full
-launch environment and delegates to the Harbor runtime. Runtime utilities
-(e.g. `harbor view`, `harbor upload`) stay under `uv run harbor …`.
+launch environment and delegates to the Harbor runtime. Summarize a finished
+job with **`uv run matraix results <job>`** (text / JSON / CSV, no extra LLM
+call). Runtime utilities (e.g. `harbor view`, `harbor upload`) stay under
+`uv run harbor …`.
 
 Set the model API key matching your provider before GUI or CLI task runs
 (smoke test does not need one):

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -381,13 +381,23 @@ After a job finishes:
 
 ```text
 jobs/<job_name>/
-├── result.json           # Summary stats
+├── result.json           # Job summary stats (tokens/cost when recorded)
 ├── job.log
 └── <trial_name>/
-    ├── results.json      # Reward / verifier outcome
+    ├── result.json       # Trial reward / verifier outcome + agent usage
     ├── persona_meta.json # Which persona was used (if persona agent)
     └── artifacts/
         └── app/output/   # The agent's submission JSON
+            # Survey: survey_result.json
+```
+
+Summarize a finished job from the CLI (no extra LLM call):
+
+```bash
+uv run matraix results jobs/<job_name>
+uv run matraix results <job_name> --format json,csv -o /tmp/matraix-exports/
+# Optional persona cuts when dimensions are present:
+# uv run matraix results <job_name> --group-by life_stage --format json
 ```
 
 Open the submission JSON to read what that simulated user chose.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -391,7 +391,8 @@ jobs/<job_name>/
             # Survey: survey_result.json
 ```
 
-Summarize a finished job from the CLI (no extra LLM call):
+Summarize a finished job from the CLI (no extra LLM call). The same command works
+for Survey, Chat, Web, and OS-app jobs:
 
 ```bash
 uv run matraix results jobs/<job_name>
@@ -400,7 +401,20 @@ uv run matraix results <job_name> --format json,csv -o /tmp/matraix-exports/
 # uv run matraix results <job_name> --group-by life_stage --format json
 ```
 
-Open the submission JSON to read what that simulated user chose.
+`matraix results` prints a deterministic ledger (coverage, usage/cost, rewards,
+trial index, artifact paths) plus a thin type-aware outcome lens (question mixes,
+choice mixes, task-outcome mixes). JSON export uses schema `MatraixJobResults.v1`.
+It does **not** call another model and does **not** replace Playground or Harbor
+debug surfaces:
+
+| Surface | Job | Audience |
+|---------|-----|----------|
+| `matraix results` | Deterministic ledger + export | CLI / scripts / CI |
+| Playground **Runs** + **Download PDF** | Persona narrative + rich aggregation | Interactive product |
+| `harbor view` | Trajectory / logs / debugger | Runtime debug |
+
+Open the submission JSON under `artifacts/app/output/` to read what that
+simulated user chose.
 
 Refresh batch reporting:
 
@@ -422,7 +436,9 @@ uv run harbor view jobs --build
 ```
 
 Opens a local web UI listing jobs and trials — transcripts, artifacts, verifier
-logs. Use this to compare personas side by side.
+logs. Use this to compare personas side by side. Prefer `matraix results` when
+you need a scriptable summary; use `harbor view` when you need to step through
+trajectories and logs.
 
 To explore without spending API credits, browse checked-in examples under `jobs/`
 if present, or run the no-key smoke recipe from step 3.
@@ -590,6 +606,8 @@ Full task checklist: [tasks/README.md](../application/tasks/README.md).
 |------|------|--------|
 | Explore / debug visually | Playground (Mode **auto**) | `jobs/` |
 | Any of 4 types (terminal, single or batch) | `generate_application_job.py --execution-mode auto` + `matraix run -c` | `jobs/<job_name>/` |
+| Deterministic job summary / export | `matraix results <job>` | text / JSON / CSV |
+| Persona narrative batch PDF | Playground **Runs** → **Download PDF** | UI PDF |
 | Validate Docker/Matraix Playground only | `harbor-smoke-local.yaml` | smoke task image |
 | Docker CLI harness (survey/chat) | `--execution-mode force_docker` or `appSim-*-local.yaml` | Docker trials |
 | Browse trajectories | `harbor view` or Playground **Runs** | local viewer |

--- a/src/matraix/cli.py
+++ b/src/matraix/cli.py
@@ -256,9 +256,10 @@ def main(argv: list[str] | None = None) -> None:
         "results",
         help="Summarize and export a finished job without another LLM call.",
         description=(
-            "Reads jobs/<job>/result.json, per-trial result.json, and known "
-            "artifacts (e.g. survey_result.json). Prints a text summary by "
-            "default; use --format json,csv for machine export."
+            "Deterministic job ledger + type-aware outcome lens for Survey, "
+            "Chat, Web, and OS-app jobs. Reads jobs/<job>/ result.json, "
+            "verifier/structured_output.json, and known artifacts. Default "
+            "path never calls another model. Use --format json,csv for export."
         ),
     )
     results_parser.add_argument(

--- a/src/matraix/cli.py
+++ b/src/matraix/cli.py
@@ -1,10 +1,8 @@
 """Product-facing ``matraix`` CLI.
 
-``matraix run`` wraps ``harbor run`` with the same launch environment the
-Playground injects (``PYTHONPATH`` plus ``MATRIX_*`` task exports), so the
-command printed by the job generator works from a clean documented setup
-without hand-crafted environment exports (issue #78). Harbor remains
-available directly as the underlying runtime.
+``matraix run`` wraps ``harbor run`` with the complete launch environment so
+commands printed by the job generator work from a clean documented setup.
+Harbor remains available directly as the underlying runtime.
 """
 
 from __future__ import annotations

--- a/src/matraix/cli.py
+++ b/src/matraix/cli.py
@@ -21,6 +21,14 @@ from matraix.launch_env import (
     merge_pythonpath,
     required_pythonpath_entries,
 )
+from matraix.job_results import (
+    collect_job_results,
+    format_csv_report,
+    format_json_report,
+    format_text_report,
+    parse_formats,
+    resolve_job_dir,
+)
 
 # Matches the export lines the job generator writes into the YAML header,
 # e.g. "#   export MATRIX_SURVEY_TASK_PATH=application/tasks/...".
@@ -148,6 +156,63 @@ def _cmd_run(args: argparse.Namespace, passthrough: list[str]) -> None:
     harbor_app(args=argv, prog_name="harbor")
 
 
+def _cmd_results(args: argparse.Namespace) -> None:
+    repo_root = (
+        Path(args.repo_root).resolve()
+        if args.repo_root
+        else find_repo_root(Path.cwd())
+    )
+    try:
+        job_dir = resolve_job_dir(args.job, repo_root=repo_root)
+        formats = parse_formats(args.format)
+    except (FileNotFoundError, ValueError) as exc:
+        sys.exit(f"matraix results: {exc}")
+
+    group_by = [part.strip() for part in (args.group_by or "").split(",") if part.strip()]
+    report = collect_job_results(job_dir, group_by=group_by or None)
+
+    writers = {
+        "text": format_text_report,
+        "json": format_json_report,
+        "csv": format_csv_report,
+    }
+
+    if args.output == "-":
+        for index, fmt in enumerate(formats):
+            if len(formats) > 1:
+                print(f"===== {fmt} =====")
+            sys.stdout.write(writers[fmt](report))
+        return
+
+    if args.output:
+        output_path = Path(args.output).expanduser()
+        if not output_path.is_absolute():
+            output_path = (Path.cwd() / output_path).resolve()
+        else:
+            output_path = output_path.resolve()
+        single_file = len(formats) == 1 and (
+            output_path.suffix.lower() in {".txt", ".md", ".json", ".csv"}
+            or not output_path.exists()
+        )
+        if single_file and not output_path.is_dir():
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(writers[formats[0]](report), encoding="utf-8")
+            print(f"matraix results: wrote {output_path}", file=sys.stderr)
+            return
+        output_path.mkdir(parents=True, exist_ok=True)
+        for fmt in formats:
+            suffix = {"text": "txt", "json": "json", "csv": "csv"}[fmt]
+            target = output_path / f"{report.job_name}.results.{suffix}"
+            target.write_text(writers[fmt](report), encoding="utf-8")
+            print(f"matraix results: wrote {target}", file=sys.stderr)
+        return
+
+    for index, fmt in enumerate(formats):
+        if len(formats) > 1:
+            print(f"===== {fmt} =====")
+        sys.stdout.write(writers[fmt](report))
+
+
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(
         prog="matraix",
@@ -189,9 +254,54 @@ def main(argv: list[str] | None = None) -> None:
         ),
     )
 
+    results_parser = subparsers.add_parser(
+        "results",
+        help="Summarize and export a finished job without another LLM call.",
+        description=(
+            "Reads jobs/<job>/result.json, per-trial result.json, and known "
+            "artifacts (e.g. survey_result.json). Prints a text summary by "
+            "default; use --format json,csv for machine export."
+        ),
+    )
+    results_parser.add_argument(
+        "job",
+        help="Job name under jobs/ or a path to a job directory",
+    )
+    results_parser.add_argument(
+        "--format",
+        default="text",
+        help="Comma-separated formats: text,json,csv (default: text)",
+    )
+    results_parser.add_argument(
+        "--group-by",
+        default=None,
+        help=(
+            "Comma-separated persona fields for cuts "
+            "(e.g. life_stage). Reads persona_meta / persona YAML dimensions."
+        ),
+    )
+    results_parser.add_argument(
+        "-o",
+        "--output",
+        default=None,
+        help=(
+            "Write export(s) to a file (single format) or directory "
+            "(multiple formats). Use - for stdout."
+        ),
+    )
+    results_parser.add_argument(
+        "--repo-root",
+        default=None,
+        help="MatrAIx repository root (default: discovered from cwd)",
+    )
+
     args, passthrough = parser.parse_known_args(argv)
     if args.command == "run":
         _cmd_run(args, passthrough)
+    elif args.command == "results":
+        if passthrough:
+            sys.exit(f"matraix results: unrecognized arguments: {' '.join(passthrough)}")
+        _cmd_results(args)
 
 
 if __name__ == "__main__":

--- a/src/matraix/job_results.py
+++ b/src/matraix/job_results.py
@@ -1,7 +1,7 @@
 """Deterministic job result summary and export for ``matraix results``.
 
-Reads Harbor ``jobs/<job>/`` trees only — no extra LLM calls. Complements
-Playground PDF / aggregation with a CLI path from run to insight (#78 P2).
+Reads Harbor ``jobs/<job>/`` trees only — no extra model calls — so finished
+runs can be summarized and exported from the CLI.
 """
 
 from __future__ import annotations
@@ -354,9 +354,9 @@ def collect_job_results(
         for trial_dir in _list_trial_dirs(job_dir)
     ]
     notes = [
-        "Deterministic export from jobs/<job>/ — no additional LLM calls.",
-        "Trial reward comes from result.json verifier_result; survey answers "
-        "from artifacts/app/output/survey_result.json when present.",
+        "Built from jobs/<job>/ on disk — no additional model calls.",
+        "Trial reward comes from result.json; survey answers from "
+        "artifacts/app/output/survey_result.json when present.",
     ]
     if group_keys and not any(trial.group_values for trial in trials):
         notes.append(

--- a/src/matraix/job_results.py
+++ b/src/matraix/job_results.py
@@ -1,7 +1,8 @@
 """Deterministic job result summary and export for ``matraix results``.
 
-Reads Harbor ``jobs/<job>/`` trees only — no extra model calls — so finished
-runs can be summarized and exported from the CLI.
+Reads Harbor ``jobs/<job>/`` trees only — no extra model calls. Universal
+``JobLedger`` plus a thin type-aware ``OutcomeLens`` (Survey / Chat / Web /
+OS-app) produce ``MatraixJobResults.v1``.
 """
 
 from __future__ import annotations
@@ -11,9 +12,12 @@ import io
 import json
 from collections import Counter, defaultdict
 from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
 
+
+SCHEMA_VERSION = "MatraixJobResults.v1"
 
 _SKIP_DIR_NAMES = frozenset(
     {
@@ -25,6 +29,8 @@ _SKIP_DIR_NAMES = frozenset(
         "__pycache__",
     }
 )
+
+_APP_TYPES = frozenset({"survey", "chatbot", "web", "os-app", "unknown"})
 
 
 @dataclass
@@ -44,30 +50,115 @@ class TrialSummary:
     error: str | None = None
     usage: TrialUsage = field(default_factory=TrialUsage)
     artifact_paths: list[str] = field(default_factory=list)
-    survey_answers: dict[str, Any] = field(default_factory=dict)
+    signals: dict[str, Any] = field(default_factory=dict)
     group_values: dict[str, str] = field(default_factory=dict)
+    # Backward-compatible alias used by early Survey CSV/tests.
+    survey_answers: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Distribution:
+    key: str
+    label: str
+    counts: dict[str, int]
+
+
+@dataclass
+class Metric:
+    key: str
+    label: str
+    value: float | int | str | None
+    unit: str | None = None
+
+
+@dataclass
+class OutcomeLens:
+    kind: str
+    primary_summary: str
+    distributions: list[Distribution] = field(default_factory=list)
+    metrics: list[Metric] = field(default_factory=list)
+    source: str = "none"
+
+
+@dataclass
+class JobLedger:
+    coverage: dict[str, int | None]
+    usage: TrialUsage
+    rewards: dict[str, Any]
+    trials: list[TrialSummary]
 
 
 @dataclass
 class JobResultsReport:
-    job_name: str
-    job_dir: str
-    n_trials: int = 0
-    n_completed: int | None = None
-    n_errored: int | None = None
-    n_running: int | None = None
-    n_pending: int | None = None
-    usage: TrialUsage = field(default_factory=TrialUsage)
-    trials: list[TrialSummary] = field(default_factory=list)
-    question_distributions: dict[str, dict[str, int]] = field(default_factory=dict)
+    """``MatraixJobResults.v1`` report object."""
+
+    schema_version: str = SCHEMA_VERSION
+    job_name: str = ""
+    job_dir: str = ""
+    generated_at: str = ""
+    deterministic: bool = True
+    app_type: str = "unknown"
+    ledger: JobLedger | None = None
+    lens: OutcomeLens | None = None
     group_by: list[str] = field(default_factory=list)
     grouped_distributions: dict[str, dict[str, dict[str, dict[str, int]]]] = field(
         default_factory=dict
     )
     notes: list[str] = field(default_factory=list)
 
+    # Convenience mirrors for callers that still expect flat fields.
+    @property
+    def n_trials(self) -> int:
+        return len(self.ledger.trials) if self.ledger else 0
+
+    @property
+    def n_completed(self) -> int | None:
+        return None if not self.ledger else self.ledger.coverage.get("completed")
+
+    @property
+    def n_errored(self) -> int | None:
+        return None if not self.ledger else self.ledger.coverage.get("errored")
+
+    @property
+    def usage(self) -> TrialUsage:
+        return self.ledger.usage if self.ledger else TrialUsage()
+
+    @property
+    def trials(self) -> list[TrialSummary]:
+        return self.ledger.trials if self.ledger else []
+
+    @property
+    def question_distributions(self) -> dict[str, dict[str, int]]:
+        if not self.lens:
+            return {}
+        return {dist.key: dict(dist.counts) for dist in self.lens.distributions}
+
     def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+        payload = {
+            "schemaVersion": self.schema_version,
+            "jobName": self.job_name,
+            "jobDir": self.job_dir,
+            "generatedAt": self.generated_at,
+            "deterministic": self.deterministic,
+            "appType": self.app_type,
+            "ledger": {
+                "coverage": dict(self.ledger.coverage) if self.ledger else {},
+                "usage": asdict(self.usage),
+                "rewards": dict(self.ledger.rewards) if self.ledger else {},
+                "trials": [asdict(trial) for trial in self.trials],
+            },
+            "lens": {
+                "kind": self.lens.kind if self.lens else "none",
+                "primarySummary": self.lens.primary_summary if self.lens else "",
+                "distributions": [asdict(dist) for dist in (self.lens.distributions if self.lens else [])],
+                "metrics": [asdict(metric) for metric in (self.lens.metrics if self.lens else [])],
+                "source": self.lens.source if self.lens else "none",
+            },
+            "groupBy": list(self.group_by),
+            "groupedDistributions": self.grouped_distributions,
+            "notes": list(self.notes),
+        }
+        return payload
 
 
 def resolve_job_dir(job: str | Path, *, repo_root: Path | None = None) -> Path:
@@ -98,20 +189,9 @@ def _read_json(path: Path) -> dict[str, Any] | None:
         return None
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
         return None
     return payload if isinstance(payload, dict) else None
-
-
-def _usage_from_mapping(mapping: dict[str, Any] | None) -> TrialUsage:
-    if not mapping:
-        return TrialUsage()
-    return TrialUsage(
-        n_input_tokens=_as_int(mapping.get("n_input_tokens")),
-        n_output_tokens=_as_int(mapping.get("n_output_tokens")),
-        n_cache_tokens=_as_int(mapping.get("n_cache_tokens")),
-        cost_usd=_as_float(mapping.get("cost_usd")),
-    )
 
 
 def _as_int(value: object) -> int | None:
@@ -140,6 +220,17 @@ def _as_float(value: object) -> float | None:
         except ValueError:
             return None
     return None
+
+
+def _usage_from_mapping(mapping: dict[str, Any] | None) -> TrialUsage:
+    if not mapping:
+        return TrialUsage()
+    return TrialUsage(
+        n_input_tokens=_as_int(mapping.get("n_input_tokens")),
+        n_output_tokens=_as_int(mapping.get("n_output_tokens")),
+        n_cache_tokens=_as_int(mapping.get("n_cache_tokens")),
+        cost_usd=_as_float(mapping.get("cost_usd")),
+    )
 
 
 def _reward_from_trial_result(result: dict[str, Any] | None) -> float | None:
@@ -179,12 +270,11 @@ def _list_trial_dirs(job_dir: Path) -> list[Path]:
 
 
 def _find_output_dir(trial_dir: Path) -> Path | None:
-    candidates = [
+    for path in (
         trial_dir / "artifacts" / "app" / "output",
         trial_dir / "artifacts" / "output",
         trial_dir / "output",
-    ]
-    for path in candidates:
+    ):
         if path.is_dir():
             return path
     return None
@@ -203,7 +293,116 @@ def _artifact_paths(trial_dir: Path, *, job_dir: Path) -> list[str]:
     return paths
 
 
-def _survey_answers(trial_dir: Path) -> dict[str, Any]:
+def _persona_meta(trial_dir: Path) -> dict[str, Any]:
+    return _read_json(trial_dir / "persona_meta.json") or {}
+
+
+def _group_values_for_trial(
+    *,
+    group_by: list[str],
+    persona_meta: dict[str, Any],
+) -> dict[str, str]:
+    if not group_by:
+        return {}
+    dimensions: dict[str, Any] = {}
+    raw_dims = persona_meta.get("dimensions")
+    if isinstance(raw_dims, dict):
+        dimensions.update(raw_dims)
+    persona_path = persona_meta.get("persona_path")
+    if isinstance(persona_path, str) and persona_path.strip():
+        path = Path(persona_path)
+        if path.is_file():
+            try:
+                import yaml
+
+                loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+            except Exception:  # noqa: BLE001
+                loaded = None
+            if isinstance(loaded, dict) and isinstance(loaded.get("dimensions"), dict):
+                dimensions.update(loaded["dimensions"])
+    out: dict[str, str] = {}
+    for key in group_by:
+        if key in persona_meta and persona_meta[key] is not None:
+            out[key] = str(persona_meta[key])
+        elif key in dimensions and dimensions[key] is not None:
+            out[key] = str(dimensions[key])
+        else:
+            out[key] = "unknown"
+    return out
+
+
+def _facet_map(context: dict[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    facets = context.get("facets")
+    if not isinstance(facets, list):
+        return out
+    for facet in facets:
+        if not isinstance(facet, dict):
+            continue
+        key = facet.get("key")
+        if key is None:
+            continue
+        if "value" in facet:
+            out[str(key)] = facet.get("value")
+    return out
+
+
+def _structured_output(trial_dir: Path) -> dict[str, Any] | None:
+    return _read_json(trial_dir / "verifier" / "structured_output.json")
+
+
+def _signals_from_structured_output(payload: dict[str, Any]) -> dict[str, Any]:
+    signals: dict[str, Any] = {}
+    contexts = payload.get("contexts")
+    if not isinstance(contexts, list):
+        return signals
+    for context in contexts:
+        if not isinstance(context, dict):
+            continue
+        context_type = str(context.get("contextType") or "").strip()
+        facets = _facet_map(context)
+        if context_type == "question_response":
+            qid = str(context.get("key") or context.get("label") or "question")
+            if qid.startswith("question."):
+                qid = qid[len("question.") :]
+            if "response" in facets:
+                signals[f"answer_{qid}"] = facets["response"]
+        elif context_type == "task_outcome":
+            if "outcome_status" in facets:
+                signals["outcome_status"] = facets["outcome_status"]
+            if "goal_completion_ratio" in facets:
+                signals["goal_completion_ratio"] = facets["goal_completion_ratio"]
+        elif context_type in {"decision", "web_artifact"}:
+            label = (
+                facets.get("decision_subject_label")
+                or facets.get("artifact_subject_label")
+                or facets.get("decision_subject_id")
+                or facets.get("artifact_subject_id")
+            )
+            if label is not None:
+                signals["decision_label"] = label
+            if "decision_outcome" in facets:
+                signals["decision_outcome"] = facets["decision_outcome"]
+        elif context_type == "goal_component":
+            key = facets.get("goal_component_key") or context.get("key")
+            status = facets.get("goal_component_status")
+            if key is not None and status is not None:
+                signals[f"goal_{key}"] = status
+        elif context_type == "user_feedback":
+            for key in (
+                "overall_experience_rating",
+                "need_constraint_satisfaction",
+                "clarification_questions_useful",
+            ):
+                if key in facets:
+                    signals[f"feedback_{key}"] = facets[key]
+        elif context_type == "conversation_summary":
+            if "conversation_path" in facets:
+                signals["conversation_path"] = facets["conversation_path"]
+    return signals
+
+
+def _survey_answers_from_artifact(trial_dir: Path) -> dict[str, Any]:
     output = _find_output_dir(trial_dir)
     if output is None:
         return {}
@@ -226,45 +425,27 @@ def _survey_answers(trial_dir: Path) -> dict[str, Any]:
     return {}
 
 
-def _persona_meta(trial_dir: Path) -> dict[str, Any]:
-    return _read_json(trial_dir / "persona_meta.json") or {}
-
-
-def _group_values_for_trial(
-    trial_dir: Path,
-    *,
-    group_by: list[str],
-    persona_meta: dict[str, Any],
-) -> dict[str, str]:
-    if not group_by:
-        return {}
-    dimensions: dict[str, Any] = {}
-    raw_dims = persona_meta.get("dimensions")
-    if isinstance(raw_dims, dict):
-        dimensions.update(raw_dims)
-    persona_path = persona_meta.get("persona_path")
-    if isinstance(persona_path, str) and persona_path.strip():
-        path = Path(persona_path)
-        if path.is_file():
-            try:
-                import yaml
-
-                loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
-            except Exception:  # noqa: BLE001
-                loaded = None
-            if isinstance(loaded, dict):
-                dims = loaded.get("dimensions")
-                if isinstance(dims, dict):
-                    dimensions.update(dims)
-    out: dict[str, str] = {}
-    for key in group_by:
-        if key in persona_meta and persona_meta[key] is not None:
-            out[key] = str(persona_meta[key])
-        elif key in dimensions and dimensions[key] is not None:
-            out[key] = str(dimensions[key])
-        else:
-            out[key] = "unknown"
-    return out
+def _decision_label_from_artifact(trial_dir: Path) -> str | None:
+    output = _find_output_dir(trial_dir)
+    if output is None:
+        return None
+    for path in sorted(output.glob("*.json")):
+        if path.name in {"user_feedback.json", "survey_result.json", "survey_responses.json", "transcript.json"}:
+            continue
+        payload = _read_json(path)
+        if not payload:
+            continue
+        for key in (
+            "decision_subject_label",
+            "selectedProductName",
+            "selected_product_name",
+            "decision_subject_id",
+            "selectedProductId",
+        ):
+            value = payload.get(key)
+            if value is not None and str(value).strip():
+                return str(value)
+    return None
 
 
 def _summarize_trial(
@@ -272,43 +453,339 @@ def _summarize_trial(
     *,
     job_dir: Path,
     group_by: list[str],
-) -> TrialSummary:
-    result = _read_json(trial_dir / "result.json")
-    agent_result = result.get("agent_result") if isinstance(result, dict) else None
-    if not isinstance(agent_result, dict):
-        agent_result = None
-    meta = _persona_meta(trial_dir)
-    return TrialSummary(
-        trial_name=trial_dir.name,
-        persona_id=(
-            str(meta["persona_id"])
-            if meta.get("persona_id") is not None
-            else None
-        ),
-        persona_name=(
-            str(meta["display_name"])
-            if meta.get("display_name") is not None
-            else (str(meta["persona_name"]) if meta.get("persona_name") is not None else None)
-        ),
-        reward=_reward_from_trial_result(result),
-        error=_trial_error(result),
-        usage=_usage_from_mapping(agent_result),
-        artifact_paths=_artifact_paths(trial_dir, job_dir=job_dir),
-        survey_answers=_survey_answers(trial_dir),
-        group_values=_group_values_for_trial(
-            trial_dir, group_by=group_by, persona_meta=meta
-        ),
+    notes: list[str],
+) -> TrialSummary | None:
+    try:
+        result = _read_json(trial_dir / "result.json")
+        agent_result = result.get("agent_result") if isinstance(result, dict) else None
+        if not isinstance(agent_result, dict):
+            agent_result = None
+        meta = _persona_meta(trial_dir)
+        structured = _structured_output(trial_dir)
+        signals: dict[str, Any] = {}
+        survey_answers: dict[str, Any] = {}
+        if structured:
+            signals.update(_signals_from_structured_output(structured))
+            for key, value in list(signals.items()):
+                if key.startswith("answer_"):
+                    survey_answers[key[len("answer_") :]] = value
+        if not survey_answers:
+            survey_answers = _survey_answers_from_artifact(trial_dir)
+            for qid, value in survey_answers.items():
+                signals.setdefault(f"answer_{qid}", value)
+        if "decision_label" not in signals:
+            label = _decision_label_from_artifact(trial_dir)
+            if label is not None:
+                signals["decision_label"] = label
+        return TrialSummary(
+            trial_name=trial_dir.name,
+            persona_id=(
+                str(meta["persona_id"]) if meta.get("persona_id") is not None else None
+            ),
+            persona_name=(
+                str(meta["display_name"])
+                if meta.get("display_name") is not None
+                else (
+                    str(meta["persona_name"])
+                    if meta.get("persona_name") is not None
+                    else None
+                )
+            ),
+            reward=_reward_from_trial_result(result),
+            error=_trial_error(result),
+            usage=_usage_from_mapping(agent_result),
+            artifact_paths=_artifact_paths(trial_dir, job_dir=job_dir),
+            signals=signals,
+            survey_answers=survey_answers,
+            group_values=_group_values_for_trial(group_by=group_by, persona_meta=meta),
+        )
+    except Exception as exc:  # noqa: BLE001
+        notes.append(f"Skipped corrupt trial {trial_dir.name}: {exc}")
+        return None
+
+
+def _detect_app_type(job_dir: Path, trials: list[TrialSummary]) -> str:
+    votes: Counter[str] = Counter()
+    for trial_dir in _list_trial_dirs(job_dir):
+        structured = _structured_output(trial_dir)
+        if structured:
+            task_type = str(structured.get("taskType") or "").strip().lower()
+            if task_type in _APP_TYPES and task_type != "unknown":
+                votes[task_type] += 1
+                continue
+        output = _find_output_dir(trial_dir)
+        if output is None:
+            continue
+        names = {path.name.lower() for path in output.glob("*.json")}
+        if "survey_result.json" in names or "survey_responses.json" in names:
+            votes["survey"] += 1
+        elif "transcript.json" in names:
+            votes["chatbot"] += 1
+        elif any("plan_comparison" in name or "choice" in name for name in names):
+            votes["web"] += 1
+        elif "decision.json" in names or "submission.json" in names:
+            votes["os-app"] += 1
+    # Config path hint from first trial.
+    for trial_dir in _list_trial_dirs(job_dir)[:3]:
+        config = _read_json(trial_dir / "config.json") or {}
+        task = config.get("task") if isinstance(config.get("task"), dict) else {}
+        path = str(task.get("path") or "").lower()
+        if "/survey" in path or path.startswith("application/tasks/survey"):
+            votes["survey"] += 1
+        elif "/chat" in path or "chatbot" in path:
+            votes["chatbot"] += 1
+        elif "/web" in path or "web_" in path or "web-" in path:
+            votes["web"] += 1
+        elif "os-app" in path or "computer-use" in path or "os_app" in path:
+            votes["os-app"] += 1
+    if not votes:
+        # Signal heuristics from collected trials.
+        if any(trial.survey_answers for trial in trials):
+            return "survey"
+        if any("decision_label" in trial.signals for trial in trials):
+            return "web"
+        if any("outcome_status" in trial.signals for trial in trials):
+            return "chatbot"
+        return "unknown"
+    return votes.most_common(1)[0][0]
+
+
+def _count_signal(trials: Iterable[TrialSummary], key: str) -> dict[str, int]:
+    counter: Counter[str] = Counter()
+    for trial in trials:
+        value = trial.signals.get(key)
+        if value is None and key.startswith("answer_"):
+            value = trial.survey_answers.get(key[len("answer_") :])
+        if value is None:
+            continue
+        counter[str(value)] += 1
+    return dict(sorted(counter.items(), key=lambda item: (-item[1], item[0])))
+
+
+def _top_mix_summary(counts: dict[str, int], *, limit: int = 4) -> str:
+    if not counts:
+        return "n/a"
+    total = sum(counts.values()) or 1
+    parts: list[str] = []
+    for value, count in list(counts.items())[:limit]:
+        pct = 100.0 * count / total
+        parts.append(f"{value} {pct:.0f}%")
+    return " · ".join(parts)
+
+
+def _mean_numeric(trials: Iterable[TrialSummary], key: str) -> float | None:
+    values: list[float] = []
+    for trial in trials:
+        raw = trial.signals.get(key)
+        number = _as_float(raw)
+        if number is not None:
+            values.append(number)
+    if not values:
+        return None
+    return sum(values) / len(values)
+
+
+def _survey_answer_keys(trials: list[TrialSummary]) -> list[str]:
+    keys = {
+        key[len("answer_") :]
+        for trial in trials
+        for key in trial.signals
+        if key.startswith("answer_")
+    } | {qid for trial in trials for qid in trial.survey_answers}
+
+    def sort_key(qid: str) -> tuple[int, int | str]:
+        if qid.startswith("q") and qid[1:].isdigit():
+            return (0, int(qid[1:]))
+        return (1, qid)
+
+    return sorted(keys, key=sort_key)
+
+
+def build_outcome_lens(app_type: str, trials: list[TrialSummary]) -> OutcomeLens:
+    distributions: list[Distribution] = []
+    metrics: list[Metric] = []
+    source = "structured_output"
+    if app_type == "survey":
+        answer_keys = _survey_answer_keys(trials)
+        for qid in answer_keys:
+            counts = _count_signal(trials, f"answer_{qid}")
+            if counts:
+                distributions.append(
+                    Distribution(key=qid, label=f"Question {qid}", counts=counts)
+                )
+        if not distributions:
+            source = "artifact_fallback" if any(trial.survey_answers for trial in trials) else "none"
+        primary = (
+            _top_mix_summary(distributions[0].counts)
+            if distributions
+            else "no survey answers recorded"
+        )
+        if distributions:
+            primary = f"{distributions[0].label}: {primary}"
+        answered = sum(1 for trial in trials if trial.survey_answers or any(
+            key.startswith("answer_") for key in trial.signals
+        ))
+        metrics.append(Metric(key="answered_trials", label="Trials with answers", value=answered))
+        return OutcomeLens(
+            kind="survey",
+            primary_summary=primary,
+            distributions=distributions,
+            metrics=metrics,
+            source=source if distributions else "none",
+        )
+
+    if app_type == "chatbot":
+        outcome_counts = _count_signal(trials, "outcome_status")
+        path_counts = _count_signal(trials, "conversation_path")
+        if outcome_counts:
+            distributions.append(
+                Distribution(key="outcome_status", label="Task outcome", counts=outcome_counts)
+            )
+        if path_counts:
+            distributions.append(
+                Distribution(key="conversation_path", label="Conversation path", counts=path_counts)
+            )
+        rating = _mean_numeric(trials, "feedback_overall_experience_rating")
+        if rating is not None:
+            metrics.append(
+                Metric(
+                    key="avg_overall_experience_rating",
+                    label="Avg overall rating",
+                    value=round(rating, 2),
+                    unit="/10",
+                )
+            )
+        primary = (
+            f"Outcomes: {_top_mix_summary(outcome_counts)}"
+            if outcome_counts
+            else "no chat outcomes recorded"
+        )
+        return OutcomeLens(
+            kind="chatbot",
+            primary_summary=primary,
+            distributions=distributions,
+            metrics=metrics,
+            source=source if distributions or metrics else "none",
+        )
+
+    if app_type == "web":
+        decision_counts = _count_signal(trials, "decision_label")
+        outcome_counts = _count_signal(trials, "outcome_status")
+        if decision_counts:
+            distributions.append(
+                Distribution(key="decision_label", label="Choice", counts=decision_counts)
+            )
+        if outcome_counts:
+            distributions.append(
+                Distribution(key="outcome_status", label="Task outcome", counts=outcome_counts)
+            )
+        primary = (
+            f"Choices: {_top_mix_summary(decision_counts)}"
+            if decision_counts
+            else (
+                f"Outcomes: {_top_mix_summary(outcome_counts)}"
+                if outcome_counts
+                else "no web decisions recorded"
+            )
+        )
+        return OutcomeLens(
+            kind="web",
+            primary_summary=primary,
+            distributions=distributions,
+            metrics=metrics,
+            source=source if distributions else "artifact_fallback" if decision_counts else "none",
+        )
+
+    if app_type == "os-app":
+        outcome_counts = _count_signal(trials, "outcome_status")
+        decision_counts = _count_signal(trials, "decision_label")
+        decision_outcome_counts = _count_signal(trials, "decision_outcome")
+        goal_keys = sorted(
+            {
+                key[len("goal_") :]
+                for trial in trials
+                for key in trial.signals
+                if key.startswith("goal_")
+            }
+        )
+        if outcome_counts:
+            distributions.append(
+                Distribution(key="outcome_status", label="Task outcome", counts=outcome_counts)
+            )
+        if decision_outcome_counts:
+            distributions.append(
+                Distribution(
+                    key="decision_outcome",
+                    label="Decision outcome",
+                    counts=decision_outcome_counts,
+                )
+            )
+        if decision_counts:
+            distributions.append(
+                Distribution(key="decision_label", label="Decision", counts=decision_counts)
+            )
+        for goal_key in goal_keys[:8]:
+            counts = _count_signal(trials, f"goal_{goal_key}")
+            if counts:
+                distributions.append(
+                    Distribution(
+                        key=f"goal_{goal_key}",
+                        label=f"Goal {goal_key}",
+                        counts=counts,
+                    )
+                )
+        passed = outcome_counts.get("passed", 0)
+        total = sum(outcome_counts.values()) or len(trials) or 1
+        primary = (
+            f"Pass rate {100.0 * passed / total:.0f}% · {_top_mix_summary(outcome_counts)}"
+            if outcome_counts
+            else (
+                f"Decisions: {_top_mix_summary(decision_counts)}"
+                if decision_counts
+                else "no OS-app outcomes recorded"
+            )
+        )
+        metrics.append(
+            Metric(
+                key="pass_rate",
+                label="Pass rate",
+                value=round(100.0 * passed / total, 1) if outcome_counts else None,
+                unit="%",
+            )
+        )
+        return OutcomeLens(
+            kind="os-app",
+            primary_summary=primary,
+            distributions=distributions,
+            metrics=metrics,
+            source=source if distributions else "none",
+        )
+
+    return OutcomeLens(
+        kind="unknown",
+        primary_summary="app type unknown — ledger only",
+        source="none",
     )
 
 
-def _question_distributions(trials: Iterable[TrialSummary]) -> dict[str, dict[str, int]]:
-    counters: dict[str, Counter[str]] = defaultdict(Counter)
+def _reward_stats(trials: list[TrialSummary]) -> dict[str, Any]:
+    rewards = [trial.reward for trial in trials if trial.reward is not None]
+    histogram: Counter[str] = Counter()
     for trial in trials:
-        for qid, value in trial.survey_answers.items():
-            counters[qid][str(value)] += 1
+        if trial.error:
+            histogram["error"] += 1
+        elif trial.reward is None:
+            histogram["missing"] += 1
+        elif trial.reward >= 1:
+            histogram["pass"] += 1
+        elif trial.reward <= 0:
+            histogram["fail"] += 1
+        else:
+            histogram["partial"] += 1
     return {
-        qid: dict(sorted(counter.items(), key=lambda item: (-item[1], item[0])))
-        for qid, counter in sorted(counters.items())
+        "count": len(rewards),
+        "mean": (sum(rewards) / len(rewards)) if rewards else None,
+        "histogram": dict(histogram),
     }
 
 
@@ -316,25 +793,45 @@ def _grouped_distributions(
     trials: list[TrialSummary],
     *,
     group_by: list[str],
+    app_type: str,
 ) -> dict[str, dict[str, dict[str, dict[str, int]]]]:
     if not group_by:
         return {}
-    # group_key -> group_value -> question -> answer -> count
+    signal_keys: list[str]
+    if app_type == "survey":
+        signal_keys = [f"answer_{qid}" for qid in _survey_answer_keys(trials)]
+    elif app_type == "web":
+        signal_keys = ["decision_label", "outcome_status"]
+    elif app_type == "os-app":
+        signal_keys = ["outcome_status", "decision_outcome", "decision_label"]
+    else:
+        signal_keys = ["outcome_status", "conversation_path"]
+
     nested: dict[str, dict[str, dict[str, Counter[str]]]] = {
         key: defaultdict(lambda: defaultdict(Counter)) for key in group_by
     }
     for trial in trials:
-        for key in group_by:
-            group_value = trial.group_values.get(key, "unknown")
-            for qid, value in trial.survey_answers.items():
-                nested[key][group_value][qid][str(value)] += 1
+        for group_key in group_by:
+            group_value = trial.group_values.get(group_key, "unknown")
+            for signal_key in signal_keys:
+                value = trial.signals.get(signal_key)
+                if value is None and signal_key.startswith("answer_"):
+                    value = trial.survey_answers.get(signal_key[len("answer_") :])
+                if value is None:
+                    continue
+                dist_key = (
+                    signal_key[len("answer_") :]
+                    if signal_key.startswith("answer_")
+                    else signal_key
+                )
+                nested[group_key][group_value][dist_key][str(value)] += 1
     out: dict[str, dict[str, dict[str, dict[str, int]]]] = {}
-    for key, by_group in nested.items():
-        out[key] = {}
-        for group_value, by_q in sorted(by_group.items()):
-            out[key][group_value] = {
-                qid: dict(sorted(counter.items(), key=lambda item: (-item[1], item[0])))
-                for qid, counter in sorted(by_q.items())
+    for group_key, by_group in nested.items():
+        out[group_key] = {}
+        for group_value, by_signal in sorted(by_group.items()):
+            out[group_key][group_value] = {
+                signal: dict(sorted(counter.items(), key=lambda item: (-item[1], item[0])))
+                for signal, counter in sorted(by_signal.items())
             }
     return out
 
@@ -344,88 +841,128 @@ def collect_job_results(
     *,
     group_by: list[str] | None = None,
 ) -> JobResultsReport:
-    """Build a deterministic report for one Harbor job directory."""
+    """Build a deterministic ``MatraixJobResults.v1`` report for one job."""
     job_dir = job_dir.resolve()
     group_keys = [key.strip() for key in (group_by or []) if key.strip()]
+    notes: list[str] = [
+        "Built from jobs/<job>/ on disk — no additional model calls.",
+        "Ledger uses result.json; lens prefers verifier/structured_output.json.",
+    ]
     job_result = _read_json(job_dir / "result.json") or {}
     stats = job_result.get("stats") if isinstance(job_result.get("stats"), dict) else {}
-    trials = [
-        _summarize_trial(trial_dir, job_dir=job_dir, group_by=group_keys)
-        for trial_dir in _list_trial_dirs(job_dir)
-    ]
-    notes = [
-        "Built from jobs/<job>/ on disk — no additional model calls.",
-        "Trial reward comes from result.json; survey answers from "
-        "artifacts/app/output/survey_result.json when present.",
-    ]
+
+    trials: list[TrialSummary] = []
+    for trial_dir in _list_trial_dirs(job_dir):
+        summary = _summarize_trial(
+            trial_dir, job_dir=job_dir, group_by=group_keys, notes=notes
+        )
+        if summary is not None:
+            trials.append(summary)
+
+    app_type = _detect_app_type(job_dir, trials)
+    if app_type not in _APP_TYPES:
+        app_type = "unknown"
+
+    completed = _as_int(stats.get("n_completed_trials"))
+    errored = _as_int(stats.get("n_errored_trials"))
+    if completed is None:
+        completed = sum(1 for trial in trials if trial.error is None)
+    if errored is None:
+        errored = sum(1 for trial in trials if trial.error)
+
+    ledger = JobLedger(
+        coverage={
+            "trials": len(trials),
+            "completed": completed,
+            "errored": errored,
+            "running": _as_int(stats.get("n_running_trials")),
+            "pending": _as_int(stats.get("n_pending_trials")),
+        },
+        usage=_usage_from_mapping(stats),
+        rewards=_reward_stats(trials),
+        trials=trials,
+    )
+    lens = build_outcome_lens(app_type, trials)
     if group_keys and not any(trial.group_values for trial in trials):
         notes.append(
             "group-by keys were requested but no matching persona fields were found."
         )
+
     return JobResultsReport(
+        schema_version=SCHEMA_VERSION,
         job_name=job_dir.name,
         job_dir=str(job_dir),
-        n_trials=len(trials),
-        n_completed=_as_int(stats.get("n_completed_trials")),
-        n_errored=_as_int(stats.get("n_errored_trials")),
-        n_running=_as_int(stats.get("n_running_trials")),
-        n_pending=_as_int(stats.get("n_pending_trials")),
-        usage=_usage_from_mapping(stats),
-        trials=trials,
-        question_distributions=_question_distributions(trials),
+        generated_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        deterministic=True,
+        app_type=app_type,
+        ledger=ledger,
+        lens=lens,
         group_by=group_keys,
-        grouped_distributions=_grouped_distributions(trials, group_by=group_keys),
+        grouped_distributions=_grouped_distributions(
+            trials, group_by=group_keys, app_type=app_type
+        ),
         notes=notes,
     )
 
 
-def format_text_report(report: JobResultsReport) -> str:
-    lines: list[str] = []
-    lines.append(f"Job: {report.job_name}")
-    lines.append(f"Path: {report.job_dir}")
-    completed = report.n_completed if report.n_completed is not None else sum(
-        1 for trial in report.trials if trial.error is None and trial.reward is not None
-    )
-    errored = report.n_errored if report.n_errored is not None else sum(
-        1 for trial in report.trials if trial.error
-    )
-    lines.append(
-        f"Trials: {report.n_trials} total · {completed} completed · {errored} errored"
-    )
-    usage_bits: list[str] = []
-    if report.usage.cost_usd is not None:
-        usage_bits.append(f"cost ${report.usage.cost_usd:g}")
-    if report.usage.n_input_tokens is not None:
-        usage_bits.append(f"{report.usage.n_input_tokens:,} in")
-    if report.usage.n_output_tokens is not None:
-        usage_bits.append(f"{report.usage.n_output_tokens:,} out")
-    if report.usage.n_cache_tokens is not None and report.usage.n_cache_tokens > 0:
-        usage_bits.append(f"{report.usage.n_cache_tokens:,} cache")
-    if usage_bits:
-        lines.append("Usage: " + " · ".join(usage_bits))
-    else:
-        lines.append("Usage: (not recorded on job result.json)")
+def _format_token_line(usage: TrialUsage) -> str:
+    bits: list[str] = []
+    if usage.n_input_tokens is not None:
+        bits.append(f"{usage.n_input_tokens:,} in")
+    if usage.n_output_tokens is not None:
+        bits.append(f"{usage.n_output_tokens:,} out")
+    if usage.n_cache_tokens is not None and usage.n_cache_tokens > 0:
+        bits.append(f"{usage.n_cache_tokens:,} cache")
+    return " · ".join(bits) if bits else "(not recorded)"
 
-    if report.question_distributions:
+
+def format_text_report(report: JobResultsReport) -> str:
+    ledger = report.ledger
+    lens = report.lens
+    coverage = ledger.coverage if ledger else {}
+    health_bits = [
+        f"{coverage.get('trials') or 0} trials",
+        f"{coverage.get('completed') or 0} ok",
+        f"{coverage.get('errored') or 0} error",
+    ]
+    if report.usage.cost_usd is not None:
+        health_bits.append(f"cost ${report.usage.cost_usd:g}")
+    lines: list[str] = [
+        f"Job: {report.job_name}",
+        f"App: {report.app_type}",
+        f"Path: {report.job_dir}",
+        f"Health: {' · '.join(health_bits)}",
+        f"Primary: {lens.primary_summary if lens else 'n/a'}",
+        f"Usage: {_format_token_line(report.usage)}",
+    ]
+
+    if lens and lens.distributions:
         lines.append("")
-        lines.append("Question distributions")
-        for qid, counts in report.question_distributions.items():
-            total = sum(counts.values())
-            top = ", ".join(f"{value}={count}" for value, count in list(counts.items())[:5])
-            lines.append(f"  {qid} (n={total}): {top}")
+        lines.append("Distributions")
+        for dist in lens.distributions[:12]:
+            total = sum(dist.counts.values())
+            top = ", ".join(f"{value}={count}" for value, count in list(dist.counts.items())[:5])
+            lines.append(f"  {dist.label} (n={total}): {top}")
+
+    if lens and lens.metrics:
+        lines.append("")
+        lines.append("Metrics")
+        for metric in lens.metrics:
+            unit = f" {metric.unit}" if metric.unit else ""
+            lines.append(f"  {metric.label}: {metric.value}{unit}")
 
     if report.grouped_distributions:
         lines.append("")
         lines.append("Grouped distributions")
         for key, by_group in report.grouped_distributions.items():
             lines.append(f"  by {key}:")
-            for group_value, by_q in by_group.items():
+            for group_value, by_signal in by_group.items():
                 lines.append(f"    {group_value}:")
-                for qid, counts in list(by_q.items())[:8]:
+                for signal, counts in list(by_signal.items())[:8]:
                     top = ", ".join(
                         f"{value}={count}" for value, count in list(counts.items())[:4]
                     )
-                    lines.append(f"      {qid}: {top}")
+                    lines.append(f"      {signal}: {top}")
 
     lines.append("")
     lines.append("Trials")
@@ -433,11 +970,7 @@ def format_text_report(report: JobResultsReport) -> str:
         persona = trial.persona_name or trial.persona_id or "-"
         reward = "-" if trial.reward is None else f"{trial.reward:g}"
         status = "error" if trial.error else "ok"
-        cost = (
-            f"${trial.usage.cost_usd:g}"
-            if trial.usage.cost_usd is not None
-            else "-"
-        )
+        cost = f"${trial.usage.cost_usd:g}" if trial.usage.cost_usd is not None else "-"
         artifact = trial.artifact_paths[0] if trial.artifact_paths else "-"
         lines.append(
             f"  {trial.trial_name} · {persona} · reward={reward} · "
@@ -448,6 +981,9 @@ def format_text_report(report: JobResultsReport) -> str:
     lines.append("Notes")
     for note in report.notes:
         lines.append(f"  - {note}")
+    if lens:
+        lines.append(f"  - lens source: {lens.source}")
+    lines.append(f"  - schema: {report.schema_version}")
     return "\n".join(lines) + "\n"
 
 
@@ -456,13 +992,16 @@ def format_json_report(report: JobResultsReport) -> str:
 
 
 def format_csv_report(report: JobResultsReport) -> str:
-    """One row per trial; survey answers expand as answer_<qid> columns."""
+    """One row per trial; signals expand as columns."""
+    signal_keys = sorted({key for trial in report.trials for key in trial.signals})
+    # Prefer answer_* aliases for survey CSV readability.
     answer_keys = sorted(
         {qid for trial in report.trials for qid in trial.survey_answers}
     )
     group_keys = report.group_by
     fieldnames = [
         "job_name",
+        "app_type",
         "trial_name",
         "persona_id",
         "persona_name",
@@ -475,6 +1014,11 @@ def format_csv_report(report: JobResultsReport) -> str:
         "artifact_paths",
         *[f"group_{key}" for key in group_keys],
         *[f"answer_{qid}" for qid in answer_keys],
+        *[
+            f"signal_{key}"
+            for key in signal_keys
+            if not key.startswith("answer_") or key[len("answer_") :] not in answer_keys
+        ],
     ]
     buf = io.StringIO()
     writer = csv.DictWriter(buf, fieldnames=fieldnames, extrasaction="ignore")
@@ -482,6 +1026,7 @@ def format_csv_report(report: JobResultsReport) -> str:
     for trial in report.trials:
         row: dict[str, Any] = {
             "job_name": report.job_name,
+            "app_type": report.app_type,
             "trial_name": trial.trial_name,
             "persona_id": trial.persona_id or "",
             "persona_name": trial.persona_name or "",
@@ -502,8 +1047,13 @@ def format_csv_report(report: JobResultsReport) -> str:
         for key in group_keys:
             row[f"group_{key}"] = trial.group_values.get(key, "")
         for qid in answer_keys:
-            value = trial.survey_answers.get(qid, "")
+            value = trial.survey_answers.get(qid, trial.signals.get(f"answer_{qid}", ""))
             row[f"answer_{qid}"] = "" if value is None else value
+        for key in signal_keys:
+            if key.startswith("answer_") and key[len("answer_") :] in answer_keys:
+                continue
+            value = trial.signals.get(key, "")
+            row[f"signal_{key}"] = "" if value is None else value
         writer.writerow(row)
     return buf.getvalue()
 

--- a/src/matraix/job_results.py
+++ b/src/matraix/job_results.py
@@ -1,0 +1,521 @@
+"""Deterministic job result summary and export for ``matraix results``.
+
+Reads Harbor ``jobs/<job>/`` trees only — no extra LLM calls. Complements
+Playground PDF / aggregation with a CLI path from run to insight (#78 P2).
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+from collections import Counter, defaultdict
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+
+_SKIP_DIR_NAMES = frozenset(
+    {
+        "_generated",
+        "agent",
+        "artifacts",
+        "verifier",
+        "logs",
+        "__pycache__",
+    }
+)
+
+
+@dataclass
+class TrialUsage:
+    n_input_tokens: int | None = None
+    n_output_tokens: int | None = None
+    n_cache_tokens: int | None = None
+    cost_usd: float | None = None
+
+
+@dataclass
+class TrialSummary:
+    trial_name: str
+    persona_id: str | None = None
+    persona_name: str | None = None
+    reward: float | None = None
+    error: str | None = None
+    usage: TrialUsage = field(default_factory=TrialUsage)
+    artifact_paths: list[str] = field(default_factory=list)
+    survey_answers: dict[str, Any] = field(default_factory=dict)
+    group_values: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class JobResultsReport:
+    job_name: str
+    job_dir: str
+    n_trials: int = 0
+    n_completed: int | None = None
+    n_errored: int | None = None
+    n_running: int | None = None
+    n_pending: int | None = None
+    usage: TrialUsage = field(default_factory=TrialUsage)
+    trials: list[TrialSummary] = field(default_factory=list)
+    question_distributions: dict[str, dict[str, int]] = field(default_factory=dict)
+    group_by: list[str] = field(default_factory=list)
+    grouped_distributions: dict[str, dict[str, dict[str, dict[str, int]]]] = field(
+        default_factory=dict
+    )
+    notes: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def resolve_job_dir(job: str | Path, *, repo_root: Path | None = None) -> Path:
+    """Resolve a job name or path to ``jobs/<job>/``."""
+    raw = Path(job).expanduser()
+    candidates: list[Path] = []
+    if raw.is_absolute() or raw.exists():
+        candidates.append(raw.resolve())
+    else:
+        cwd = Path.cwd()
+        candidates.append((cwd / raw).resolve())
+        candidates.append((cwd / "jobs" / raw).resolve())
+        if repo_root is not None:
+            candidates.append((repo_root / raw).resolve())
+            candidates.append((repo_root / "jobs" / raw).resolve())
+    for path in candidates:
+        if path.is_dir() and (path / "result.json").is_file():
+            return path
+        if path.is_dir() and any(
+            (child / "result.json").is_file() for child in path.iterdir() if child.is_dir()
+        ):
+            return path
+    raise FileNotFoundError(f"job directory not found: {job}")
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _usage_from_mapping(mapping: dict[str, Any] | None) -> TrialUsage:
+    if not mapping:
+        return TrialUsage()
+    return TrialUsage(
+        n_input_tokens=_as_int(mapping.get("n_input_tokens")),
+        n_output_tokens=_as_int(mapping.get("n_output_tokens")),
+        n_cache_tokens=_as_int(mapping.get("n_cache_tokens")),
+        cost_usd=_as_float(mapping.get("cost_usd")),
+    )
+
+
+def _as_int(value: object) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            return int(float(value.strip()))
+        except ValueError:
+            return None
+    return None
+
+
+def _as_float(value: object) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            return float(value.strip())
+        except ValueError:
+            return None
+    return None
+
+
+def _reward_from_trial_result(result: dict[str, Any] | None) -> float | None:
+    if not result:
+        return None
+    verifier = result.get("verifier_result")
+    if isinstance(verifier, dict):
+        rewards = verifier.get("rewards")
+        if isinstance(rewards, dict) and "reward" in rewards:
+            return _as_float(rewards.get("reward"))
+        if "reward" in verifier:
+            return _as_float(verifier.get("reward"))
+    return None
+
+
+def _trial_error(result: dict[str, Any] | None) -> str | None:
+    if not result:
+        return None
+    exc = result.get("exception_info")
+    if isinstance(exc, dict):
+        msg = exc.get("exception_message") or exc.get("exception_type")
+        if isinstance(msg, str) and msg.strip():
+            return msg.strip()
+    return None
+
+
+def _list_trial_dirs(job_dir: Path) -> list[Path]:
+    trials: list[Path] = []
+    for child in sorted(job_dir.iterdir()):
+        if not child.is_dir():
+            continue
+        if child.name in _SKIP_DIR_NAMES or child.name.startswith("."):
+            continue
+        if (child / "result.json").is_file() or (child / "artifacts").is_dir():
+            trials.append(child)
+    return trials
+
+
+def _find_output_dir(trial_dir: Path) -> Path | None:
+    candidates = [
+        trial_dir / "artifacts" / "app" / "output",
+        trial_dir / "artifacts" / "output",
+        trial_dir / "output",
+    ]
+    for path in candidates:
+        if path.is_dir():
+            return path
+    return None
+
+
+def _artifact_paths(trial_dir: Path, *, job_dir: Path) -> list[str]:
+    output = _find_output_dir(trial_dir)
+    if output is None:
+        return []
+    paths: list[str] = []
+    for path in sorted(output.glob("*.json")):
+        try:
+            paths.append(str(path.relative_to(job_dir)))
+        except ValueError:
+            paths.append(str(path))
+    return paths
+
+
+def _survey_answers(trial_dir: Path) -> dict[str, Any]:
+    output = _find_output_dir(trial_dir)
+    if output is None:
+        return {}
+    for name in ("survey_result.json", "survey_responses.json"):
+        payload = _read_json(output / name)
+        if not payload:
+            continue
+        answers = payload.get("answers")
+        if not isinstance(answers, list):
+            continue
+        out: dict[str, Any] = {}
+        for entry in answers:
+            if not isinstance(entry, dict):
+                continue
+            qid = entry.get("questionId") or entry.get("question_id")
+            if qid is None:
+                continue
+            out[str(qid)] = entry.get("value")
+        return out
+    return {}
+
+
+def _persona_meta(trial_dir: Path) -> dict[str, Any]:
+    return _read_json(trial_dir / "persona_meta.json") or {}
+
+
+def _group_values_for_trial(
+    trial_dir: Path,
+    *,
+    group_by: list[str],
+    persona_meta: dict[str, Any],
+) -> dict[str, str]:
+    if not group_by:
+        return {}
+    dimensions: dict[str, Any] = {}
+    raw_dims = persona_meta.get("dimensions")
+    if isinstance(raw_dims, dict):
+        dimensions.update(raw_dims)
+    persona_path = persona_meta.get("persona_path")
+    if isinstance(persona_path, str) and persona_path.strip():
+        path = Path(persona_path)
+        if path.is_file():
+            try:
+                import yaml
+
+                loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+            except Exception:  # noqa: BLE001
+                loaded = None
+            if isinstance(loaded, dict):
+                dims = loaded.get("dimensions")
+                if isinstance(dims, dict):
+                    dimensions.update(dims)
+    out: dict[str, str] = {}
+    for key in group_by:
+        if key in persona_meta and persona_meta[key] is not None:
+            out[key] = str(persona_meta[key])
+        elif key in dimensions and dimensions[key] is not None:
+            out[key] = str(dimensions[key])
+        else:
+            out[key] = "unknown"
+    return out
+
+
+def _summarize_trial(
+    trial_dir: Path,
+    *,
+    job_dir: Path,
+    group_by: list[str],
+) -> TrialSummary:
+    result = _read_json(trial_dir / "result.json")
+    agent_result = result.get("agent_result") if isinstance(result, dict) else None
+    if not isinstance(agent_result, dict):
+        agent_result = None
+    meta = _persona_meta(trial_dir)
+    return TrialSummary(
+        trial_name=trial_dir.name,
+        persona_id=(
+            str(meta["persona_id"])
+            if meta.get("persona_id") is not None
+            else None
+        ),
+        persona_name=(
+            str(meta["display_name"])
+            if meta.get("display_name") is not None
+            else (str(meta["persona_name"]) if meta.get("persona_name") is not None else None)
+        ),
+        reward=_reward_from_trial_result(result),
+        error=_trial_error(result),
+        usage=_usage_from_mapping(agent_result),
+        artifact_paths=_artifact_paths(trial_dir, job_dir=job_dir),
+        survey_answers=_survey_answers(trial_dir),
+        group_values=_group_values_for_trial(
+            trial_dir, group_by=group_by, persona_meta=meta
+        ),
+    )
+
+
+def _question_distributions(trials: Iterable[TrialSummary]) -> dict[str, dict[str, int]]:
+    counters: dict[str, Counter[str]] = defaultdict(Counter)
+    for trial in trials:
+        for qid, value in trial.survey_answers.items():
+            counters[qid][str(value)] += 1
+    return {
+        qid: dict(sorted(counter.items(), key=lambda item: (-item[1], item[0])))
+        for qid, counter in sorted(counters.items())
+    }
+
+
+def _grouped_distributions(
+    trials: list[TrialSummary],
+    *,
+    group_by: list[str],
+) -> dict[str, dict[str, dict[str, dict[str, int]]]]:
+    if not group_by:
+        return {}
+    # group_key -> group_value -> question -> answer -> count
+    nested: dict[str, dict[str, dict[str, Counter[str]]]] = {
+        key: defaultdict(lambda: defaultdict(Counter)) for key in group_by
+    }
+    for trial in trials:
+        for key in group_by:
+            group_value = trial.group_values.get(key, "unknown")
+            for qid, value in trial.survey_answers.items():
+                nested[key][group_value][qid][str(value)] += 1
+    out: dict[str, dict[str, dict[str, dict[str, int]]]] = {}
+    for key, by_group in nested.items():
+        out[key] = {}
+        for group_value, by_q in sorted(by_group.items()):
+            out[key][group_value] = {
+                qid: dict(sorted(counter.items(), key=lambda item: (-item[1], item[0])))
+                for qid, counter in sorted(by_q.items())
+            }
+    return out
+
+
+def collect_job_results(
+    job_dir: Path,
+    *,
+    group_by: list[str] | None = None,
+) -> JobResultsReport:
+    """Build a deterministic report for one Harbor job directory."""
+    job_dir = job_dir.resolve()
+    group_keys = [key.strip() for key in (group_by or []) if key.strip()]
+    job_result = _read_json(job_dir / "result.json") or {}
+    stats = job_result.get("stats") if isinstance(job_result.get("stats"), dict) else {}
+    trials = [
+        _summarize_trial(trial_dir, job_dir=job_dir, group_by=group_keys)
+        for trial_dir in _list_trial_dirs(job_dir)
+    ]
+    notes = [
+        "Deterministic export from jobs/<job>/ — no additional LLM calls.",
+        "Trial reward comes from result.json verifier_result; survey answers "
+        "from artifacts/app/output/survey_result.json when present.",
+    ]
+    if group_keys and not any(trial.group_values for trial in trials):
+        notes.append(
+            "group-by keys were requested but no matching persona fields were found."
+        )
+    return JobResultsReport(
+        job_name=job_dir.name,
+        job_dir=str(job_dir),
+        n_trials=len(trials),
+        n_completed=_as_int(stats.get("n_completed_trials")),
+        n_errored=_as_int(stats.get("n_errored_trials")),
+        n_running=_as_int(stats.get("n_running_trials")),
+        n_pending=_as_int(stats.get("n_pending_trials")),
+        usage=_usage_from_mapping(stats),
+        trials=trials,
+        question_distributions=_question_distributions(trials),
+        group_by=group_keys,
+        grouped_distributions=_grouped_distributions(trials, group_by=group_keys),
+        notes=notes,
+    )
+
+
+def format_text_report(report: JobResultsReport) -> str:
+    lines: list[str] = []
+    lines.append(f"Job: {report.job_name}")
+    lines.append(f"Path: {report.job_dir}")
+    completed = report.n_completed if report.n_completed is not None else sum(
+        1 for trial in report.trials if trial.error is None and trial.reward is not None
+    )
+    errored = report.n_errored if report.n_errored is not None else sum(
+        1 for trial in report.trials if trial.error
+    )
+    lines.append(
+        f"Trials: {report.n_trials} total · {completed} completed · {errored} errored"
+    )
+    usage_bits: list[str] = []
+    if report.usage.cost_usd is not None:
+        usage_bits.append(f"cost ${report.usage.cost_usd:g}")
+    if report.usage.n_input_tokens is not None:
+        usage_bits.append(f"{report.usage.n_input_tokens:,} in")
+    if report.usage.n_output_tokens is not None:
+        usage_bits.append(f"{report.usage.n_output_tokens:,} out")
+    if report.usage.n_cache_tokens is not None and report.usage.n_cache_tokens > 0:
+        usage_bits.append(f"{report.usage.n_cache_tokens:,} cache")
+    if usage_bits:
+        lines.append("Usage: " + " · ".join(usage_bits))
+    else:
+        lines.append("Usage: (not recorded on job result.json)")
+
+    if report.question_distributions:
+        lines.append("")
+        lines.append("Question distributions")
+        for qid, counts in report.question_distributions.items():
+            total = sum(counts.values())
+            top = ", ".join(f"{value}={count}" for value, count in list(counts.items())[:5])
+            lines.append(f"  {qid} (n={total}): {top}")
+
+    if report.grouped_distributions:
+        lines.append("")
+        lines.append("Grouped distributions")
+        for key, by_group in report.grouped_distributions.items():
+            lines.append(f"  by {key}:")
+            for group_value, by_q in by_group.items():
+                lines.append(f"    {group_value}:")
+                for qid, counts in list(by_q.items())[:8]:
+                    top = ", ".join(
+                        f"{value}={count}" for value, count in list(counts.items())[:4]
+                    )
+                    lines.append(f"      {qid}: {top}")
+
+    lines.append("")
+    lines.append("Trials")
+    for trial in report.trials:
+        persona = trial.persona_name or trial.persona_id or "-"
+        reward = "-" if trial.reward is None else f"{trial.reward:g}"
+        status = "error" if trial.error else "ok"
+        cost = (
+            f"${trial.usage.cost_usd:g}"
+            if trial.usage.cost_usd is not None
+            else "-"
+        )
+        artifact = trial.artifact_paths[0] if trial.artifact_paths else "-"
+        lines.append(
+            f"  {trial.trial_name} · {persona} · reward={reward} · "
+            f"{status} · cost={cost} · {artifact}"
+        )
+
+    lines.append("")
+    lines.append("Notes")
+    for note in report.notes:
+        lines.append(f"  - {note}")
+    return "\n".join(lines) + "\n"
+
+
+def format_json_report(report: JobResultsReport) -> str:
+    return json.dumps(report.to_dict(), indent=2, ensure_ascii=False) + "\n"
+
+
+def format_csv_report(report: JobResultsReport) -> str:
+    """One row per trial; survey answers expand as answer_<qid> columns."""
+    answer_keys = sorted(
+        {qid for trial in report.trials for qid in trial.survey_answers}
+    )
+    group_keys = report.group_by
+    fieldnames = [
+        "job_name",
+        "trial_name",
+        "persona_id",
+        "persona_name",
+        "reward",
+        "error",
+        "n_input_tokens",
+        "n_output_tokens",
+        "n_cache_tokens",
+        "cost_usd",
+        "artifact_paths",
+        *[f"group_{key}" for key in group_keys],
+        *[f"answer_{qid}" for qid in answer_keys],
+    ]
+    buf = io.StringIO()
+    writer = csv.DictWriter(buf, fieldnames=fieldnames, extrasaction="ignore")
+    writer.writeheader()
+    for trial in report.trials:
+        row: dict[str, Any] = {
+            "job_name": report.job_name,
+            "trial_name": trial.trial_name,
+            "persona_id": trial.persona_id or "",
+            "persona_name": trial.persona_name or "",
+            "reward": "" if trial.reward is None else trial.reward,
+            "error": trial.error or "",
+            "n_input_tokens": trial.usage.n_input_tokens
+            if trial.usage.n_input_tokens is not None
+            else "",
+            "n_output_tokens": trial.usage.n_output_tokens
+            if trial.usage.n_output_tokens is not None
+            else "",
+            "n_cache_tokens": trial.usage.n_cache_tokens
+            if trial.usage.n_cache_tokens is not None
+            else "",
+            "cost_usd": trial.usage.cost_usd if trial.usage.cost_usd is not None else "",
+            "artifact_paths": ";".join(trial.artifact_paths),
+        }
+        for key in group_keys:
+            row[f"group_{key}"] = trial.group_values.get(key, "")
+        for qid in answer_keys:
+            value = trial.survey_answers.get(qid, "")
+            row[f"answer_{qid}"] = "" if value is None else value
+        writer.writerow(row)
+    return buf.getvalue()
+
+
+def parse_formats(raw: str | None) -> list[str]:
+    if not raw or not raw.strip():
+        return ["text"]
+    formats = [part.strip().lower() for part in raw.split(",") if part.strip()]
+    allowed = {"text", "json", "csv"}
+    unknown = [fmt for fmt in formats if fmt not in allowed]
+    if unknown:
+        raise ValueError(
+            f"unsupported format(s): {', '.join(unknown)} (allowed: text,json,csv)"
+        )
+    return formats or ["text"]

--- a/src/matraix/launch_env.py
+++ b/src/matraix/launch_env.py
@@ -1,10 +1,8 @@
-"""Single source of truth for the Harbor launch environment.
+"""Shared Harbor launch environment for Playground and ``matraix run``.
 
-The Playground backend and the ``matraix`` CLI both spawn ``harbor run``
-processes that import monorepo packages (``backend``, ``matraix.agents``,
-``playground``, …). Every launcher must inject the same ``PYTHONPATH``
-entries; keeping the list here prevents the GUI and CLI launch paths from
-drifting apart (issue #78).
+Both launchers start ``harbor run`` processes that import monorepo packages
+(``backend``, ``matraix.agents``, ``playground``, …). Keeping the required
+``PYTHONPATH`` entries here prevents the GUI and CLI from drifting apart.
 """
 
 from __future__ import annotations

--- a/tests/unit/matraix/test_job_results.py
+++ b/tests/unit/matraix/test_job_results.py
@@ -1,0 +1,112 @@
+"""Tests for ``matraix results`` job summary / export."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from matraix.job_results import (
+    collect_job_results,
+    format_csv_report,
+    format_json_report,
+    format_text_report,
+    parse_formats,
+    resolve_job_dir,
+)
+
+
+def _write_survey_job(tmp_path: Path) -> Path:
+    job = tmp_path / "jobs" / "demo-survey"
+    trial = job / "survey_demo__abc123"
+    output = trial / "artifacts" / "app" / "output"
+    output.mkdir(parents=True)
+    (job / "result.json").write_text(
+        json.dumps(
+            {
+                "stats": {
+                    "n_completed_trials": 1,
+                    "n_errored_trials": 0,
+                    "n_input_tokens": 1200,
+                    "n_output_tokens": 80,
+                    "cost_usd": 0.012,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (trial / "result.json").write_text(
+        json.dumps(
+            {
+                "agent_result": {
+                    "n_input_tokens": 1200,
+                    "n_output_tokens": 80,
+                    "cost_usd": 0.012,
+                },
+                "verifier_result": {"rewards": {"reward": 1.0}},
+                "exception_info": None,
+            }
+        ),
+        encoding="utf-8",
+    )
+    (trial / "persona_meta.json").write_text(
+        json.dumps(
+            {
+                "persona_id": "0042",
+                "display_name": "Siti Rahman",
+                "dimensions": {"life_stage": "early_career"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (output / "survey_result.json").write_text(
+        json.dumps(
+            {
+                "answers": [
+                    {"questionId": "q0", "value": "option_a"},
+                    {"questionId": "overall_interest", "value": 4},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    return job
+
+
+def test_resolve_job_dir_by_name(tmp_path: Path, monkeypatch) -> None:
+    job = _write_survey_job(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    assert resolve_job_dir("demo-survey", repo_root=tmp_path) == job.resolve()
+
+
+def test_collect_job_results_survey_distributions(tmp_path: Path) -> None:
+    job = _write_survey_job(tmp_path)
+    report = collect_job_results(job, group_by=["life_stage"])
+    assert report.n_trials == 1
+    assert report.usage.cost_usd == 0.012
+    assert report.trials[0].reward == 1.0
+    assert report.question_distributions["q0"] == {"option_a": 1}
+    assert "life_stage" in report.grouped_distributions
+    assert "early_career" in report.grouped_distributions["life_stage"]
+
+
+def test_formatters_include_usage_and_answers(tmp_path: Path) -> None:
+    job = _write_survey_job(tmp_path)
+    report = collect_job_results(job)
+    text = format_text_report(report)
+    assert "demo-survey" in text
+    assert "0.012" in text
+    assert "q0" in text
+    payload = json.loads(format_json_report(report))
+    assert payload["trials"][0]["survey_answers"]["overall_interest"] == 4
+    csv_text = format_csv_report(report)
+    assert "answer_q0" in csv_text
+    assert "option_a" in csv_text
+
+
+def test_parse_formats_rejects_unknown() -> None:
+    assert parse_formats("json,csv") == ["json", "csv"]
+    try:
+        parse_formats("html")
+        assert False, "expected ValueError"
+    except ValueError as exc:
+        assert "html" in str(exc)

--- a/tests/unit/matraix/test_job_results.py
+++ b/tests/unit/matraix/test_job_results.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 from matraix.job_results import (
+    SCHEMA_VERSION,
     collect_job_results,
     format_csv_report,
     format_json_report,
@@ -15,34 +16,43 @@ from matraix.job_results import (
 )
 
 
-def _write_survey_job(tmp_path: Path) -> Path:
-    job = tmp_path / "jobs" / "demo-survey"
-    trial = job / "survey_demo__abc123"
+def _write_trial_shell(
+    job: Path,
+    trial_name: str,
+    *,
+    stats: dict | None = None,
+    reward: float = 1.0,
+    persona: dict | None = None,
+    cost_usd: float = 0.012,
+) -> Path:
+    trial = job / trial_name
     output = trial / "artifacts" / "app" / "output"
     output.mkdir(parents=True)
-    (job / "result.json").write_text(
-        json.dumps(
-            {
-                "stats": {
-                    "n_completed_trials": 1,
-                    "n_errored_trials": 0,
-                    "n_input_tokens": 1200,
-                    "n_output_tokens": 80,
-                    "cost_usd": 0.012,
+    if not (job / "result.json").is_file():
+        (job / "result.json").write_text(
+            json.dumps(
+                {
+                    "stats": stats
+                    or {
+                        "n_completed_trials": 1,
+                        "n_errored_trials": 0,
+                        "n_input_tokens": 1200,
+                        "n_output_tokens": 80,
+                        "cost_usd": cost_usd,
+                    }
                 }
-            }
-        ),
-        encoding="utf-8",
-    )
+            ),
+            encoding="utf-8",
+        )
     (trial / "result.json").write_text(
         json.dumps(
             {
                 "agent_result": {
                     "n_input_tokens": 1200,
                     "n_output_tokens": 80,
-                    "cost_usd": 0.012,
+                    "cost_usd": cost_usd,
                 },
-                "verifier_result": {"rewards": {"reward": 1.0}},
+                "verifier_result": {"rewards": {"reward": reward}},
                 "exception_info": None,
             }
         ),
@@ -50,7 +60,8 @@ def _write_survey_job(tmp_path: Path) -> Path:
     )
     (trial / "persona_meta.json").write_text(
         json.dumps(
-            {
+            persona
+            or {
                 "persona_id": "0042",
                 "display_name": "Siti Rahman",
                 "dimensions": {"life_stage": "early_career"},
@@ -58,13 +69,156 @@ def _write_survey_job(tmp_path: Path) -> Path:
         ),
         encoding="utf-8",
     )
-    (output / "survey_result.json").write_text(
+    return trial
+
+
+def _write_survey_job(tmp_path: Path, *, via_structured: bool = False) -> Path:
+    job = tmp_path / "jobs" / "demo-survey"
+    trial = _write_trial_shell(job, "survey_demo__abc123")
+    output = trial / "artifacts" / "app" / "output"
+    if via_structured:
+        verifier = trial / "verifier"
+        verifier.mkdir(parents=True, exist_ok=True)
+        (verifier / "structured_output.json").write_text(
+            json.dumps(
+                {
+                    "taskType": "survey",
+                    "contexts": [
+                        {
+                            "contextType": "question_response",
+                            "key": "question.q0",
+                            "facets": [{"key": "response", "value": "option_a"}],
+                        },
+                        {
+                            "contextType": "question_response",
+                            "key": "question.overall_interest",
+                            "facets": [{"key": "response", "value": 4}],
+                        },
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+    else:
+        (output / "survey_result.json").write_text(
+            json.dumps(
+                {
+                    "answers": [
+                        {"questionId": "q0", "value": "option_a"},
+                        {"questionId": "overall_interest", "value": 4},
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+    return job
+
+
+def _write_web_job(tmp_path: Path) -> Path:
+    job = tmp_path / "jobs" / "demo-web"
+    trial = _write_trial_shell(job, "web_demo__xyz")
+    verifier = trial / "verifier"
+    verifier.mkdir(parents=True)
+    (verifier / "structured_output.json").write_text(
         json.dumps(
             {
-                "answers": [
-                    {"questionId": "q0", "value": "option_a"},
-                    {"questionId": "overall_interest", "value": 4},
-                ]
+                "taskType": "web",
+                "contexts": [
+                    {
+                        "contextType": "task_outcome",
+                        "key": "task_outcome.primary",
+                        "facets": [{"key": "outcome_status", "value": "passed"}],
+                    },
+                    {
+                        "contextType": "web_artifact",
+                        "key": "web_artifact.primary",
+                        "facets": [
+                            {"key": "artifact_subject_label", "value": "Plus"},
+                            {"key": "artifact_subject_id", "value": "plus"},
+                        ],
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return job
+
+
+def _write_chat_job(tmp_path: Path) -> Path:
+    job = tmp_path / "jobs" / "demo-chat"
+    trial = _write_trial_shell(job, "chat_demo__xyz")
+    verifier = trial / "verifier"
+    verifier.mkdir(parents=True)
+    (verifier / "structured_output.json").write_text(
+        json.dumps(
+            {
+                "taskType": "chatbot",
+                "contexts": [
+                    {
+                        "contextType": "task_outcome",
+                        "key": "task_outcome.primary",
+                        "facets": [
+                            {"key": "outcome_status", "value": "partially_resolved"}
+                        ],
+                    },
+                    {
+                        "contextType": "conversation_summary",
+                        "key": "conversation_summary.primary",
+                        "facets": [
+                            {"key": "conversation_path", "value": "clarify_then_partial"}
+                        ],
+                    },
+                    {
+                        "contextType": "user_feedback",
+                        "key": "user_feedback.primary",
+                        "facets": [
+                            {"key": "overall_experience_rating", "value": 4}
+                        ],
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return job
+
+
+def _write_os_app_job(tmp_path: Path) -> Path:
+    job = tmp_path / "jobs" / "demo-os-app"
+    trial = _write_trial_shell(job, "os_demo__xyz")
+    verifier = trial / "verifier"
+    verifier.mkdir(parents=True)
+    (verifier / "structured_output.json").write_text(
+        json.dumps(
+            {
+                "taskType": "os-app",
+                "contexts": [
+                    {
+                        "contextType": "task_outcome",
+                        "key": "task_outcome.primary",
+                        "facets": [{"key": "outcome_status", "value": "passed"}],
+                    },
+                    {
+                        "contextType": "goal_component",
+                        "key": "goal_component.viewed_chart",
+                        "facets": [
+                            {"key": "goal_component_key", "value": "viewed_chart"},
+                            {"key": "goal_component_status", "value": "passed"},
+                        ],
+                    },
+                    {
+                        "contextType": "decision",
+                        "key": "decision.sentiment",
+                        "facets": [
+                            {"key": "decision_outcome", "value": "hold"},
+                            {
+                                "key": "decision_subject_label",
+                                "value": "Micron Technology (MU)",
+                            },
+                        ],
+                    },
+                ],
             }
         ),
         encoding="utf-8",
@@ -82,11 +236,46 @@ def test_collect_job_results_survey_distributions(tmp_path: Path) -> None:
     job = _write_survey_job(tmp_path)
     report = collect_job_results(job, group_by=["life_stage"])
     assert report.n_trials == 1
+    assert report.app_type == "survey"
     assert report.usage.cost_usd == 0.012
     assert report.trials[0].reward == 1.0
     assert report.question_distributions["q0"] == {"option_a": 1}
+    assert report.lens is not None
+    assert report.lens.kind == "survey"
     assert "life_stage" in report.grouped_distributions
     assert "early_career" in report.grouped_distributions["life_stage"]
+
+
+def test_survey_prefers_structured_output(tmp_path: Path) -> None:
+    job = _write_survey_job(tmp_path, via_structured=True)
+    report = collect_job_results(job)
+    assert report.app_type == "survey"
+    assert report.lens is not None
+    assert report.lens.source == "structured_output"
+    assert report.question_distributions["q0"] == {"option_a": 1}
+
+
+def test_web_chat_os_primary_summaries(tmp_path: Path) -> None:
+    web = collect_job_results(_write_web_job(tmp_path))
+    assert web.app_type == "web"
+    assert web.lens is not None
+    assert "Plus" in web.lens.primary_summary
+    text = format_text_report(web)
+    assert "App: web" in text
+    assert "Primary:" in text
+    assert "Health:" in text
+
+    chat = collect_job_results(_write_chat_job(tmp_path))
+    assert chat.app_type == "chatbot"
+    assert chat.lens is not None
+    assert "partially_resolved" in chat.lens.primary_summary
+    assert any(metric.key == "avg_overall_experience_rating" for metric in chat.lens.metrics)
+
+    os_app = collect_job_results(_write_os_app_job(tmp_path))
+    assert os_app.app_type == "os-app"
+    assert os_app.lens is not None
+    assert "Pass rate" in os_app.lens.primary_summary
+    assert any(dist.key == "decision_outcome" for dist in os_app.lens.distributions)
 
 
 def test_formatters_include_usage_and_answers(tmp_path: Path) -> None:
@@ -94,10 +283,14 @@ def test_formatters_include_usage_and_answers(tmp_path: Path) -> None:
     report = collect_job_results(job)
     text = format_text_report(report)
     assert "demo-survey" in text
+    assert "App: survey" in text
     assert "0.012" in text
     assert "q0" in text
     payload = json.loads(format_json_report(report))
-    assert payload["trials"][0]["survey_answers"]["overall_interest"] == 4
+    assert payload["schemaVersion"] == SCHEMA_VERSION
+    assert payload["appType"] == "survey"
+    assert payload["ledger"]["trials"][0]["survey_answers"]["overall_interest"] == 4
+    assert payload["lens"]["kind"] == "survey"
     csv_text = format_csv_report(report)
     assert "answer_q0" in csv_text
     assert "option_a" in csv_text

--- a/tests/unit/matraix/test_matraix_cli.py
+++ b/tests/unit/matraix/test_matraix_cli.py
@@ -235,3 +235,31 @@ def test_main_run_sets_max_cost_usd_env(tmp_path: Path, monkeypatch) -> None:
         "configs/jobs/application-task-job-recipe/example-survey-auto-n1.yaml",
         "--yes",
     ]
+
+
+def test_main_results_prints_text_summary(tmp_path: Path, monkeypatch, capsys) -> None:
+    from matraix.job_results import collect_job_results
+
+    job = tmp_path / "jobs" / "cli-results-demo"
+    trial = job / "trial-1"
+    output = trial / "artifacts" / "app" / "output"
+    output.mkdir(parents=True)
+    (job / "result.json").write_text(
+        json.dumps({"stats": {"n_completed_trials": 1, "n_errored_trials": 0}}),
+        encoding="utf-8",
+    )
+    (trial / "result.json").write_text(
+        json.dumps({"verifier_result": {"rewards": {"reward": 1.0}}}),
+        encoding="utf-8",
+    )
+    (output / "survey_result.json").write_text(
+        json.dumps({"answers": [{"questionId": "q0", "value": "yes"}]}),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    cli.main(["results", "cli-results-demo", "--repo-root", str(tmp_path)])
+    out = capsys.readouterr().out
+    assert "cli-results-demo" in out
+    assert "q0" in out
+    report = collect_job_results(job)
+    assert report.question_distributions["q0"]["yes"] == 1


### PR DESCRIPTION
## Summary

- Add `matraix results <job>` so a finished job can be summarized from the CLI: trial counts, usage/cost when recorded, survey question distributions, and artifact paths
- Support `--format text,json,csv`, optional `--group-by` persona dimension cuts, and `-o` file/directory export
- Fix the quickstart job tree so trial files are named `result.json`, and point readers at the new command

Related to #78 (results/export and docs path consistency).

## Test plan

- [x] `pytest tests/unit/matraix/test_job_results.py tests/unit/matraix/test_matraix_cli.py`
- [x] `uv run matraix results <survey-job>` shows question distributions
- [ ] `uv run matraix results <job> --format json,csv -o /tmp/out/`