### PR TITLE
fix(playground): restore locale trigger focus after mouse selection

### DIFF
--- a/application/playground/frontend/src/components/LocalePopover.tsx
+++ b/application/playground/frontend/src/components/LocalePopover.tsx
@@ -12,6 +12,7 @@ export function LocalePopover() {
   const triggerRef = useRef<HTMLButtonElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
   const firstOptionRef = useRef<HTMLButtonElement>(null);
+  const restoreFocusRef = useRef(false);
   const [position, setPosition] = useState({ left: 12, top: 56 });
 
   const updatePosition = useCallback(() => {
@@ -62,6 +63,13 @@ export function LocalePopover() {
     firstOptionRef.current?.focus();
   }, [open, updatePosition]);
 
+  useEffect(() => {
+    if (open || !restoreFocusRef.current) return;
+    restoreFocusRef.current = false;
+    const raf = requestAnimationFrame(() => triggerRef.current?.focus());
+    return () => cancelAnimationFrame(raf);
+  }, [open]);
+
   return (
     <div ref={rootRef} className="relative">
       <button
@@ -111,8 +119,8 @@ export function LocalePopover() {
                       aria-current={active ? "true" : undefined}
                       onClick={() => {
                         void setLocale(definition.code);
+                        restoreFocusRef.current = true;
                         setOpen(false);
-                        triggerRef.current?.focus();
                       }}
                       className={`flex w-full items-center justify-between rounded-xl px-3 py-2 text-start text-sm transition ${FOCUS_RING} ${
                         active

--- a/application/playground/frontend/src/i18n/__tests__/foundation.test.tsx
+++ b/application/playground/frontend/src/i18n/__tests__/foundation.test.tsx
@@ -140,4 +140,19 @@ describe("provider and locale popover", () => {
     await waitFor(() => expect(window.localStorage.getItem("matraix.uiLocale")).toBe("en-US"));
     expect(screen.queryByRole("dialog")).toBeNull();
   });
+
+  it("returns focus to the trigger after selecting a locale with the mouse", async () => {
+    render(
+      <I18nProvider>
+        <LocalePopover />
+      </I18nProvider>,
+    );
+    const trigger = screen.getByRole("button", { name: SOURCE_MESSAGES["locale.buttonLabel"] });
+    fireEvent.click(trigger);
+    const englishOption = screen.getByRole("button", { name: "English" });
+    await waitFor(() => expect(document.activeElement).toBe(englishOption));
+    fireEvent.click(englishOption);
+    expect(screen.queryByRole("dialog")).toBeNull();
+    await waitFor(() => expect(document.activeElement).toBe(trigger));
+  });
 });


### PR DESCRIPTION
Addresses the focus carry-over noted on #66: after choosing a locale with the mouse, focus did not return to the globe trigger (Escape did).

**What changed**
- The option-selection path no longer focuses the trigger while the panel (and the just-clicked option button) is still mounted - that focus call could land before React unmounts the panel, leaving focus on `body`.
- Selection now sets a restore flag and a `useEffect` on `open` returning focus to the trigger on the next frame, after the panel has unmounted. Outside-click closes are untouched (focus legitimately goes where the user clicked), and the Escape path is unchanged.

**Verification**
- New case in `foundation.test.tsx`: select a locale with the mouse -> dialog closes -> focus lands back on the trigger.
- `vitest run` green (9/9), `typecheck` green.

Refs #66 (carry-over polish item, not a sequence PR).