### PR TITLE
docs: two-lane smoke in README (+ i18n)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ people**.
 
 ## Requirements
 
-- [Docker](https://docs.docker.com/get-docker/)
+- [Docker](https://docs.docker.com/get-docker/) (Web / OS-app tasks and the Docker smoke lane)
 - [uv](https://docs.astral.sh/uv/) and Python 3.12
 - Node.js 20+ (Playground / viewer frontends only)
 - Model API keys for persona-agent examples — see [agents.md](docs/environment/agents.md)
-
+  (host Survey smoke via `matraix smoke` needs none)
 > **Windows users**: run everything inside
 > [WSL2](https://learn.microsoft.com/windows/wsl/install) — open PowerShell,
 > run `wsl --install` (installs Ubuntu), then clone this repo **inside the WSL
@@ -128,15 +128,23 @@ Details: [Handbook § Persona 1M](docs/README.md#3-persona-1m-recommended).
 
 ## Quick start
 
-### Smoke test
+### Smoke tests
 
-No API key required. **Requires Docker** (the smoke job uses
-`environment.type: docker`):
+No API key required. Two lanes:
+
+**Host Survey** (no Docker) — questionnaire + fake-client `json_survey` path:
+
+```bash
+uv run matraix smoke application/tasks/example-survey_product-feedback
+```
+
+**Docker / Harbor** — hello-world stack check (`environment.type: docker`):
 
 ```bash
 uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml
 ```
 
+Details: [quickstart §3](docs/quickstart.md#3-smoke-tests-two-lanes).
 ### GUI task runs
 
 Playground picks tasks, samples personas, and launches the same Matraix Playground jobs as CLI auto mode.

--- a/docs/i18n/README.es.md
+++ b/docs/i18n/README.es.md
@@ -124,15 +124,23 @@ Detalles: [Handbook § Persona 1M](../README.md#3-persona-1m-recommended).
 
 ## Inicio rápido
 
-### Prueba de humo (smoke test)
+### Pruebas de humo (smoke tests)
 
-No se requiere clave de API. **Requiere Docker** (el job de prueba de humo usa
-`environment.type: docker`):
+No se requiere clave de API. Dos vías:
+
+**Host Survey** (sin Docker) — cuestionario + ruta `json_survey` con cliente fake:
+
+```bash
+uv run matraix smoke application/tasks/example-survey_product-feedback
+```
+
+**Docker / Harbor** — comprobación hello-world (`environment.type: docker`):
 
 ```bash
 uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml
 ```
 
+Detalles: [quickstart §3](../quickstart.md#3-smoke-tests-two-lanes).
 ### Ejecuciones de tareas por GUI
 
 Playground elige tareas, muestrea personas y lanza los mismos jobs de

--- a/docs/i18n/README.ja.md
+++ b/docs/i18n/README.ja.md
@@ -119,14 +119,23 @@ Playground: Dataset → **`matraix-persona-1m`**。CLI: `--dataset persona/datas
 
 ## クイックスタート
 
-### スモークテスト（smoke test）
+### スモークテスト（smoke tests）
 
-API キー不要。**Docker が必要**（スモークテストの job は `environment.type: docker` を使用）：
+API キー不要。2 つのレーン：
+
+**Host Survey**（Docker 不要）— アンケート + fake-client の `json_survey` パス：
+
+```bash
+uv run matraix smoke application/tasks/example-survey_product-feedback
+```
+
+**Docker / Harbor** — hello-world スタック確認（`environment.type: docker`）：
 
 ```bash
 uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml
 ```
 
+詳細: [quickstart §3](../quickstart.md#3-smoke-tests-two-lanes)。
 ### GUI でのタスク実行
 
 Playground はタスク選択・ペルソナサンプリングを行い、CLI auto モードと同じ

--- a/docs/i18n/README.ko.md
+++ b/docs/i18n/README.ko.md
@@ -118,14 +118,23 @@ Playground: Dataset → **`matraix-persona-1m`**. CLI: `--dataset persona/datase
 
 ## 빠른 시작
 
-### 스모크 테스트(smoke test)
+### 스모크 테스트(smoke tests)
 
-API 키 불필요. **Docker 필요**(스모크 테스트 job은 `environment.type: docker` 사용):
+API 키 불필요. 두 가지 레인:
+
+**Host Survey**(Docker 불필요) — 설문 + fake-client `json_survey` 경로:
+
+```bash
+uv run matraix smoke application/tasks/example-survey_product-feedback
+```
+
+**Docker / Harbor** — hello-world 스택 확인(`environment.type: docker`):
 
 ```bash
 uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml
 ```
 
+자세한 내용: [quickstart §3](../quickstart.md#3-smoke-tests-two-lanes).
 ### GUI 태스크 실행
 
 Playground는 태스크를 고르고 페르소나를 샘플링한 뒤, CLI auto 모드와 동일한

--- a/docs/i18n/README.pt-BR.md
+++ b/docs/i18n/README.pt-BR.md
@@ -123,15 +123,23 @@ Detalhes: [Handbook § Persona 1M](../README.md#3-persona-1m-recommended).
 
 ## Início rápido
 
-### Teste de fumaça (smoke test)
+### Testes de fumaça (smoke tests)
 
-Nenhuma chave de API necessária. **Requer Docker** (o job de teste de fumaça usa
-`environment.type: docker`):
+Nenhuma chave de API necessária. Duas faixas:
+
+**Host Survey** (sem Docker) — questionário + caminho `json_survey` com cliente fake:
+
+```bash
+uv run matraix smoke application/tasks/example-survey_product-feedback
+```
+
+**Docker / Harbor** — verificação hello-world (`environment.type: docker`):
 
 ```bash
 uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml
 ```
 
+Detalhes: [quickstart §3](../quickstart.md#3-smoke-tests-two-lanes).
 ### Execuções de tarefa via GUI
 
 O Playground escolhe tarefas, amostra personas e lança os mesmos jobs do

--- a/docs/i18n/README.zh-CN.md
+++ b/docs/i18n/README.zh-CN.md
@@ -107,14 +107,23 @@ Playground：Dataset → **`matraix-persona-1m`**。CLI：`--dataset persona/dat
 
 ## 快速开始
 
-### 冒烟测试（smoke test）
+### 冒烟测试（smoke tests）
 
-无需 API Key。**需要 Docker**（冒烟测试 job 使用 `environment.type: docker`）：
+无需 API Key。两条车道：
+
+**Host Survey**（无需 Docker）— 问卷 + fake-client `json_survey` 路径：
+
+```bash
+uv run matraix smoke application/tasks/example-survey_product-feedback
+```
+
+**Docker / Harbor** — hello-world 栈检查（`environment.type: docker`）：
 
 ```bash
 uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml
 ```
 
+详情：[quickstart §3](../quickstart.md#3-smoke-tests-two-lanes)。
 ### GUI 任务运行
 
 Playground 可选择任务、抽样人格，并启动与 CLI auto 模式相同的 Matraix Playground job。

--- a/docs/i18n/README.zh-TW.md
+++ b/docs/i18n/README.zh-TW.md
@@ -107,14 +107,23 @@ Playground：Dataset → **`matraix-persona-1m`**。CLI：`--dataset persona/dat
 
 ## 快速開始
 
-### 冒煙測試（smoke test）
+### 冒煙測試（smoke tests）
 
-無需 API Key。**需要 Docker**（冒煙測試 job 使用 `environment.type: docker`）：
+無需 API Key。兩條車道：
+
+**Host Survey**（無需 Docker）— 問卷 + fake-client `json_survey` 路徑：
+
+```bash
+uv run matraix smoke application/tasks/example-survey_product-feedback
+```
+
+**Docker / Harbor** — hello-world 棧檢查（`environment.type: docker`）：
 
 ```bash
 uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml
 ```
 
+詳情：[quickstart §3](../quickstart.md#3-smoke-tests-two-lanes)。
 ### GUI 任務執行
 
 Playground 可選擇任務、抽樣人格，並啟動與 CLI auto 模式相同的 Matraix Playground job。


### PR DESCRIPTION
## Summary
- Update main README Quick start smoke section to show host Survey (`matraix smoke`) and Docker (`harbor-smoke-local`) lanes.
- Soften Requirements so Docker is not implied for Survey-only onboarding.
- Mirror the same smoke section in i18n READMEs.

## Test plan
- [ ] Skim README Quick start on GitHub preview
- [ ] Confirm i18n smoke blocks still link to quickstart §3

Made with [Cursor](https://cursor.com)