### PR TITLE
docs: product-facing two-check smoke for four task types

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ people**.
 
 ## Requirements
 
-- [Docker](https://docs.docker.com/get-docker/)
+- [Docker](https://docs.docker.com/get-docker/) (Web / OS-app tasks and the Docker smoke lane)
 - [uv](https://docs.astral.sh/uv/) and Python 3.12
 - Node.js 20+ (Playground / viewer frontends only)
 - Model API keys for persona-agent examples — see [agents.md](docs/environment/agents.md)
-
+  (host Survey smoke via `matraix smoke` needs none)
 > **Windows users**: run everything inside
 > [WSL2](https://learn.microsoft.com/windows/wsl/install) — open PowerShell,
 > run `wsl --install` (installs Ubuntu), then clone this repo **inside the WSL
@@ -128,15 +128,23 @@ Details: [Handbook § Persona 1M](docs/README.md#3-persona-1m-recommended).
 
 ## Quick start
 
-### Smoke test
+### Smoke tests
 
-No API key required. **Requires Docker** (the smoke job uses
-`environment.type: docker`):
+No API key required. Two lanes:
+
+**Host Survey** (no Docker) — questionnaire + fake-client `json_survey` path:
+
+```bash
+uv run matraix smoke application/tasks/example-survey_product-feedback
+```
+
+**Docker / Harbor** — hello-world stack check (`environment.type: docker`):
 
 ```bash
 uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml
 ```
 
+Details: [quickstart §3](docs/quickstart.md#3-smoke-tests-two-lanes).
 ### GUI task runs
 
 Playground picks tasks, samples personas, and launches the same Matraix Playground jobs as CLI auto mode.

--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ people**.
 
 ## Requirements
 
-- [Docker](https://docs.docker.com/get-docker/) (Web / OS-app tasks and the Docker smoke lane)
+- [Docker](https://docs.docker.com/get-docker/) (container lane: Web / OS-app under Mode **auto**)
 - [uv](https://docs.astral.sh/uv/) and Python 3.12
 - Node.js 20+ (Playground / viewer frontends only)
 - Model API keys for persona-agent examples — see [agents.md](docs/environment/agents.md)
-  (host Survey smoke via `matraix smoke` needs none)
+  (the two onboarding smokes below need none)
 > **Windows users**: run everything inside
 > [WSL2](https://learn.microsoft.com/windows/wsl/install) — open PowerShell,
 > run `wsl --install` (installs Ubuntu), then clone this repo **inside the WSL
@@ -95,14 +95,14 @@ uv pip install -e packages/rewardkit
 ```
 
 Run jobs and tasks with **`uv run matraix run …`** — it sets up the full
-launch environment and delegates to the Harbor runtime. Check a Survey task
-with **`uv run matraix smoke <task>`** (host / `json_survey`, no Docker, no API
-key). Summarize a finished job with **`uv run matraix results <job>`** (text /
-JSON / CSV, no extra LLM call). Runtime utilities (e.g. `harbor view`,
-`harbor upload`) stay under `uv run harbor …`.
+launch environment and delegates to the Harbor runtime. Prove the two Mode
+**auto** runtimes with the [smoke tests](#smoke-tests) below (no API key).
+Summarize a finished job with **`uv run matraix results <job>`** (text / JSON /
+CSV, no extra LLM call). Runtime utilities (e.g. `harbor view`, `harbor upload`)
+stay under `uv run harbor …`.
 
 Set the model API key matching your provider before GUI or CLI task runs
-(smokes above do not need one):
+(onboarding smokes do not need one):
 
 ```bash
 export ANTHROPIC_API_KEY="sk-ant-..."   # anthropic/claude-* models
@@ -130,21 +130,18 @@ Details: [Handbook § Persona 1M](docs/README.md#3-persona-1m-recommended).
 
 ### Smoke tests
 
-No API key required. Two lanes:
+Under Mode **auto**, all four application types share **two runtimes**. The
+onboarding smokes prove those runtimes are ready (no API key):
 
-**Host Survey** (no Docker) — questionnaire + fake-client `json_survey` path:
+| Lane | Covers under **auto** | Command |
+|------|------------------------|---------|
+| **Host** | Survey + Chat | `uv run matraix smoke application/tasks/example-survey_product-feedback` |
+| **Container** | Web + OS-app | `uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml` |
 
-```bash
-uv run matraix smoke application/tasks/example-survey_product-feedback
-```
+Host smoke uses a Survey task as the representative (zero-cost fake client).
+Container smoke uses the Harbor hello-world image (first run may take several
+minutes to build). Details: [quickstart §3](docs/quickstart.md#3-smoke-tests-two-lanes).
 
-**Docker / Harbor** — hello-world stack check (`environment.type: docker`):
-
-```bash
-uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml
-```
-
-Details: [quickstart §3](docs/quickstart.md#3-smoke-tests-two-lanes).
 ### GUI task runs
 
 Playground picks tasks, samples personas, and launches the same Matraix Playground jobs as CLI auto mode.

--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ people**.
 
 ## Requirements
 
-- [Docker](https://docs.docker.com/get-docker/) (container lane: Web / OS-app under Mode **auto**)
+- [Docker](https://docs.docker.com/get-docker/) — needed for Web and OS-app tasks
 - [uv](https://docs.astral.sh/uv/) and Python 3.12
 - Node.js 20+ (Playground / viewer frontends only)
-- Model API keys for persona-agent examples — see [agents.md](docs/environment/agents.md)
-  (the two onboarding smokes below need none)
+- Model API keys for real persona runs — see [agents.md](docs/environment/agents.md)
+  (the install checks below do not need a key)
 > **Windows users**: run everything inside
 > [WSL2](https://learn.microsoft.com/windows/wsl/install) — open PowerShell,
 > run `wsl --install` (installs Ubuntu), then clone this repo **inside the WSL
@@ -94,15 +94,13 @@ uv pip install -e packages/harbor-langsmith
 uv pip install -e packages/rewardkit
 ```
 
-Run jobs and tasks with **`uv run matraix run …`** — it sets up the full
-launch environment and delegates to the Harbor runtime. Prove the two Mode
-**auto** runtimes with the [smoke tests](#smoke-tests) below (no API key).
-Summarize a finished job with **`uv run matraix results <job>`** (text / JSON /
-CSV, no extra LLM call). Runtime utilities (e.g. `harbor view`, `harbor upload`)
-stay under `uv run harbor …`.
+Run jobs with **`uv run matraix run …`**. After install, use the
+[smoke tests](#smoke-tests) below to confirm Survey, Chat, Web, and OS-app are
+ready (no API key). Summarize a finished job with
+**`uv run matraix results <job>`**. Advanced runtime tools stay under
+`uv run harbor …`.
 
-Set the model API key matching your provider before GUI or CLI task runs
-(onboarding smokes do not need one):
+Set a model API key before real GUI or CLI runs (smoke checks do not need one):
 
 ```bash
 export ANTHROPIC_API_KEY="sk-ant-..."   # anthropic/claude-* models
@@ -130,17 +128,17 @@ Details: [Handbook § Persona 1M](docs/README.md#3-persona-1m-recommended).
 
 ### Smoke tests
 
-Under Mode **auto**, all four application types share **two runtimes**. The
-onboarding smokes prove those runtimes are ready (no API key):
+Two quick checks after install — no API key. Together they cover the default
+path for all four task types (Survey, Chat, Web, OS-app):
 
-| Lane | Covers under **auto** | Command |
-|------|------------------------|---------|
-| **Host** | Survey + Chat | `uv run matraix smoke application/tasks/example-survey_product-feedback` |
-| **Container** | Web + OS-app | `uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml` |
+| Check | Confirms you can run | Command |
+|-------|----------------------|---------|
+| **Without Docker** | Survey and Chat | `uv run matraix smoke application/tasks/example-survey_product-feedback` |
+| **With Docker** | Web and OS-app | `uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml` |
 
-Host smoke uses a Survey task as the representative (zero-cost fake client).
-Container smoke uses the Harbor hello-world image (first run may take several
-minutes to build). Details: [quickstart §3](docs/quickstart.md#3-smoke-tests-two-lanes).
+The first finishes in seconds and should print `Smoke: ok`. The second builds a
+small local image on first run (a few minutes), then writes under
+`jobs/harbor-smoke-local/`. Step-by-step: [quickstart §3](docs/quickstart.md#3-smoke-tests-two-lanes).
 
 ### GUI task runs
 

--- a/docs/i18n/README.es.md
+++ b/docs/i18n/README.es.md
@@ -126,21 +126,14 @@ Detalles: [Handbook § Persona 1M](../README.md#3-persona-1m-recommended).
 
 ### Pruebas de humo (smoke tests)
 
-No se requiere clave de API. Dos vías:
+En Mode **auto**, los cuatro tipos de aplicación comparten **dos runtimes**. Las pruebas de humo de onboarding certifican esos carriles (sin clave de API) y dejan listos los cuatro tipos:
 
-**Host Survey** (sin Docker) — cuestionario + ruta `json_survey` con cliente fake:
+| Carril | Cubre en **auto** | Comando |
+|--------|-------------------|---------|
+| **Host** | Survey + Chat | `uv run matraix smoke application/tasks/example-survey_product-feedback` |
+| **Container** | Web + OS-app | `uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml` |
 
-```bash
-uv run matraix smoke application/tasks/example-survey_product-feedback
-```
-
-**Docker / Harbor** — comprobación hello-world (`environment.type: docker`):
-
-```bash
-uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml
-```
-
-Detalles: [quickstart §3](../quickstart.md#3-smoke-tests-two-lanes).
+Host usa Survey como representante (cliente fake, coste 0). Container usa la imagen hello-world de Harbor (la primera ejecución puede tardar minutos en construir). Detalles: [quickstart §3](../quickstart.md#3-smoke-tests-two-lanes).
 ### Ejecuciones de tareas por GUI
 
 Playground elige tareas, muestrea personas y lanza los mismos jobs de

--- a/docs/i18n/README.es.md
+++ b/docs/i18n/README.es.md
@@ -126,14 +126,15 @@ Detalles: [Handbook § Persona 1M](../README.md#3-persona-1m-recommended).
 
 ### Pruebas de humo (smoke tests)
 
-En Mode **auto**, los cuatro tipos de aplicación comparten **dos runtimes**. Las pruebas de humo de onboarding certifican esos carriles (sin clave de API) y dejan listos los cuatro tipos:
+Tras instalar, ejecuta estas dos comprobaciones (sin clave de API). Juntas
+confirman la ruta por defecto de Survey, Chat, Web y OS-app:
 
-| Carril | Cubre en **auto** | Comando |
-|--------|-------------------|---------|
-| **Host** | Survey + Chat | `uv run matraix smoke application/tasks/example-survey_product-feedback` |
-| **Container** | Web + OS-app | `uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml` |
+| Comprobación | Confirma que puedes ejecutar | Comando |
+|--------------|------------------------------|---------|
+| **Sin Docker** | Survey y Chat | `uv run matraix smoke application/tasks/example-survey_product-feedback` |
+| **Con Docker** | Web y OS-app | `uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml` |
 
-Host usa Survey como representante (cliente fake, coste 0). Container usa la imagen hello-world de Harbor (la primera ejecución puede tardar minutos en construir). Detalles: [quickstart §3](../quickstart.md#3-smoke-tests-two-lanes).
+La primera suele terminar en segundos con `Smoke: ok`. La segunda construye una imagen local la primera vez (unos minutos) y escribe en `jobs/harbor-smoke-local/`. Pasos: [quickstart §3](../quickstart.md#3-smoke-tests-two-lanes).
 ### Ejecuciones de tareas por GUI
 
 Playground elige tareas, muestrea personas y lanza los mismos jobs de

--- a/docs/i18n/README.es.md
+++ b/docs/i18n/README.es.md
@@ -124,15 +124,23 @@ Detalles: [Handbook § Persona 1M](../README.md#3-persona-1m-recommended).
 
 ## Inicio rápido
 
-### Prueba de humo (smoke test)
+### Pruebas de humo (smoke tests)
 
-No se requiere clave de API. **Requiere Docker** (el job de prueba de humo usa
-`environment.type: docker`):
+No se requiere clave de API. Dos vías:
+
+**Host Survey** (sin Docker) — cuestionario + ruta `json_survey` con cliente fake:
+
+```bash
+uv run matraix smoke application/tasks/example-survey_product-feedback
+```
+
+**Docker / Harbor** — comprobación hello-world (`environment.type: docker`):
 
 ```bash
 uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml
 ```
 
+Detalles: [quickstart §3](../quickstart.md#3-smoke-tests-two-lanes).
 ### Ejecuciones de tareas por GUI
 
 Playground elige tareas, muestrea personas y lanza los mismos jobs de

--- a/docs/i18n/README.ja.md
+++ b/docs/i18n/README.ja.md
@@ -119,14 +119,23 @@ Playground: Dataset → **`matraix-persona-1m`**。CLI: `--dataset persona/datas
 
 ## クイックスタート
 
-### スモークテスト（smoke test）
+### スモークテスト（smoke tests）
 
-API キー不要。**Docker が必要**（スモークテストの job は `environment.type: docker` を使用）：
+API キー不要。2 つのレーン：
+
+**Host Survey**（Docker 不要）— アンケート + fake-client の `json_survey` パス：
+
+```bash
+uv run matraix smoke application/tasks/example-survey_product-feedback
+```
+
+**Docker / Harbor** — hello-world スタック確認（`environment.type: docker`）：
 
 ```bash
 uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml
 ```
 
+詳細: [quickstart §3](../quickstart.md#3-smoke-tests-two-lanes)。
 ### GUI でのタスク実行
 
 Playground はタスク選択・ペルソナサンプリングを行い、CLI auto モードと同じ

--- a/docs/i18n/README.ja.md
+++ b/docs/i18n/README.ja.md
@@ -121,21 +121,14 @@ Playground: Dataset → **`matraix-persona-1m`**。CLI: `--dataset persona/datas
 
 ### スモークテスト（smoke tests）
 
-API キー不要。2 つのレーン：
+Mode **auto** では、4 種類型のアプリタスクが **2 つのランタイム** を共有します。オンボーディング用スモークで両レーンを確認すれば（API キー不要）、4 種類は基本的に実行可能です：
 
-**Host Survey**（Docker 不要）— アンケート + fake-client の `json_survey` パス：
+| レーン | **auto** がカバー | コマンド |
+|--------|-------------------|----------|
+| **Host** | Survey + Chat | `uv run matraix smoke application/tasks/example-survey_product-feedback` |
+| **Container** | Web + OS-app | `uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml` |
 
-```bash
-uv run matraix smoke application/tasks/example-survey_product-feedback
-```
-
-**Docker / Harbor** — hello-world スタック確認（`environment.type: docker`）：
-
-```bash
-uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml
-```
-
-詳細: [quickstart §3](../quickstart.md#3-smoke-tests-two-lanes)。
+Host は Survey を代表に使用（ゼロコストの fake client）。Container は Harbor hello-world イメージ（初回は数分のビルドあり）。詳細: [quickstart §3](../quickstart.md#3-smoke-tests-two-lanes)。
 ### GUI でのタスク実行
 
 Playground はタスク選択・ペルソナサンプリングを行い、CLI auto モードと同じ

--- a/docs/i18n/README.ja.md
+++ b/docs/i18n/README.ja.md
@@ -121,14 +121,15 @@ Playground: Dataset → **`matraix-persona-1m`**。CLI: `--dataset persona/datas
 
 ### スモークテスト（smoke tests）
 
-Mode **auto** では、4 種類型のアプリタスクが **2 つのランタイム** を共有します。オンボーディング用スモークで両レーンを確認すれば（API キー不要）、4 種類は基本的に実行可能です：
+インストール後に、次の 2 つのチェックを実行してください（API キー不要）。
+あわせて Survey / Chat / Web / OS-app のデフォルト実行パスが使えることを確認できます：
 
-| レーン | **auto** がカバー | コマンド |
-|--------|-------------------|----------|
-| **Host** | Survey + Chat | `uv run matraix smoke application/tasks/example-survey_product-feedback` |
-| **Container** | Web + OS-app | `uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml` |
+| チェック | 確認できること | コマンド |
+|----------|----------------|----------|
+| **Docker なし** | Survey と Chat | `uv run matraix smoke application/tasks/example-survey_product-feedback` |
+| **Docker あり** | Web と OS-app | `uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml` |
 
-Host は Survey を代表に使用（ゼロコストの fake client）。Container は Harbor hello-world イメージ（初回は数分のビルドあり）。詳細: [quickstart §3](../quickstart.md#3-smoke-tests-two-lanes)。
+1 つ目は数秒で `Smoke: ok` と表示されます。2 つ目は初回にローカルイメージをビルドします（数分）。成功時の出力は `jobs/harbor-smoke-local/`。手順: [quickstart §3](../quickstart.md#3-smoke-tests-two-lanes)。
 ### GUI でのタスク実行
 
 Playground はタスク選択・ペルソナサンプリングを行い、CLI auto モードと同じ

--- a/docs/i18n/README.ko.md
+++ b/docs/i18n/README.ko.md
@@ -120,21 +120,14 @@ Playground: Dataset → **`matraix-persona-1m`**. CLI: `--dataset persona/datase
 
 ### 스모크 테스트(smoke tests)
 
-API 키 불필요. 두 가지 레인:
+Mode **auto**에서 네 가지 앱 타입은 **두 런타임**을 공유합니다. 온보딩 스모크로 두 레인을 확인하면(API 키 불필요) 네 타입이 기본적으로 실행 가능한 상태입니다:
 
-**Host Survey**(Docker 불필요) — 설문 + fake-client `json_survey` 경로:
+| 레인 | **auto** 범위 | 명령 |
+|------|---------------|------|
+| **Host** | Survey + Chat | `uv run matraix smoke application/tasks/example-survey_product-feedback` |
+| **Container** | Web + OS-app | `uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml` |
 
-```bash
-uv run matraix smoke application/tasks/example-survey_product-feedback
-```
-
-**Docker / Harbor** — hello-world 스택 확인(`environment.type: docker`):
-
-```bash
-uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml
-```
-
-자세한 내용: [quickstart §3](../quickstart.md#3-smoke-tests-two-lanes).
+Host는 Survey를 대표로 사용(제로 비용 fake client). Container는 Harbor hello-world 이미지(첫 실행 시 수 분 빌드 가능). 자세한 내용: [quickstart §3](../quickstart.md#3-smoke-tests-two-lanes).
 ### GUI 태스크 실행
 
 Playground는 태스크를 고르고 페르소나를 샘플링한 뒤, CLI auto 모드와 동일한

--- a/docs/i18n/README.ko.md
+++ b/docs/i18n/README.ko.md
@@ -118,14 +118,23 @@ Playground: Dataset → **`matraix-persona-1m`**. CLI: `--dataset persona/datase
 
 ## 빠른 시작
 
-### 스모크 테스트(smoke test)
+### 스모크 테스트(smoke tests)
 
-API 키 불필요. **Docker 필요**(스모크 테스트 job은 `environment.type: docker` 사용):
+API 키 불필요. 두 가지 레인:
+
+**Host Survey**(Docker 불필요) — 설문 + fake-client `json_survey` 경로:
+
+```bash
+uv run matraix smoke application/tasks/example-survey_product-feedback
+```
+
+**Docker / Harbor** — hello-world 스택 확인(`environment.type: docker`):
 
 ```bash
 uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml
 ```
 
+자세한 내용: [quickstart §3](../quickstart.md#3-smoke-tests-two-lanes).
 ### GUI 태스크 실행
 
 Playground는 태스크를 고르고 페르소나를 샘플링한 뒤, CLI auto 모드와 동일한

--- a/docs/i18n/README.ko.md
+++ b/docs/i18n/README.ko.md
@@ -120,14 +120,15 @@ Playground: Dataset → **`matraix-persona-1m`**. CLI: `--dataset persona/datase
 
 ### 스모크 테스트(smoke tests)
 
-Mode **auto**에서 네 가지 앱 타입은 **두 런타임**을 공유합니다. 온보딩 스모크로 두 레인을 확인하면(API 키 불필요) 네 타입이 기본적으로 실행 가능한 상태입니다:
+설치 후 아래 두 검사를 실행하세요(API 키 불필요). 함께 돌리면 Survey / Chat / Web / OS-app
+기본 실행 경로가 준비되었는지 확인할 수 있습니다:
 
-| 레인 | **auto** 범위 | 명령 |
-|------|---------------|------|
-| **Host** | Survey + Chat | `uv run matraix smoke application/tasks/example-survey_product-feedback` |
-| **Container** | Web + OS-app | `uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml` |
+| 검사 | 확인할 수 있는 것 | 명령 |
+|------|-------------------|------|
+| **Docker 없이** | Survey와 Chat | `uv run matraix smoke application/tasks/example-survey_product-feedback` |
+| **Docker 사용** | Web와 OS-app | `uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml` |
 
-Host는 Survey를 대표로 사용(제로 비용 fake client). Container는 Harbor hello-world 이미지(첫 실행 시 수 분 빌드 가능). 자세한 내용: [quickstart §3](../quickstart.md#3-smoke-tests-two-lanes).
+첫 번째는 보통 몇 초 안에 `Smoke: ok`를 출력합니다. 두 번째는 첫 실행 시 로컬 이미지를 빌드합니다(수 분). 성공 시 출력은 `jobs/harbor-smoke-local/`. 단계: [quickstart §3](../quickstart.md#3-smoke-tests-two-lanes).
 ### GUI 태스크 실행
 
 Playground는 태스크를 고르고 페르소나를 샘플링한 뒤, CLI auto 모드와 동일한

--- a/docs/i18n/README.pt-BR.md
+++ b/docs/i18n/README.pt-BR.md
@@ -125,14 +125,15 @@ Detalhes: [Handbook § Persona 1M](../README.md#3-persona-1m-recommended).
 
 ### Testes de fumaça (smoke tests)
 
-No Mode **auto**, os quatro tipos de aplicação compartilham **dois runtimes**. Os smokes de onboarding certificam essas faixas (sem chave de API) e deixam os quatro tipos basicamente prontos:
+Após instalar, rode estas duas verificações (sem chave de API). Juntas elas
+confirmam o caminho padrão de Survey, Chat, Web e OS-app:
 
-| Faixa | Cobre no **auto** | Comando |
-|-------|-------------------|---------|
-| **Host** | Survey + Chat | `uv run matraix smoke application/tasks/example-survey_product-feedback` |
-| **Container** | Web + OS-app | `uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml` |
+| Verificação | Confirma que você pode rodar | Comando |
+|-------------|------------------------------|---------|
+| **Sem Docker** | Survey e Chat | `uv run matraix smoke application/tasks/example-survey_product-feedback` |
+| **Com Docker** | Web e OS-app | `uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml` |
 
-Host usa Survey como representante (cliente fake, custo $0). Container usa a imagem hello-world do Harbor (a primeira execução pode levar minutos para build). Detalhes: [quickstart §3](../quickstart.md#3-smoke-tests-two-lanes).
+A primeira costuma terminar em segundos com `Smoke: ok`. A segunda constrói uma imagem local na primeira execução (alguns minutos) e grava em `jobs/harbor-smoke-local/`. Passos: [quickstart §3](../quickstart.md#3-smoke-tests-two-lanes).
 ### Execuções de tarefa via GUI
 
 O Playground escolhe tarefas, amostra personas e lança os mesmos jobs do

--- a/docs/i18n/README.pt-BR.md
+++ b/docs/i18n/README.pt-BR.md
@@ -123,15 +123,23 @@ Detalhes: [Handbook § Persona 1M](../README.md#3-persona-1m-recommended).
 
 ## Início rápido
 
-### Teste de fumaça (smoke test)
+### Testes de fumaça (smoke tests)
 
-Nenhuma chave de API necessária. **Requer Docker** (o job de teste de fumaça usa
-`environment.type: docker`):
+Nenhuma chave de API necessária. Duas faixas:
+
+**Host Survey** (sem Docker) — questionário + caminho `json_survey` com cliente fake:
+
+```bash
+uv run matraix smoke application/tasks/example-survey_product-feedback
+```
+
+**Docker / Harbor** — verificação hello-world (`environment.type: docker`):
 
 ```bash
 uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml
 ```
 
+Detalhes: [quickstart §3](../quickstart.md#3-smoke-tests-two-lanes).
 ### Execuções de tarefa via GUI
 
 O Playground escolhe tarefas, amostra personas e lança os mesmos jobs do

--- a/docs/i18n/README.pt-BR.md
+++ b/docs/i18n/README.pt-BR.md
@@ -125,21 +125,14 @@ Detalhes: [Handbook § Persona 1M](../README.md#3-persona-1m-recommended).
 
 ### Testes de fumaça (smoke tests)
 
-Nenhuma chave de API necessária. Duas faixas:
+No Mode **auto**, os quatro tipos de aplicação compartilham **dois runtimes**. Os smokes de onboarding certificam essas faixas (sem chave de API) e deixam os quatro tipos basicamente prontos:
 
-**Host Survey** (sem Docker) — questionário + caminho `json_survey` com cliente fake:
+| Faixa | Cobre no **auto** | Comando |
+|-------|-------------------|---------|
+| **Host** | Survey + Chat | `uv run matraix smoke application/tasks/example-survey_product-feedback` |
+| **Container** | Web + OS-app | `uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml` |
 
-```bash
-uv run matraix smoke application/tasks/example-survey_product-feedback
-```
-
-**Docker / Harbor** — verificação hello-world (`environment.type: docker`):
-
-```bash
-uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml
-```
-
-Detalhes: [quickstart §3](../quickstart.md#3-smoke-tests-two-lanes).
+Host usa Survey como representante (cliente fake, custo $0). Container usa a imagem hello-world do Harbor (a primeira execução pode levar minutos para build). Detalhes: [quickstart §3](../quickstart.md#3-smoke-tests-two-lanes).
 ### Execuções de tarefa via GUI
 
 O Playground escolhe tarefas, amostra personas e lança os mesmos jobs do

--- a/docs/i18n/README.zh-CN.md
+++ b/docs/i18n/README.zh-CN.md
@@ -107,14 +107,23 @@ Playground：Dataset → **`matraix-persona-1m`**。CLI：`--dataset persona/dat
 
 ## 快速开始
 
-### 冒烟测试（smoke test）
+### 冒烟测试（smoke tests）
 
-无需 API Key。**需要 Docker**（冒烟测试 job 使用 `environment.type: docker`）：
+无需 API Key。两条车道：
+
+**Host Survey**（无需 Docker）— 问卷 + fake-client `json_survey` 路径：
+
+```bash
+uv run matraix smoke application/tasks/example-survey_product-feedback
+```
+
+**Docker / Harbor** — hello-world 栈检查（`environment.type: docker`）：
 
 ```bash
 uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml
 ```
 
+详情：[quickstart §3](../quickstart.md#3-smoke-tests-two-lanes)。
 ### GUI 任务运行
 
 Playground 可选择任务、抽样人格，并启动与 CLI auto 模式相同的 Matraix Playground job。

--- a/docs/i18n/README.zh-CN.md
+++ b/docs/i18n/README.zh-CN.md
@@ -109,21 +109,14 @@ Playground：Dataset → **`matraix-persona-1m`**。CLI：`--dataset persona/dat
 
 ### 冒烟测试（smoke tests）
 
-无需 API Key。两条车道：
+Mode **auto** 下，四类应用任务共用 **两条 runtime**。Onboarding smoke 验证这两条车道（无需 API Key）即表示四类基本可跑：
 
-**Host Survey**（无需 Docker）— 问卷 + fake-client `json_survey` 路径：
+| 车道 | **auto** 覆盖 | 命令 |
+|------|---------------|------|
+| **Host** | Survey + Chat | `uv run matraix smoke application/tasks/example-survey_product-feedback` |
+| **Container** | Web + OS-app | `uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml` |
 
-```bash
-uv run matraix smoke application/tasks/example-survey_product-feedback
-```
-
-**Docker / Harbor** — hello-world 栈检查（`environment.type: docker`）：
-
-```bash
-uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml
-```
-
-详情：[quickstart §3](../quickstart.md#3-smoke-tests-two-lanes)。
+Host 以 Survey 为代表（零成本 fake client）；Container 用 Harbor hello-world 镜像（首次可能需几分钟构建）。详情：[quickstart §3](../quickstart.md#3-smoke-tests-two-lanes)。
 ### GUI 任务运行
 
 Playground 可选择任务、抽样人格，并启动与 CLI auto 模式相同的 Matraix Playground job。

--- a/docs/i18n/README.zh-CN.md
+++ b/docs/i18n/README.zh-CN.md
@@ -109,14 +109,15 @@ Playground：Dataset → **`matraix-persona-1m`**。CLI：`--dataset persona/dat
 
 ### 冒烟测试（smoke tests）
 
-Mode **auto** 下，四类应用任务共用 **两条 runtime**。Onboarding smoke 验证这两条车道（无需 API Key）即表示四类基本可跑：
+安装后先跑这两条检查（无需 API Key）。合在一起就覆盖默认路径下的四类任务
+（Survey、Chat、Web、OS-app）：
 
-| 车道 | **auto** 覆盖 | 命令 |
-|------|---------------|------|
-| **Host** | Survey + Chat | `uv run matraix smoke application/tasks/example-survey_product-feedback` |
-| **Container** | Web + OS-app | `uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml` |
+| 检查 | 确认你可以跑 | 命令 |
+|------|--------------|------|
+| **不用 Docker** | Survey、Chat | `uv run matraix smoke application/tasks/example-survey_product-feedback` |
+| **需要 Docker** | Web、OS-app | `uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml` |
 
-Host 以 Survey 为代表（零成本 fake client）；Container 用 Harbor hello-world 镜像（首次可能需几分钟构建）。详情：[quickstart §3](../quickstart.md#3-smoke-tests-two-lanes)。
+第一条通常几秒内打印 `Smoke: ok`。第二条首次会构建本地镜像（几分钟），成功后输出在 `jobs/harbor-smoke-local/`。步骤说明：[quickstart §3](../quickstart.md#3-smoke-tests-two-lanes)。
 ### GUI 任务运行
 
 Playground 可选择任务、抽样人格，并启动与 CLI auto 模式相同的 Matraix Playground job。

--- a/docs/i18n/README.zh-TW.md
+++ b/docs/i18n/README.zh-TW.md
@@ -109,14 +109,15 @@ Playground：Dataset → **`matraix-persona-1m`**。CLI：`--dataset persona/dat
 
 ### 冒煙測試（smoke tests）
 
-Mode **auto** 下，四類應用任務共用 **兩條 runtime**。Onboarding smoke 驗證這兩條車道（無需 API Key）即表示四類基本可跑：
+安裝後先跑這兩條檢查（無需 API Key）。合在一起就覆蓋預設路徑下的四類任務
+（Survey、Chat、Web、OS-app）：
 
-| 車道 | **auto** 覆蓋 | 命令 |
-|------|---------------|------|
-| **Host** | Survey + Chat | `uv run matraix smoke application/tasks/example-survey_product-feedback` |
-| **Container** | Web + OS-app | `uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml` |
+| 檢查 | 確認你可以跑 | 命令 |
+|------|--------------|------|
+| **不用 Docker** | Survey、Chat | `uv run matraix smoke application/tasks/example-survey_product-feedback` |
+| **需要 Docker** | Web、OS-app | `uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml` |
 
-Host 以 Survey 為代表（零成本 fake client）；Container 用 Harbor hello-world 映像（首次可能需幾分鐘建置）。詳情：[quickstart §3](../quickstart.md#3-smoke-tests-two-lanes)。
+第一條通常幾秒內印出 `Smoke: ok`。第二條首次會建置本地映像（幾分鐘），成功後輸出在 `jobs/harbor-smoke-local/`。步驟說明：[quickstart §3](../quickstart.md#3-smoke-tests-two-lanes)。
 ### GUI 任務執行
 
 Playground 可選擇任務、抽樣人格，並啟動與 CLI auto 模式相同的 Matraix Playground job。

--- a/docs/i18n/README.zh-TW.md
+++ b/docs/i18n/README.zh-TW.md
@@ -107,14 +107,23 @@ Playground：Dataset → **`matraix-persona-1m`**。CLI：`--dataset persona/dat
 
 ## 快速開始
 
-### 冒煙測試（smoke test）
+### 冒煙測試（smoke tests）
 
-無需 API Key。**需要 Docker**（冒煙測試 job 使用 `environment.type: docker`）：
+無需 API Key。兩條車道：
+
+**Host Survey**（無需 Docker）— 問卷 + fake-client `json_survey` 路徑：
+
+```bash
+uv run matraix smoke application/tasks/example-survey_product-feedback
+```
+
+**Docker / Harbor** — hello-world 棧檢查（`environment.type: docker`）：
 
 ```bash
 uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml
 ```
 
+詳情：[quickstart §3](../quickstart.md#3-smoke-tests-two-lanes)。
 ### GUI 任務執行
 
 Playground 可選擇任務、抽樣人格，並啟動與 CLI auto 模式相同的 Matraix Playground job。

--- a/docs/i18n/README.zh-TW.md
+++ b/docs/i18n/README.zh-TW.md
@@ -109,21 +109,14 @@ Playground：Dataset → **`matraix-persona-1m`**。CLI：`--dataset persona/dat
 
 ### 冒煙測試（smoke tests）
 
-無需 API Key。兩條車道：
+Mode **auto** 下，四類應用任務共用 **兩條 runtime**。Onboarding smoke 驗證這兩條車道（無需 API Key）即表示四類基本可跑：
 
-**Host Survey**（無需 Docker）— 問卷 + fake-client `json_survey` 路徑：
+| 車道 | **auto** 覆蓋 | 命令 |
+|------|---------------|------|
+| **Host** | Survey + Chat | `uv run matraix smoke application/tasks/example-survey_product-feedback` |
+| **Container** | Web + OS-app | `uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml` |
 
-```bash
-uv run matraix smoke application/tasks/example-survey_product-feedback
-```
-
-**Docker / Harbor** — hello-world 棧檢查（`environment.type: docker`）：
-
-```bash
-uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml
-```
-
-詳情：[quickstart §3](../quickstart.md#3-smoke-tests-two-lanes)。
+Host 以 Survey 為代表（零成本 fake client）；Container 用 Harbor hello-world 映像（首次可能需幾分鐘建置）。詳情：[quickstart §3](../quickstart.md#3-smoke-tests-two-lanes)。
 ### GUI 任務執行
 
 Playground 可選擇任務、抽樣人格，並啟動與 CLI auto 模式相同的 Matraix Playground job。

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -97,13 +97,18 @@ uv run matraix --help
 
 ## 3. Smoke tests (two lanes)
 
-Onboarding uses **two** smokes — pick the lane you need:
+Under Mode **auto**, Survey / Chat / Web / OS-app share **two runtimes**.
+Onboarding smokes prove those lanes — together they mean the four types are
+ready to run for real (no API key):
 
-### Host Survey (no Docker, no API key)
+| Lane | Covers under **auto** | What the smoke checks |
+|------|------------------------|------------------------|
+| **Host** | Survey + Chat | Launch env, persona render, host agent path (no Docker) |
+| **Container** | Web + OS-app | Docker + Harbor task image path |
 
-Confirms the Survey / `json_survey` path: questionnaire loads, a persona
-renders, the real host survey runner produces a valid answer envelope with a
-**fake** client (synthetic answers, $0):
+### Host lane
+
+Representative command (Survey task, fake client, $0):
 
 ```bash
 uv run matraix smoke application/tasks/example-survey_product-feedback
@@ -111,10 +116,9 @@ uv run matraix smoke application/tasks/example-survey_product-feedback
 
 **Success:** prints `Smoke: ok` with `cost $0`. Does not call a provider.
 
-### Docker / Harbor (no API key)
+### Container lane
 
-Confirms Docker and Matraix Playground with the upstream **hello-world** task
-(reference solution, no LLM call):
+Representative command (Harbor hello-world, no LLM):
 
 ```bash
 uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml
@@ -122,11 +126,12 @@ uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml
 
 First run builds the Docker image (several minutes).
 
-**Success:** the command finishes without error and writes output under
+**Success:** finishes without error and writes output under
 `jobs/harbor-smoke-local/`.
 
-Host Survey smoke does **not** cover Chat sidecars or Web/OS-app agents.
-Docker hello-world does **not** claim OS-app CUA.
+These smokes certify the **shared runtimes**, not every Chat sidecar or every
+OS-app CUA backend. After both pass, use Mode **auto** examples in §6 for each
+of the four types with a real model.
 ---
 
 ## 4. Set your API key
@@ -626,8 +631,8 @@ Full task checklist: [tasks/README.md](../application/tasks/README.md).
 | Any of 4 types (terminal, single or batch) | `generate_application_job.py --execution-mode auto` + `matraix run -c` | `jobs/<job_name>/` |
 | Deterministic job summary / export | `matraix results <job>` | text / JSON / CSV |
 | Persona narrative batch PDF | Playground **Runs** → **Download PDF** | UI PDF |
-| Validate Docker/Matraix Playground only | `harbor-smoke-local.yaml` | smoke task image |
-| Host Survey check (no Docker, $0) | `matraix smoke <survey-task>` | fake envelope |
+| Host lane smoke (Survey+Chat runtime) | `matraix smoke <survey-task>` | fake envelope, $0 |
+| Container lane smoke (Web+OS-app runtime) | `harbor-smoke-local.yaml` | smoke task image |
 | Docker CLI harness (survey/chat) | `--execution-mode force_docker` or `appSim-*-local.yaml` | Docker trials |
 | Browse trajectories | `harbor view` or Playground **Runs** | local viewer |
 | New scenario | copy `example-*` + register for Playground | `application/tasks/<name>/` |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -97,41 +97,35 @@ uv run matraix --help
 
 ## 3. Smoke tests (two lanes)
 
-Under Mode **auto**, Survey / Chat / Web / OS-app share **two runtimes**.
-Onboarding smokes prove those lanes — together they mean the four types are
-ready to run for real (no API key):
+After install, run **both** checks below (no API key). Together they confirm
+the default path for **Survey, Chat, Web, and OS-app** is ready before you
+spend on a real model:
 
-| Lane | Covers under **auto** | What the smoke checks |
-|------|------------------------|------------------------|
-| **Host** | Survey + Chat | Launch env, persona render, host agent path (no Docker) |
-| **Container** | Web + OS-app | Docker + Harbor task image path |
+| Check | Confirms you can run | Needs Docker? |
+|-------|----------------------|---------------|
+| Without Docker | Survey and Chat | No |
+| With Docker | Web and OS-app | Yes |
 
-### Host lane
-
-Representative command (Survey task, fake client, $0):
+### Without Docker — Survey & Chat
 
 ```bash
 uv run matraix smoke application/tasks/example-survey_product-feedback
 ```
 
-**Success:** prints `Smoke: ok` with `cost $0`. Does not call a provider.
+**Success:** prints `Smoke: ok` and does not call a model provider.
 
-### Container lane
-
-Representative command (Harbor hello-world, no LLM):
+### With Docker — Web & OS-app
 
 ```bash
 uv run matraix run -c configs/jobs/example-job-recipe/harbor-smoke-local.yaml
 ```
 
-First run builds the Docker image (several minutes).
+First run builds a small local image (a few minutes).
 
-**Success:** finishes without error and writes output under
-`jobs/harbor-smoke-local/`.
+**Success:** finishes without error and writes under `jobs/harbor-smoke-local/`.
 
-These smokes certify the **shared runtimes**, not every Chat sidecar or every
-OS-app CUA backend. After both pass, use Mode **auto** examples in §6 for each
-of the four types with a real model.
+When both pass, continue to §6 to run any of the four types with Mode **auto**
+and a real model.
 ---
 
 ## 4. Set your API key
@@ -631,8 +625,8 @@ Full task checklist: [tasks/README.md](../application/tasks/README.md).
 | Any of 4 types (terminal, single or batch) | `generate_application_job.py --execution-mode auto` + `matraix run -c` | `jobs/<job_name>/` |
 | Deterministic job summary / export | `matraix results <job>` | text / JSON / CSV |
 | Persona narrative batch PDF | Playground **Runs** → **Download PDF** | UI PDF |
-| Host lane smoke (Survey+Chat runtime) | `matraix smoke <survey-task>` | fake envelope, $0 |
-| Container lane smoke (Web+OS-app runtime) | `harbor-smoke-local.yaml` | smoke task image |
+| Install check — Survey & Chat (no Docker) | `matraix smoke <survey-task>` | `Smoke: ok` |
+| Install check — Web & OS-app (Docker) | `harbor-smoke-local.yaml` | `jobs/harbor-smoke-local/` |
 | Docker CLI harness (survey/chat) | `--execution-mode force_docker` or `appSim-*-local.yaml` | Docker trials |
 | Browse trajectories | `harbor view` or Playground **Runs** | local viewer |
 | New scenario | copy `example-*` + register for Playground | `application/tasks/<name>/` |


### PR DESCRIPTION
## Summary
- Product/user-facing smoke copy: after install, two checks (with / without Docker) cover Survey, Chat, Web, and OS-app.
- Drop Host/Container/runtime/fake-client jargon from README, quickstart, and i18n mirrors.

## Test plan
- [ ] README Quick start reads clearly for a first-time user
- [ ] quickstart §3 matches the same framing