### PR TITLE
feat(playground): add reproducible runtime persona language

### DIFF
--- a/application/playground/backend/api/app.py
+++ b/application/playground/backend/api/app.py
@@ -705,6 +705,8 @@ def create_app(catalog_path: Optional[str] = None) -> FastAPI:
                 persona_filters=body.personaFilters,
                 cohort_id=body.cohortId,
                 use_entire_pool=body.useEntirePool,
+                language=body.language,
+                language_source=body.languageSource,
             )
         except ValueError as exc:
             raise HTTPException(status_code=422, detail=str(exc)) from exc
@@ -720,6 +722,12 @@ def create_app(catalog_path: Optional[str] = None) -> FastAPI:
             "trialProfile": trial_profile,
             "mode": body.mode,
             "plane": resolved_plane,
+            "effectiveLanguage": launch.get("effectiveLanguage")
+            if isinstance(launch, dict)
+            else None,
+            "languageSource": launch.get("languageSource")
+            if isinstance(launch, dict)
+            else None,
         }
 
     @app.get(

--- a/application/playground/backend/api/schemas.py
+++ b/application/playground/backend/api/schemas.py
@@ -31,6 +31,11 @@ from typing import Any, Dict, List, Literal, Optional
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from backend.service.config import PERSONA_MODEL_OPTIONS
+from matraix.launch_env import (
+    PERSONA_LANGUAGE_TOKENS,
+    canonicalize_persona_language,
+    normalize_persona_language_source,
+)
 
 __all__ = [
     "HealthResponse",
@@ -95,7 +100,7 @@ DEFAULT_APPLICATION_CONTEXTS = {
 }
 
 SUPPORTED_PERSONA_MODELS = tuple(PERSONA_MODEL_OPTIONS)
-
+SUPPORTED_PERSONA_LANGUAGES = PERSONA_LANGUAGE_TOKENS
 
 def _resolved_chat_context(
     *,
@@ -736,6 +741,47 @@ class HarborJobLaunchRequest(BaseModel):
     chatApplicationId: Optional[str] = None
     chatApplicationContext: Optional[str] = None
     chatMaxTurns: Optional[int] = None
+    # Runtime/persona language. A language without a source is an explicit
+    # API/CLI override; follow_ui is the only UI-derived source. env/default
+    # provenance is resolved internally by the backend and never accepted
+    # from a caller.
+    language: Optional[str] = None
+    languageSource: Optional[str] = None
+
+    @field_validator("language")
+    @classmethod
+    def _validate_language(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        canonical = canonicalize_persona_language(value)
+        if canonical is None:
+            raise ValueError(
+                "language must be one of {} or a supported locale".format(
+                    ", ".join(SUPPORTED_PERSONA_LANGUAGES)
+                )
+            )
+        return canonical
+
+    @field_validator("languageSource")
+    @classmethod
+    def _validate_language_source(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        try:
+            return normalize_persona_language_source(value)
+        except ValueError as exc:
+            raise ValueError(
+                "languageSource must be follow_ui, explicit, or null "
+                "(env/default provenance is derived server-side): {}".format(exc)
+            ) from exc
+
+    @model_validator(mode="after")
+    def _validate_language_source_pair(self) -> "HarborJobLaunchRequest":
+        if self.language is None and self.languageSource is not None:
+            raise ValueError("languageSource requires language")
+        if self.language is not None and self.languageSource is None:
+            self.languageSource = "explicit"
+        return self
 
     @field_validator("mode")
     @classmethod
@@ -804,6 +850,8 @@ class HarborJobLaunchResponse(BaseModel):
     trialProfile: Optional[str] = None
     mode: Optional[str] = None
     plane: Optional[str] = None
+    effectiveLanguage: Optional[str] = None
+    languageSource: Optional[str] = None
 
 
 class HarborJobsListResponse(BaseModel):

--- a/application/playground/backend/service/appworld_types.py
+++ b/application/playground/backend/service/appworld_types.py
@@ -37,11 +37,15 @@ class AppWorldEvalConfig:
 
     persona_model: str = DEFAULT_PERSONA_MODEL
     mode: str = "local_persona_appworld"
+    persona_language: str = "en"
+    persona_language_source: str = "default"
 
     def to_dict(self) -> Dict[str, Any]:
         return {
             "personaModel": self.persona_model,
             "mode": self.mode,
+            "effectiveLanguage": self.persona_language,
+            "languageSource": self.persona_language_source,
         }
 
 

--- a/application/playground/backend/service/harbor_job_service.py
+++ b/application/playground/backend/service/harbor_job_service.py
@@ -42,7 +42,13 @@ from matraix.application_job import (
     build_application_job_config,
     resolve_job_environment,
 )
-from matraix.launch_env import build_launch_env
+from matraix.launch_env import (
+    PERSONA_LANGUAGE_ENV,
+    build_launch_env,
+    canonicalize_persona_language,
+    normalize_persona_language,
+    normalize_persona_language_source,
+)
 
 DEFAULT_AGENT_BY_TYPE: dict[str, str] = {
     # Keys here stay canonical; ``normalize_metadata_type()`` handles legacy
@@ -61,6 +67,41 @@ AUTO_TRIAL_PROFILE_BY_TYPE: dict[str, str] = {
 }
 
 logger = logging.getLogger(__name__)
+
+
+# Runtime/persona language is deliberately resolved at the Harbor boundary.
+# The token table and alias normalization live in launch_env so API, Harbor,
+# and CLI cannot drift apart.
+DEFAULT_PERSONA_LANGUAGE = "en"
+
+
+def resolve_harbor_persona_language(
+    language: str | None,
+    language_source: str | None,
+) -> tuple[str, str]:
+    """Resolve the reproducible language tuple stored with a Harbor job.
+
+    A request language is an explicit override unless the UI marks it as
+    locale-derived. When no request language is present, only this backend
+    reads ``MATRIX_PERSONA_LANGUAGE``; callers cannot claim ``env``.
+    Invalid or absent environment values fall back to English/default.
+    """
+
+    normalized_source = normalize_persona_language_source(language_source)
+    if language is not None:
+        normalized_language = normalize_persona_language(language)
+        return normalized_language, normalized_source or "explicit"
+
+    if normalized_source is not None:
+        raise ValueError(
+            "language_source requires language; env/default provenance is "
+            "derived server-side"
+        )
+
+    env_language = canonicalize_persona_language(os.environ.get(PERSONA_LANGUAGE_ENV))
+    if env_language is not None:
+        return env_language, "env"
+    return DEFAULT_PERSONA_LANGUAGE, "default"
 
 
 def _should_use_local_distributed_harbor(
@@ -485,6 +526,8 @@ class HarborLaunchRecord:
     exit_code: int | None = None
     execution_plane: str = "harbor"
     remote_run_id: str | None = None
+    effective_language: str = DEFAULT_PERSONA_LANGUAGE
+    language_source: str = "default"
 
 
 @dataclass
@@ -532,13 +575,14 @@ class HarborJobService:
         if not job_dir.is_dir():
             return []
         skip = {"_inputs", "_generated"}
-        return sorted(
+        names = sorted(
             [
                 d.name
                 for d in job_dir.iterdir()
                 if d.is_dir() and d.name not in skip and not d.name.startswith(".")
             ]
         )
+        return names
 
     def _trial_has_result(self, job_name: str, trial_name: str) -> bool:
         return (self.jobs_dir / job_name / trial_name / "result.json").is_file()
@@ -947,6 +991,15 @@ class HarborJobService:
         # also drives the reporting scheduler). Embedding aggregation here made
         # every job-detail poll rebuild and ship the full report payload.
         task_meta = self._job_task_meta(job_name, job_dir)
+        launch_view = _launch_view(launch) if launch else None
+        launch_meta = self._read_json(self._launch_meta_path(job_name))
+        if isinstance(launch_view, dict) and isinstance(launch_meta, dict):
+            launch_view["effectiveLanguage"] = (
+                launch_meta.get("effective_language") or launch_view["effectiveLanguage"]
+            )
+            launch_view["languageSource"] = (
+                launch_meta.get("language_source") or launch_view["languageSource"]
+            )
         return {
             "jobName": job_name,
             "jobsDir": _rel_path(self.jobs_dir, self.repo_root),
@@ -963,7 +1016,7 @@ class HarborJobService:
             "config": self._read_json(job_dir / "config.json"),
             "result": self._read_json(job_dir / "result.json"),
             "trials": trials,
-            "launch": _launch_view(launch) if launch else None,
+            "launch": launch_view,
             "aggregation": None,
         }
 
@@ -1001,6 +1054,8 @@ class HarborJobService:
         os_app_backend: str | None = None,
         cua_backend: str | None = None,
         execution_plane: str | None = None,
+        language: str | None = None,
+        language_source: str | None = None,
     ) -> str:
         from backend.service.execution_plane import (
             ExecutionPlaneError,
@@ -1019,6 +1074,10 @@ class HarborJobService:
             raise ValueError(
                 "execution plane 'remote' requires REMOTE_RUNNER_API_URL"
             )
+        effective_language, effective_language_source = resolve_harbor_persona_language(
+            language,
+            language_source,
+        )
         if os_app_backend is None and cua_backend is not None:
             os_app_backend = cua_backend
         if persona_ids is not None and len(persona_ids) == 0:
@@ -1183,6 +1242,16 @@ class HarborJobService:
                         kwargs.setdefault("max_steps", 100)
         job_meta = job_config.pop("_job_meta", None)
 
+        # Always inject the resolved tuple, including the English/default
+        # case. Local, remote, and retry dispatches therefore consume the
+        # same immutable job config instead of re-reading host environment.
+        for agent_config in job_config.get("agents", []):
+            if isinstance(agent_config, dict):
+                kwargs = agent_config.setdefault("kwargs", {})
+                if isinstance(kwargs, dict):
+                    kwargs["persona_language"] = effective_language
+                    kwargs["persona_language_source"] = effective_language_source
+
         self.generated_configs_dir.mkdir(parents=True, exist_ok=True)
         config_path = self.generated_configs_dir / "{}.yaml".format(resolved_job_name)
         header = (
@@ -1197,6 +1266,8 @@ class HarborJobService:
             "# Persona sources: {}\n"
             "# Persona filters: {}\n"
             "# Personas: {}\n"
+            "# Effective language: {}\n"
+            "# Language source: {}\n"
             "# Jobs output: {}/\n\n".format(
                 task_path,
                 resolved_task_path,
@@ -1212,6 +1283,8 @@ class HarborJobService:
                 )
                 or "(none)",
                 ", ".join(job_meta.get("selected_persona_ids", []) if job_meta else []),
+                effective_language,
+                effective_language_source,
                 _rel_path(self.jobs_dir, self.repo_root),
             )
         )
@@ -1226,6 +1299,8 @@ class HarborJobService:
             config_path=_rel_path(config_path, self.repo_root),
             started_at=_utc_now(),
             execution_plane=resolved_plane,
+            effective_language=effective_language,
+            language_source=effective_language_source,
         )
         with self._guard:
             self._launches[resolved_job_name] = record
@@ -1253,6 +1328,8 @@ class HarborJobService:
                 "chatApplicationId": chat_application_id,
                 "chatApplicationContext": chat_application_context,
                 "chatMaxTurns": chat_max_turns,
+                "effective_language": effective_language,
+                "language_source": effective_language_source,
                 "jobConfig": job_config,
             },
         )
@@ -1894,6 +1971,15 @@ class HarborJobService:
             self._status_states.pop(job_name, None)
 
         plane = str(meta.get("executionPlane") or "harbor")
+        retry_language = normalize_persona_language(meta.get("effective_language"))
+        if retry_language is None:
+            retry_language = DEFAULT_PERSONA_LANGUAGE
+        try:
+            retry_source = normalize_persona_language_source(meta.get("language_source"))
+        except ValueError:
+            retry_source = None
+        if retry_source is None:
+            retry_source = "default"
         with self._guard:
             self._launches[job_name] = HarborLaunchRecord(
                 job_name=job_name,
@@ -1901,6 +1987,8 @@ class HarborJobService:
                 config_path=config_rel or None,
                 started_at=_utc_now(),
                 execution_plane=plane,
+                effective_language=retry_language,
+                language_source=retry_source,
             )
 
         if meta.get("useLocalDistributed"):
@@ -2054,6 +2142,7 @@ class HarborJobService:
                 jobs_dir=self.jobs_dir,
                 job_name=job_name,
                 trial_name=trial_name,
+                launch_meta_path=self._launch_meta_path(job_name),
             )
             # Mapping can materialize missing artifacts, so cache the final
             # on-disk state that produced this payload.
@@ -2202,6 +2291,8 @@ def _launch_view(record: HarborLaunchRecord | None) -> dict[str, Any] | None:
         "exitCode": record.exit_code,
         "executionPlane": record.execution_plane,
         "remoteRunId": record.remote_run_id,
+        "effectiveLanguage": record.effective_language,
+        "languageSource": record.language_source,
     }
 
 

--- a/application/playground/backend/service/harbor_trial_debrief.py
+++ b/application/playground/backend/service/harbor_trial_debrief.py
@@ -17,6 +17,11 @@ from backend.service.llm_usage_view import usage_from_trial_dir
 from backend.service.survey_types import build_survey_eval_result_from_artifacts
 from backend.service.survey_types import survey_result_view
 from backend.service.survey_types import SurveyEvalConfig, SurveyInstrument, SurveyQuestion
+from playground.persona_language import (
+    PersonaLanguageResolution,
+    PERSONA_LANGUAGE_SOURCES,
+    normalize_persona_language,
+)
 from playground.types import Persona, PlaygroundConfig
 
 if TYPE_CHECKING:
@@ -696,13 +701,83 @@ def _read_persona_yaml_raw(repo_root: Path, persona_rel: str | None) -> dict[str
     return raw if isinstance(raw, dict) else None
 
 
+def _persona_language_from_meta(meta: dict[str, Any] | None) -> PersonaLanguageResolution | None:
+    if not isinstance(meta, dict):
+        return None
+    source = str(meta.get("language_source") or "").strip().lower()
+    if source not in PERSONA_LANGUAGE_SOURCES:
+        return None
+    try:
+        language = normalize_persona_language(meta.get("effective_language"))
+    except (TypeError, ValueError):
+        return None
+    if language is None:
+        return None
+    return PersonaLanguageResolution(language=language, source=source)
+
+
+def _inferred_launch_meta_paths(trial_dir: Path) -> tuple[Path, ...]:
+    """Return known launch metadata locations without creating or modifying files.
+
+    HarborJobService passes its configured path explicitly.  The fallback keeps
+    direct debrief callers useful for the repository layout used by Harbor:
+    ``<repo>/jobs/<job>/<trial>`` and ``<repo>/configs/jobs/<job>.launch.json``.
+    """
+    job_dir = trial_dir.parent
+    candidates = [job_dir / ".playground-launch.json"]
+    try:
+        repo_root = trial_dir.parents[2]
+    except IndexError:
+        return tuple(candidates)
+    candidates.append(repo_root / "configs" / "jobs" / "{}.launch.json".format(job_dir.name))
+    return tuple(candidates)
+
+
+def _recorded_persona_language(
+    trial_dir: Path,
+    *,
+    launch_meta_path: Path | None = None,
+) -> PersonaLanguageResolution:
+    """Read language metadata in trial -> launch -> English/default order.
+
+    Debrief is a read path: missing or malformed metadata is ignored and never
+    repaired by writing ``persona_meta.json``.  The explicit launch path is
+    used by HarborJobService because callers may configure a non-default jobs
+    config directory; direct callers use the repository-layout fallback.
+    """
+    paths: list[Path] = [trial_dir / "persona_meta.json"]
+    if launch_meta_path is not None:
+        paths.append(launch_meta_path)
+    paths.extend(_inferred_launch_meta_paths(trial_dir))
+    seen: set[Path] = set()
+    for path in paths:
+        if path in seen:
+            continue
+        seen.add(path)
+        try:
+            resolution = _persona_language_from_meta(_read_json(path))
+        except (OSError, ValueError):
+            resolution = None
+        if resolution is not None:
+            return resolution
+    return PersonaLanguageResolution(language="en", source="default")
+
+
 def _render_persona_prompt(
-    repo_root: Path, persona_rel: str | None, persona: Persona
+    repo_root: Path,
+    persona_rel: str | None,
+    persona: Persona,
+    *,
+    persona_language: str,
 ) -> str:
     from playground.user_sim.prompt import render_persona_block
 
     yaml_path = _persona_prompt_abs_path(repo_root, persona_rel)
-    block = render_persona_block(persona, persona_yaml_path=yaml_path).strip()
+    block = render_persona_block(
+        persona,
+        persona_yaml_path=yaml_path,
+        persona_language=persona_language,
+    ).strip()
     if block and not _is_thin_persona_prompt(block, persona=persona):
         return block
     raw = _read_persona_yaml_raw(repo_root, persona_rel)
@@ -762,10 +837,14 @@ def _enrich_debrief_prompts(
     repo_root: Path,
     persona_rel: str | None,
     persona: Persona,
+    launch_meta_path: Path | None = None,
 ) -> None:
     """Ensure debrief rails have persona profile + task instruction text."""
     existing = debrief.get("prompts")
     prompts = dict(existing) if isinstance(existing, dict) else {}
+    language = _recorded_persona_language(trial_dir, launch_meta_path=launch_meta_path)
+    debrief["effectiveLanguage"] = language.language
+    debrief["languageSource"] = language.source
 
     event_prompts = _read_prompts_event(trial_dir)
     done = _read_chat_done_event(trial_dir)
@@ -782,19 +861,42 @@ def _enrich_debrief_prompts(
     prompts = _merge_prompt_dicts(prompts, done_prompts)
     prompts = _merge_prompt_dicts(prompts, event_prompts)
 
-    persona_prompt = str(prompts.get("personaPrompt") or "").strip()
-    harbor_prompt = str(prompts.get("harborPrompt") or "").strip()
-    rendered = _render_persona_prompt(repo_root, persona_rel, persona)
-    if rendered and not _is_thin_persona_prompt(rendered, persona=persona):
-        persona_prompt = rendered
+    # Runtime events/artifacts are authoritative.  Preserve their exact
+    # prompt text even when it was rendered in a non-English language; a
+    # language-aware reconstruction is only a legacy fallback.
+    recorded_sources = (event_prompts, done_prompts, existing)
+    recorded_prompt_keys = {
+        str(key)
+        for source in recorded_sources
+        if isinstance(source, dict)
+        for key, value in source.items()
+        if isinstance(value, str) and value.strip()
+    }
+    persona_prompt = ""
+    harbor_prompt = ""
+    for source in recorded_sources:
+        if not isinstance(source, dict):
+            continue
+        candidate = str(source.get("personaPrompt") or "").strip()
+        if not persona_prompt and candidate:
+            persona_prompt = candidate
+        candidate = str(source.get("harborPrompt") or "").strip()
+        if not harbor_prompt and candidate:
+            harbor_prompt = candidate
+
+    if persona_prompt:
         prompts["personaPrompt"] = persona_prompt
-    elif not persona_prompt or _is_thin_persona_prompt(persona_prompt, persona=persona):
-        if harbor_prompt and not _is_thin_persona_prompt(harbor_prompt, persona=persona):
-            persona_prompt = harbor_prompt
-        elif rendered and not _is_thin_persona_prompt(rendered, persona=persona):
-            persona_prompt = rendered
-        if persona_prompt:
-            prompts["personaPrompt"] = persona_prompt
+    elif harbor_prompt:
+        prompts["personaPrompt"] = harbor_prompt
+    else:
+        rendered = _render_persona_prompt(
+            repo_root,
+            persona_rel,
+            persona,
+            persona_language=language.language,
+        )
+        if rendered and not _is_thin_persona_prompt(rendered, persona=persona):
+            prompts["personaPrompt"] = rendered
 
     task_prompt = str(prompts.get("taskPrompt") or "").strip()
     instruction = _read_trial_instruction_markdown(trial_dir, repo_root)
@@ -812,7 +914,11 @@ def _enrich_debrief_prompts(
     if instruction:
         if not task_prompt:
             prompts["taskPrompt"] = instruction
-        elif len(task_prompt) < 160 and instruction not in task_prompt:
+        elif (
+            "taskPrompt" not in recorded_prompt_keys
+            and len(task_prompt) < 160
+            and instruction not in task_prompt
+        ):
             prompts["taskPrompt"] = "{}\n\n---\n\n{}".format(instruction, task_prompt)
 
     if prompts:
@@ -1510,6 +1616,7 @@ def map_trial_debrief(
     jobs_dir: Path,
     job_name: str,
     trial_name: str,
+    launch_meta_path: Path | None = None,
 ) -> dict[str, Any]:
     """Build a Playground-compatible debrief payload for one Harbor trial."""
     trial_dir = jobs_dir / job_name / trial_name
@@ -1547,6 +1654,7 @@ def map_trial_debrief(
                     repo_root=repo_root,
                     persona_rel=persona_rel,
                     persona=persona,
+                    launch_meta_path=launch_meta_path,
                 )
                 _attach_verifier_artifacts(debrief, trial_dir)
                 return _attach_usage(debrief, trial_dir)
@@ -1570,6 +1678,7 @@ def map_trial_debrief(
             repo_root=repo_root,
             persona_rel=persona_rel,
             persona=persona,
+            launch_meta_path=launch_meta_path,
         )
         _attach_verifier_artifacts(debrief, trial_dir)
         return _attach_usage(debrief, trial_dir)
@@ -1705,5 +1814,6 @@ def map_trial_debrief(
         repo_root=repo_root,
         persona_rel=persona_rel,
         persona=persona,
+        launch_meta_path=launch_meta_path,
     )
     return _attach_usage(debrief, trial_dir)

--- a/application/playground/backend/service/local_appworld_eval.py
+++ b/application/playground/backend/service/local_appworld_eval.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import Any, Callable, Dict, Optional
 
 from backend.service.appworld_types import (
@@ -11,6 +12,7 @@ from backend.service.appworld_types import (
     AppWorldResultArtifact,
     AppWorldTrace,
 )
+from playground.persona_language import resolve_persona_language_with_source
 from playground.types import Persona
 from playground.user_sim.prompt import render_persona_block
 
@@ -42,6 +44,8 @@ class LocalAppWorldEvalRunner:
         *,
         created_at: str,
         on_event: Optional[Callable[[Dict[str, Any]], None]] = None,
+        persona_language: str | None = None,
+        persona_language_source: str | None = None,
     ) -> AppWorldEvalResult:
         config = config or AppWorldEvalConfig()
 
@@ -49,7 +53,24 @@ class LocalAppWorldEvalRunner:
             if on_event is not None:
                 on_event(event)
 
-        persona_prompt = render_persona_block(persona).strip()
+        language = resolve_persona_language_with_source(
+            persona_language if persona_language is not None else config.persona_language,
+            requested_source=(
+                persona_language_source
+                if persona_language_source is not None
+                else config.persona_language_source
+            ),
+            environ={},
+        )
+        config = replace(
+            config,
+            persona_language=language.language,
+            persona_language_source=language.source,
+        )
+        persona_prompt = render_persona_block(
+            persona,
+            persona_language=language.language,
+        ).strip()
         task_prompt = build_appworld_task_prompt(task)
         prompts = {
             "personaPrompt": persona_prompt,

--- a/application/playground/backend/service/survey_types.py
+++ b/application/playground/backend/service/survey_types.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import sys
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
 
@@ -16,6 +16,8 @@ except ModuleNotFoundError:
     if str(core_src) not in sys.path:
         sys.path.insert(0, str(core_src))
     from playground.types import DEFAULT_PERSONA_MODEL, Persona
+
+from playground.persona_language import resolve_persona_language_with_source
 
 QUESTION_TYPES = {"likert", "single_choice", "multi_choice", "free_text"}
 
@@ -217,12 +219,25 @@ class SurveyEvalConfig:
     # Deprecated: rationale/confidence now come from questionnaire.yaml.
     # Kept for API compatibility; ignored by the survey runner.
     require_rationale: bool = True
+    persona_language: str = "en"
+    persona_language_source: str = "default"
+
+    def __post_init__(self) -> None:
+        resolution = resolve_persona_language_with_source(
+            self.persona_language,
+            requested_source=self.persona_language_source,
+            environ={},
+        )
+        self.persona_language = resolution.language
+        self.persona_language_source = resolution.source
 
     def to_dict(self) -> dict[str, Any]:
         return {
             "personaModel": self.persona_model,
             "mode": self.mode,
             "requireRationale": self.require_rationale,
+            "effectiveLanguage": self.persona_language,
+            "languageSource": self.persona_language_source,
         }
 
 
@@ -345,6 +360,8 @@ class SurveyEvalResult:
     def to_dict(self) -> dict[str, Any]:
         payload = {
             "config": self.config.to_dict(),
+            "effectiveLanguage": self.config.persona_language,
+            "languageSource": self.config.persona_language_source,
             "persona": self.persona.to_dict(),
             "instrument": self.instrument.to_dict(),
             "trajectory": [event.to_dict() for event in self.trajectory],
@@ -465,6 +482,41 @@ def _normalize_survey_prompts(prompts: dict[str, Any] | None) -> dict[str, str]:
     }
 
 
+def _config_with_artifact_language(
+    config: SurveyEvalConfig,
+    payload: dict[str, Any],
+) -> SurveyEvalConfig:
+    """Recover the recorded runtime language without consulting the host env."""
+    raw_config = payload.get("config")
+    artifact_config = raw_config if isinstance(raw_config, dict) else {}
+    language = artifact_config.get(
+        "effectiveLanguage",
+        artifact_config.get(
+            "personaLanguage",
+            artifact_config.get("persona_language", payload.get("effectiveLanguage")),
+        ),
+    )
+    source = artifact_config.get(
+        "languageSource",
+        artifact_config.get(
+            "personaLanguageSource",
+            artifact_config.get("persona_language_source", payload.get("languageSource")),
+        ),
+    )
+    if language is None and source is None:
+        return config
+    resolution = resolve_persona_language_with_source(
+        language if language is not None else config.persona_language,
+        requested_source=source if source is not None else config.persona_language_source,
+        environ={},
+    )
+    return replace(
+        config,
+        persona_language=resolution.language,
+        persona_language_source=resolution.source,
+    )
+
+
 def build_survey_eval_result_from_artifacts(
     *,
     output_dir: Path,
@@ -475,6 +527,7 @@ def build_survey_eval_result_from_artifacts(
     prompts: dict[str, Any] | None = None,
 ) -> SurveyEvalResult:
     payload = _read_artifact_json(output_dir / "survey_result.json")
+    config = _config_with_artifact_language(config, payload)
     artifact_instrument = payload.get("instrument")
     if isinstance(artifact_instrument, dict):
         artifact_id = str(artifact_instrument.get("id", "")).strip()
@@ -497,6 +550,9 @@ def build_survey_eval_result_from_artifacts(
         except (TypeError, ValueError):
             continue
     mean = sum(likert_values) / len(likert_values) if likert_values else None
+    artifact_prompts = prompts if prompts is not None else payload.get("prompts")
+    if not isinstance(artifact_prompts, dict):
+        artifact_prompts = None
     return SurveyEvalResult(
         config=config,
         persona=persona,
@@ -509,7 +565,7 @@ def build_survey_eval_result_from_artifacts(
             mean_likert=mean,
         ),
         created_at=created_at,
-        prompts=_normalize_survey_prompts(prompts),
+        prompts=_normalize_survey_prompts(artifact_prompts),
     )
 
 
@@ -523,6 +579,8 @@ def survey_result_view(result: SurveyEvalResult) -> dict[str, Any]:
     ]
     metrics = result.metrics.to_dict()
     return {
+        "effectiveLanguage": result.config.persona_language,
+        "languageSource": result.config.persona_language_source,
         "instrument": result.instrument.to_dict(),
         "answers": [answer.to_dict() for answer in result.answers],
         "trajectory": [event.to_dict() for event in result.trajectory],

--- a/application/playground/backend/tests/test_api_schemas.py
+++ b/application/playground/backend/tests/test_api_schemas.py
@@ -1,3 +1,6 @@
+import pytest
+from pydantic import ValidationError
+
 from backend.api.schemas import HarborJobLaunchRequest
 
 
@@ -20,3 +23,54 @@ def test_harbor_job_launch_request_defaults_chat_context():
 
     assert request.chatApplicationContext == "financial_research"
     assert request.chatDomain is None
+
+
+@pytest.mark.parametrize(
+    ("language", "language_source", "expected_language", "expected_source"),
+    [
+        ("en", None, "en", "explicit"),
+        ("zh-CN", "follow_ui", "zh-Hans", "follow_ui"),
+        ("ZH-hant", "follow_ui", "zh-Hant", "follow_ui"),
+        ("ja-JP", "explicit", "ja", "explicit"),
+        ("pt", None, "pt-BR", "explicit"),
+    ],
+)
+def test_harbor_job_launch_request_accepts_and_normalizes_language(
+    language: str,
+    language_source: str | None,
+    expected_language: str,
+    expected_source: str,
+):
+    request = HarborJobLaunchRequest(
+        taskPath="application/tasks/chat_recai",
+        language=language,
+        languageSource=language_source,
+    )
+
+    assert request.language == expected_language
+    assert request.languageSource == expected_source
+
+
+@pytest.mark.parametrize("source", ["ui", "env", "default", "cli"])
+def test_harbor_job_launch_request_rejects_non_client_sources(source: str):
+    with pytest.raises(ValidationError, match="languageSource"):
+        HarborJobLaunchRequest(
+            taskPath="application/tasks/chat_recai",
+            language="en",
+            languageSource=source,
+        )
+
+
+def test_harbor_job_launch_request_rejects_source_without_language():
+    with pytest.raises(ValidationError, match="languageSource"):
+        HarborJobLaunchRequest(
+            taskPath="application/tasks/chat_recai",
+            languageSource="follow_ui",
+        )
+
+
+def test_harbor_job_launch_request_defaults_language_fields_to_null():
+    request = HarborJobLaunchRequest(taskPath="application/tasks/chat_recai")
+
+    assert request.language is None
+    assert request.languageSource is None

--- a/application/playground/backend/tests/test_appworld_eval_service.py
+++ b/application/playground/backend/tests/test_appworld_eval_service.py
@@ -54,6 +54,37 @@ def test_appworld_eval_service_persists_trace_and_reloads_view(tmp_path):
     assert persisted["trace"]["raw"]["trajectory"][0]["action"] == "list_apps"
 
 
+def test_local_appworld_eval_localizes_persona_prompt_only() -> None:
+    persona = _persona("p1")
+    task = get_appworld_eval_task("appworld-demo-personal-admin")
+    result = LocalAppWorldEvalRunner()(
+        persona,
+        task,
+        created_at="2026-06-29T00:00:00Z",
+        persona_language="zh-Hans",
+        persona_language_source="explicit",
+    )
+
+    assert result.config.persona_language == "zh-Hans"
+    assert result.config.persona_language_source == "explicit"
+    assert result.config.to_dict()["effectiveLanguage"] == "zh-Hans"
+    assert result.config.to_dict()["languageSource"] == "explicit"
+    assert "Write persona narrative" in result.prompts["personaPrompt"]
+    assert "Application: AppWorld" in result.prompts["taskPrompt"]
+    assert "Write persona narrative" not in result.prompts["taskPrompt"]
+
+
+def test_local_appworld_eval_legacy_defaults_to_english() -> None:
+    result = LocalAppWorldEvalRunner()(
+        _persona("p1"),
+        get_appworld_eval_task("appworld-demo-personal-admin"),
+        created_at="2026-06-29T00:00:00Z",
+    )
+
+    assert result.config.persona_language == "en"
+    assert result.config.persona_language_source == "default"
+
+
 def _wait_done(service: AppWorldEvalService, job_id: str) -> dict[str, object]:
     deadline = time.time() + 5
     while True:

--- a/application/playground/backend/tests/test_harbor_chat_eval.py
+++ b/application/playground/backend/tests/test_harbor_chat_eval.py
@@ -128,6 +128,8 @@ def test_harbor_output_artifacts_from_result_maps_chat_contract(monkeypatch):
         "applicationId": "meal_planning_nutrition",
         "applicationContext": "meal_planning",
         "turnCount": 2,
+        "config": result.config.to_dict(),
+        "prompts": {},
     }
     feedback = artifacts["user_feedback.json"]
     assert feedback["needConstraintSatisfaction"] == "yes"
@@ -191,11 +193,54 @@ def test_harbor_chat_config_from_env_prefers_harbor_model_name(monkeypatch) -> N
     assert config.persona_model == "anthropic/claude-sonnet-4-6"
 
 
+def test_harbor_chat_config_from_env_records_persona_language_source(monkeypatch):
+    monkeypatch.setenv("MATRIX_PERSONA_LANGUAGE", "zh-Hans")
+    monkeypatch.setenv("MATRIX_PERSONA_LANGUAGE_SOURCE", "follow_ui")
+
+    config = harbor_chat_config_from_env()
+
+    assert config.persona_language == "zh-Hans"
+    assert config.persona_language_source == "follow_ui"
+
+
+@pytest.mark.anyio
+async def test_run_harbor_chat_eval_passes_language_and_source_to_runner(monkeypatch):
+    received: dict[str, str] = {}
+
+    async def fake_run_playground_async(*args, **kwargs):
+        del args
+        received["persona_language"] = kwargs["persona_language"]
+        received["persona_language_source"] = kwargs["persona_language_source"]
+        return "result"
+
+    monkeypatch.setattr(
+        "playground.user_sim.runner.run_playground_async",
+        fake_run_playground_async,
+    )
+
+    result = await chat_eval_module.run_harbor_chat_eval(
+        object(),
+        Persona(id="p1", name="Persona One"),
+        "A chatbot.",
+        PlaygroundConfig(),
+        created_at="2026-06-30T00:00:00Z",
+        persona_language="zh-Hant",
+        persona_language_source="follow_ui",
+    )
+
+    assert result == "result"
+    assert received == {
+        "persona_language": "zh-Hant",
+        "persona_language_source": "follow_ui",
+    }
+
+
 @pytest.mark.anyio
 async def test_run_harbor_chat_eval_for_persona_writes_output_artifacts(
     tmp_path, monkeypatch
 ):
     uploaded: dict[str, dict] = {}
+    received_config: dict[str, str] = {}
 
     class FakeEnvironment:
         def __init__(self) -> None:
@@ -225,6 +270,8 @@ async def test_run_harbor_chat_eval_for_persona_writes_output_artifacts(
         persona_yaml_path=None,
         repo_root=None,
         job_dir=None,
+        persona_language=None,
+        persona_language_source=None,
     ):
         del (
             persona,
@@ -236,6 +283,10 @@ async def test_run_harbor_chat_eval_for_persona_writes_output_artifacts(
             repo_root,
             job_dir,
         )
+        received_config["persona_language"] = config.persona_language
+        received_config["persona_language_source"] = config.persona_language_source
+        assert persona_language is None
+        assert persona_language_source is None
         session._session_id = "sess-1"
         return PlaygroundResult(
             config=config,
@@ -324,6 +375,8 @@ async def test_run_harbor_chat_eval_for_persona_writes_output_artifacts(
             application_id="meal_planning_nutrition",
             application_context="meal_planning",
             engine="gpt-4o-mini",
+            persona_language="zh-Hans",
+            persona_language_source="follow_ui",
         ),
     )
     monkeypatch.setattr(
@@ -347,8 +400,19 @@ async def test_run_harbor_chat_eval_for_persona_writes_output_artifacts(
     )
 
     assert session_id == "sess-1"
+    assert received_config == {
+        "persona_language": "zh-Hans",
+        "persona_language_source": "follow_ui",
+    }
     assert result.metric_scores.num_turns == 2
     assert uploaded["/app/output/transcript.json"]["messages"][3]["content"] == "Try Past Lives"
     assert uploaded["/app/output/transcript.json"]["sessionId"] == "sess-1"
     assert uploaded["/app/output/application_result.json"]["turnCount"] == 2
+    assert uploaded["/app/output/application_result.json"]["config"][
+        "effectiveLanguage"
+    ] == "zh-Hans"
+    assert uploaded["/app/output/application_result.json"]["config"][
+        "languageSource"
+    ] == "follow_ui"
+    assert uploaded["/app/output/application_result.json"]["prompts"] == result.prompts
     assert uploaded["/app/output/user_feedback.json"]["overallExperienceRating"] == 8

--- a/application/playground/backend/tests/test_harbor_job_service.py
+++ b/application/playground/backend/tests/test_harbor_job_service.py
@@ -4,7 +4,26 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from backend.service.harbor_job_service import HarborJobService, HarborLaunchRecord
+
+
+@pytest.mark.parametrize(
+    ("language", "language_source"),
+    [("es", "env"), (None, "follow_ui"), ("xx", None), ("es", "ui"), ("es", "cli")],
+)
+def test_launch_rejects_invalid_or_caller_owned_language_provenance(
+    language, language_source
+):
+    service = object.__new__(HarborJobService)
+
+    with pytest.raises(ValueError, match="language|language_source"):
+        service.launch(
+            task_path="application/tasks/example-survey_product-feedback",
+            language=language,
+            language_source=language_source,
+        )
 
 
 def test_launch_writes_job_config(tmp_path, monkeypatch):
@@ -47,12 +66,23 @@ def test_launch_writes_job_config(tmp_path, monkeypatch):
         persona_pool="persona/datasets/matraix-persona-dev-sample",
         persona_model="anthropic/claude-haiku-4-5",
         job_name="test-harbor-job",
+        language="zh-Hant",
+        language_source="follow_ui",
     )
     assert job_name == "test-harbor-job"
     config_path = repo / "configs" / "jobs" / "application-task-job-recipe" / "test-harbor-job.yaml"
     assert config_path.is_file()
     text = config_path.read_text(encoding="utf-8")
     assert "persona_0001.yaml" in text or "persona_0002.yaml" in text
+    assert "persona_language: zh-Hant" in text
+    assert "persona_language_source: follow_ui" in text
+    launch_meta = json.loads(service._launch_meta_path(job_name).read_text(encoding="utf-8"))
+    assert launch_meta["effective_language"] == "zh-Hant"
+    assert launch_meta["language_source"] == "follow_ui"
+    queued_detail = service.get_job(job_name)
+    assert queued_detail is not None
+    assert queued_detail["launch"]["effectiveLanguage"] == "zh-Hant"
+    assert queued_detail["launch"]["languageSource"] == "follow_ui"
     assert service._executor.calls
     fn, args, kwargs = service._executor.calls[0]
     assert fn.__name__ == "_run_local_distributed"
@@ -66,9 +96,77 @@ def test_launch_writes_job_config(tmp_path, monkeypatch):
     detail = service.get_job("test-harbor-job")
     assert detail is not None
     assert detail["launch"]["status"] == "completed"
+    assert detail["launch"]["effectiveLanguage"] == "zh-Hant"
+    assert detail["launch"]["languageSource"] == "follow_ui"
     assert len(detail["trials"]) == 2
 
+    for trial in detail["trials"]:
+        # Harbor reads runtime metadata but does not synthesize persona_meta.json.
+        assert not (jobs_dir / job_name / trial["trialName"] / "persona_meta.json").exists()
+
     service.shutdown()
+
+
+def test_launch_derives_env_and_default_language_into_job_metadata(tmp_path, monkeypatch):
+    repo = tmp_path
+    jobs_dir = repo / "jobs"
+    jobs_dir.mkdir()
+    pool = repo / "persona" / "datasets" / "matraix-persona-dev-sample"
+    pool.mkdir(parents=True)
+    (pool / "persona_0001.yaml").write_text(
+        "persona_id: '0001'\nversion: '1.0'\nsource: Nemotron\ndimensions: {}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("playground.harbor.playground._repo_root", lambda: repo)
+
+    monkeypatch.setenv("MATRIX_PERSONA_LANGUAGE", "ja-JP")
+    service = HarborJobService(
+        repo_root=repo,
+        jobs_dir=jobs_dir,
+        generated_configs_dir=repo / "configs" / "jobs",
+    )
+    service._executor = _FakeExecutor()
+    job_name = service.launch(
+        task_path="application/tasks/example-survey_product-feedback",
+        persona_ids=["0001"],
+        job_name="env-language-job",
+    )
+    meta = json.loads(service._launch_meta_path(job_name).read_text(encoding="utf-8"))
+    assert meta["effective_language"] == "ja"
+    assert meta["language_source"] == "env"
+    config = (repo / "configs" / "jobs" / "env-language-job.yaml").read_text(
+        encoding="utf-8"
+    )
+    assert "persona_language: ja" in config
+    assert "persona_language_source: env" in config
+    service.shutdown()
+
+    monkeypatch.delenv("MATRIX_PERSONA_LANGUAGE", raising=False)
+    service = HarborJobService(
+        repo_root=repo,
+        jobs_dir=jobs_dir,
+        generated_configs_dir=repo / "configs" / "jobs",
+    )
+    service._executor = _FakeExecutor()
+    default_job = service.launch(
+        task_path="application/tasks/example-survey_product-feedback",
+        persona_ids=["0001"],
+        job_name="default-language-job",
+    )
+    meta = json.loads(service._launch_meta_path(default_job).read_text(encoding="utf-8"))
+    assert meta["effective_language"] == "en"
+    assert meta["language_source"] == "default"
+    service.shutdown()
+
+
+def test_list_trial_names_is_read_only_for_persona_metadata(tmp_path):
+    service = object.__new__(HarborJobService)
+    service.jobs_dir = tmp_path / "jobs"
+    trial_dir = service.jobs_dir / "job-read-only" / "trial-0001"
+    trial_dir.mkdir(parents=True)
+
+    assert service._list_trial_names("job-read-only") == ["trial-0001"]
+    assert not (trial_dir / "persona_meta.json").exists()
 
 
 def test_launch_with_frozen_cohort(tmp_path, monkeypatch):
@@ -201,10 +299,15 @@ def test_retry_failed_reruns_only_failed_trials(tmp_path, monkeypatch):
         persona_ids=["0001"],
         persona_model="anthropic/claude-haiku-4-5",
         job_name="retry-job",
+        language="zh",
     )
     # Launch metadata is persisted so a retry can replay the identical dispatch.
     meta_path = service._launch_meta_path(job_name)
     assert meta_path.is_file()
+    launch_meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    assert launch_meta["effective_language"] == "zh-Hans"
+    assert launch_meta["language_source"] == "explicit"
+    original_config = launch_meta["configPath"]
     assert len(service._executor.calls) == 1
 
     # Mark the launch record finished so retry is allowed.
@@ -238,6 +341,12 @@ def test_retry_failed_reruns_only_failed_trials(tmp_path, monkeypatch):
     # A fresh dispatch was submitted and the record is active again.
     assert len(service._executor.calls) == 2
     assert service._launches[job_name].status == "queued"
+    retried_meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    assert retried_meta["configPath"] == original_config
+    assert retried_meta["effective_language"] == "zh-Hans"
+    assert retried_meta["language_source"] == "explicit"
+    assert service._launches[job_name].effective_language == "zh-Hans"
+    assert service._launches[job_name].language_source == "explicit"
 
     service.shutdown()
 

--- a/application/playground/backend/tests/test_harbor_jobs_api.py
+++ b/application/playground/backend/tests/test_harbor_jobs_api.py
@@ -78,10 +78,14 @@ class _FakeHarborJobService:
     def launch(self, **kwargs: Any) -> str:
         self.launches.append(kwargs)
         job_name = kwargs.get("job_name") or "pg-launched"
+        launch = {"status": "queued"}
+        if kwargs.get("language") is not None:
+            launch["effectiveLanguage"] = kwargs["language"]
+            launch["languageSource"] = kwargs["language_source"]
         self._jobs[job_name] = {
             "jobName": job_name,
             "trials": [],
-            "launch": {"status": "queued"},
+            "launch": launch,
         }
         return job_name
 
@@ -199,6 +203,23 @@ def test_launch_harbor_job_with_persona_ids(client, fake_harbor_jobs):
     assert resp.status_code == 200
     assert fake_harbor_jobs.launches[-1]["persona_ids"] == ["0042"]
     assert fake_harbor_jobs.launches[-1]["execution_mode"] == "auto"
+
+
+def test_launch_harbor_job_passes_and_returns_runtime_language(client, fake_harbor_jobs):
+    resp = client.post(
+        "/api/harbor/jobs",
+        json={
+            "taskPath": "application/tasks/example-survey_product-feedback",
+            "language": "zh-CN",
+            "languageSource": "follow_ui",
+        },
+    )
+
+    assert resp.status_code == 200
+    assert fake_harbor_jobs.launches[-1]["language"] == "zh-Hans"
+    assert fake_harbor_jobs.launches[-1]["language_source"] == "follow_ui"
+    assert resp.json()["effectiveLanguage"] == "zh-Hans"
+    assert resp.json()["languageSource"] == "follow_ui"
 
 
 def test_launch_harbor_job_prefers_chat_application_context(client, fake_harbor_jobs):

--- a/application/playground/backend/tests/test_harbor_playground.py
+++ b/application/playground/backend/tests/test_harbor_playground.py
@@ -741,6 +741,11 @@ def test_harbor_runner_writes_run_inputs_invokes_harbor_and_maps_artifacts(
         assert config["environment"]["force_build"] is False
         assert config["environment"]["delete"] is False
         assert config["agents"][0]["kwargs"]["persona_path"].endswith("persona.yaml")
+        assert config["agents"][0]["kwargs"]["persona_language"] == "zh-Hant"
+        assert (
+            config["agents"][0]["kwargs"]["persona_language_source"]
+            == "follow_ui"
+        )
         assert config["tasks"][0]["path"].endswith(
             "application/tasks/chat_meal-planning-nutrition"
         )
@@ -781,6 +786,11 @@ def test_harbor_runner_writes_run_inputs_invokes_harbor_and_maps_artifacts(
             for index, value in enumerate(command)
             if value == "--agent-env"
         }
+        verifier_env = {
+            command[index + 1].split("=", 1)[0]: command[index + 1].split("=", 1)[1]
+            for index, value in enumerate(command)
+            if value == "--verifier-env"
+        }
         assert agent_env["MATRIX_CHATBOT_APPLICATION_ID"] == "meal_planning_nutrition"
         assert agent_env["MATRIX_CHATBOT_APPLICATION_CONTEXT"] == "meal_planning"
         assert agent_env["MATRIX_CHATBOT_TASK_PATH"] == "application/tasks/chat_meal-planning-nutrition"
@@ -788,7 +798,13 @@ def test_harbor_runner_writes_run_inputs_invokes_harbor_and_maps_artifacts(
         assert agent_env["MATRIX_CHATBOT_MIN_TURNS"] == "3"
         assert agent_env["MATRIX_CHATBOT_TASK_PROMPT_PATH"] == "/app/input/task_prompt.md"
         assert agent_env["MATRIX_CHATBOT_PERSONA_MODEL"] == "anthropic/claude-haiku-4-5"
-        assert "MATRIX_SCORER_MODULE" not in " ".join(command)
+        assert agent_env["MATRIX_PERSONA_LANGUAGE"] == "zh-Hant"
+        assert agent_env["MATRIX_PERSONA_LANGUAGE_SOURCE"] == "follow_ui"
+        assert verifier_env["MATRIX_PERSONA_LANGUAGE"] == "zh-Hant"
+        assert verifier_env["MATRIX_PERSONA_LANGUAGE_SOURCE"] == "follow_ui"
+        scorer_config = json.loads(verifier_env["MATRIX_SCORER_CONFIG_JSON"])
+        assert scorer_config["effectiveLanguage"] == "zh-Hant"
+        assert scorer_config["languageSource"] == "follow_ui"
 
         output_dir = (
             tmp_path
@@ -869,6 +885,8 @@ def test_harbor_runner_writes_run_inputs_invokes_harbor_and_maps_artifacts(
             application_context="meal_planning",
             engine="gpt-4o",
             max_turns=5,
+            persona_language="zh-Hant",
+            persona_language_source="follow_ui",
         ),
         object(),
         created_at="2026-06-23T00:00:00Z",
@@ -877,20 +895,26 @@ def test_harbor_runner_writes_run_inputs_invokes_harbor_and_maps_artifacts(
 
     assert calls
     assert "--agent-env" in calls[0][0]
-    assert "--verifier-env" not in calls[0][0]
+    assert "--verifier-env" in calls[0][0]
     assert "--env-file" in calls[0][0]
     assert session.turns[0]["structuredExposure"][0]["value"][0]["itemId"] == "42"
     payload = result.to_dict()
     assert payload["questionnaire"]["overallRating"] == 9
-    assert payload["prompts"]["harborPrompt"] == "A careful viewer."
+    assert payload["prompts"]["harborPrompt"].startswith("A careful viewer.")
+    assert "Effective persona language: Traditional Chinese (zh-Hant)." in payload[
+        "prompts"
+    ]["harborPrompt"]
     assert (
         "You are a user of a meal planning nutrition assistant"
         in payload["prompts"]["taskPrompt"]
     )
+    assert "Runtime persona language contract" not in payload["prompts"]["taskPrompt"]
     assert {"type": "phase", "phase": "harbor_starting"} in events
     assert any(
         event.get("type") == "prompts"
-        and event["prompts"]["harborPrompt"] == "A careful viewer."
+        and event["prompts"]["harborPrompt"].startswith("A careful viewer.")
+        and "Effective persona language: Traditional Chinese (zh-Hant)."
+        in event["prompts"]["harborPrompt"]
         and "You are a user of a meal planning nutrition assistant"
         in event["prompts"]["taskPrompt"]
         for event in events

--- a/application/playground/backend/tests/test_harbor_trial_debrief.py
+++ b/application/playground/backend/tests/test_harbor_trial_debrief.py
@@ -203,6 +203,180 @@ def test_map_trial_debrief_chatbot_enriches_prompts_from_events(tmp_path: Path) 
     assert debrief["instructionMarkdown"].startswith("# Task instruction")
 
 
+def test_debrief_preserves_recorded_prompt_before_language_reconstruction(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path
+    task_dir = repo / "application" / "tasks" / "chat_meal-planning-nutrition"
+    task_dir.mkdir(parents=True)
+    (task_dir / "task.toml").write_text('[metadata]\ntype = "chat"\n', encoding="utf-8")
+    (task_dir / "instruction.md").write_text("# Task instruction\nUse the chat API.\n", encoding="utf-8")
+    _write_chat_trial(repo, "job-recorded-prompt", "trial-recorded-prompt")
+    trial_dir = repo / "jobs" / "job-recorded-prompt" / "trial-recorded-prompt"
+    (trial_dir / "config.json").write_text(
+        json.dumps({"task": {"path": "application/tasks/chat_meal-planning-nutrition"}}),
+        encoding="utf-8",
+    )
+    (trial_dir / "persona_meta.json").write_text(
+        json.dumps({"effective_language": "zh-CN", "language_source": "follow_ui"}),
+        encoding="utf-8",
+    )
+    recorded = "EXACT RECORDED ZH-HANS PERSONA PROMPT - do not reconstruct."
+    (trial_dir / "events.jsonl").write_text(
+        json.dumps(
+            {
+                "type": "prompts",
+                "prompts": {
+                    "personaPrompt": recorded,
+                    "harborPrompt": recorded + "\n\nTask remains task-owned.",
+                    "taskPrompt": "Original task prompt remains unchanged.",
+                },
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    debrief = map_trial_debrief(
+        repo_root=repo,
+        jobs_dir=repo / "jobs",
+        job_name="job-recorded-prompt",
+        trial_name="trial-recorded-prompt",
+    )
+
+    assert debrief["prompts"]["personaPrompt"] == recorded
+    assert debrief["prompts"]["taskPrompt"] == "Original task prompt remains unchanged."
+    assert debrief["effectiveLanguage"] == "zh-Hans"
+    assert debrief["languageSource"] == "follow_ui"
+
+
+def test_debrief_restores_recorded_prompts_from_artifact_without_events(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path
+    task_dir = repo / "application" / "tasks" / "chat_meal-planning-nutrition"
+    task_dir.mkdir(parents=True)
+    (task_dir / "task.toml").write_text('[metadata]\ntype = "chat"\n', encoding="utf-8")
+    (task_dir / "instruction.md").write_text("# Task instruction\nUse the chat API.\n", encoding="utf-8")
+    _write_chat_trial(repo, "job-artifact-prompt", "trial-artifact-prompt")
+    trial_dir = repo / "jobs" / "job-artifact-prompt" / "trial-artifact-prompt"
+    (trial_dir / "config.json").write_text(
+        json.dumps({"task": {"path": "application/tasks/chat_meal-planning-nutrition"}}),
+        encoding="utf-8",
+    )
+    (trial_dir / "persona_meta.json").write_text(
+        json.dumps({"effective_language": "ja", "language_source": "explicit"}),
+        encoding="utf-8",
+    )
+    output = trial_dir / "artifacts" / "app" / "output"
+    recorded_prompts = {
+        "personaPrompt": "EXACT ARTIFACT PERSONA PROMPT",
+        "harborPrompt": "EXACT ARTIFACT HARBOR PROMPT",
+        "taskPrompt": "EXACT ARTIFACT TASK PROMPT",
+    }
+    (output / "application_result.json").write_text(
+        json.dumps({"prompts": recorded_prompts}),
+        encoding="utf-8",
+    )
+
+    debrief = map_trial_debrief(
+        repo_root=repo,
+        jobs_dir=repo / "jobs",
+        job_name="job-artifact-prompt",
+        trial_name="trial-artifact-prompt",
+    )
+
+    assert debrief["prompts"] == recorded_prompts
+    assert debrief["effectiveLanguage"] == "ja"
+    assert debrief["languageSource"] == "explicit"
+
+
+def test_debrief_uses_launch_metadata_without_writing_trial_metadata(tmp_path: Path) -> None:
+    repo = tmp_path
+    task_dir = repo / "application" / "tasks" / "chat_meal-planning-nutrition"
+    task_dir.mkdir(parents=True)
+    (task_dir / "task.toml").write_text('[metadata]\ntype = "chat"\n', encoding="utf-8")
+    (task_dir / "instruction.md").write_text("# Task instruction\nUse the chat API.\n", encoding="utf-8")
+    _write_chat_trial(repo, "job-launch-fallback", "trial-launch-fallback")
+    trial_dir = repo / "jobs" / "job-launch-fallback" / "trial-launch-fallback"
+    (trial_dir / "config.json").write_text(
+        json.dumps({"task": {"path": "application/tasks/chat_meal-planning-nutrition"}}),
+        encoding="utf-8",
+    )
+    launch_meta_path = repo / "configs" / "jobs" / "job-launch-fallback.launch.json"
+    launch_meta_path.parent.mkdir(parents=True)
+    launch_meta_path.write_text(
+        json.dumps({"effective_language": "zh-Hant", "language_source": "explicit"}),
+        encoding="utf-8",
+    )
+
+    debrief = map_trial_debrief(
+        repo_root=repo,
+        jobs_dir=repo / "jobs",
+        job_name="job-launch-fallback",
+        trial_name="trial-launch-fallback",
+    )
+
+    assert debrief["effectiveLanguage"] == "zh-Hant"
+    assert debrief["languageSource"] == "explicit"
+    assert not (trial_dir / "persona_meta.json").exists()
+
+
+def test_debrief_unknown_recorded_language_source_falls_back_to_english(tmp_path: Path) -> None:
+    repo = tmp_path
+    task_dir = repo / "application" / "tasks" / "chat_meal-planning-nutrition"
+    task_dir.mkdir(parents=True)
+    (task_dir / "task.toml").write_text('[metadata]\ntype = "chat"\n', encoding="utf-8")
+    (task_dir / "instruction.md").write_text("# Task instruction\nUse the chat API.\n", encoding="utf-8")
+    _write_chat_trial(repo, "job-unknown-language", "trial-unknown-language")
+    trial_dir = repo / "jobs" / "job-unknown-language" / "trial-unknown-language"
+    (trial_dir / "config.json").write_text(
+        json.dumps({"task": {"path": "application/tasks/chat_meal-planning-nutrition"}}),
+        encoding="utf-8",
+    )
+    (trial_dir / "persona_meta.json").write_text(
+        json.dumps({"effective_language": "pt", "language_source": "cli"}),
+        encoding="utf-8",
+    )
+
+    debrief = map_trial_debrief(
+        repo_root=repo,
+        jobs_dir=repo / "jobs",
+        job_name="job-unknown-language",
+        trial_name="trial-unknown-language",
+    )
+
+    assert debrief["effectiveLanguage"] == "en"
+    assert debrief["languageSource"] == "default"
+    assert "Effective persona language: English (en)" in debrief["prompts"]["personaPrompt"]
+
+
+def test_legacy_debrief_reconstruction_falls_back_to_english(tmp_path: Path) -> None:
+    repo = tmp_path
+    task_dir = repo / "application" / "tasks" / "chat_meal-planning-nutrition"
+    task_dir.mkdir(parents=True)
+    (task_dir / "task.toml").write_text('[metadata]\ntype = "chat"\n', encoding="utf-8")
+    (task_dir / "instruction.md").write_text("# Task instruction\nUse the chat API.\n", encoding="utf-8")
+    _write_chat_trial(repo, "job-legacy-prompt", "trial-legacy-prompt")
+    trial_dir = repo / "jobs" / "job-legacy-prompt" / "trial-legacy-prompt"
+    (trial_dir / "config.json").write_text(
+        json.dumps({"task": {"path": "application/tasks/chat_meal-planning-nutrition"}}),
+        encoding="utf-8",
+    )
+
+    debrief = map_trial_debrief(
+        repo_root=repo,
+        jobs_dir=repo / "jobs",
+        job_name="job-legacy-prompt",
+        trial_name="trial-legacy-prompt",
+    )
+
+    assert debrief["effectiveLanguage"] == "en"
+    assert debrief["languageSource"] == "default"
+    assert "Effective persona language: English (en)" in debrief["prompts"]["personaPrompt"]
+
+
 def test_map_trial_debrief_survey_from_events_without_output_dir(tmp_path: Path) -> None:
     repo = tmp_path
     task_dir = repo / "application" / "tasks" / "example-survey_product-feedback"
@@ -477,8 +651,9 @@ def test_map_trial_debrief_survey_enriches_persona_dimensions(tmp_path: Path) ->
         trial_name="trial-a",
     )
     persona_prompt = debrief["prompts"]["personaPrompt"]
-    assert "Profile dimensions" in persona_prompt
-    assert "Non-binary" in persona_prompt
+    assert persona_prompt == "Persona:\npersona-0174"
+    assert debrief["persona"]["dimensions"]["age_bracket"] == "65+"
+    assert debrief["persona"]["dimensions"]["gender_identity"] == "Non-binary"
     assert debrief["persona"]["dimensions"]["region"] == "East Asia"
 
 

--- a/application/playground/backend/tests/test_remote_runner_harbor_job_service.py
+++ b/application/playground/backend/tests/test_remote_runner_harbor_job_service.py
@@ -61,6 +61,8 @@ def test_launch_remote_plane_dispatches_harbor_job(tmp_path, monkeypatch) -> Non
         persona_ids=["0001"],
         job_name="remote-survey-job",
         execution_plane="remote",
+        language="zh-CN",
+        language_source="follow_ui",
     )
 
     service._executor.shutdown(wait=True)
@@ -68,13 +70,26 @@ def test_launch_remote_plane_dispatches_harbor_job(tmp_path, monkeypatch) -> Non
     assert fake_client.calls
     assert fake_client.calls[0]["task_type"] == "harbor_job"
     assert "configYaml" in fake_client.calls[0]["payload"]
+    config_yaml = fake_client.calls[0]["payload"]["configYaml"]
+    assert "persona_language: zh-Hans" in config_yaml
+    assert "persona_language_source: follow_ui" in config_yaml
     remote_env = fake_client.calls[0]["payload"]["env"]
     assert remote_env["MATRIX_SURVEY_TASK_PATH"] == "application/tasks/example-survey_product-feedback"
     assert "PYTHONPATH" in remote_env
     assert "ANTHROPIC_API_KEY" not in remote_env
     assert "OPENAI_API_KEY" not in remote_env
     assert "REMOTE_RUNNER_API_URL" not in remote_env
+    launch_meta = service._launch_meta_path(job_name).read_text(encoding="utf-8")
+    assert '"effective_language": "zh-Hans"' in launch_meta
+    assert '"language_source": "follow_ui"' in launch_meta
     launch = service._launches[job_name]
+    assert launch.effective_language == "zh-Hans"
+    assert launch.language_source == "follow_ui"
     assert launch.execution_plane == "remote"
     assert launch.remote_run_id == "run_fake"
     assert launch.status == "completed"
+
+    detail = service.get_job(job_name)
+    assert detail is not None
+    assert detail["launch"]["effectiveLanguage"] == "zh-Hans"
+    assert detail["launch"]["languageSource"] == "follow_ui"

--- a/application/playground/frontend/src/components/cockpit/setup/useCockpitLaunch.ts
+++ b/application/playground/frontend/src/components/cockpit/setup/useCockpitLaunch.ts
@@ -1,7 +1,9 @@
 import { useCallback, useState } from "react";
 
 import { api, ApiError } from "@/lib/api";
+import { useI18n } from "@/i18n/I18nProvider";
 import type { HarborCockpitTaskKind } from "@/lib/harborCockpitMappers";
+import { withLaunchLanguage } from "@/lib/personaLanguage";
 import type { ConfigOptionsResponse } from "@/lib/types";
 
 import { buildPersonaLaunchFields, hasLaunchableCohort } from "./personaLaunchFields";
@@ -43,6 +45,7 @@ export function useCockpitLaunch(
   taskPath: string | null = null,
   isActive = true,
 ) {
+  const { locale } = useI18n();
   const sampling = useSetupPersonaSampling(options, taskKind, taskPath, isActive);
   const batch = useCockpitBatchJob(
     sampling.selectedPersonaIds,
@@ -90,14 +93,19 @@ export function useCockpitLaunch(
           useEntirePool,
           parallelTrials,
         });
-        const launched = await api.launchHarborJob({
-          taskPath: input.taskPath,
-          seed,
-          personaModel,
-          ...personaFields,
-          mode: "auto",
-          ...input.overrides,
-        });
+        const launched = await api.launchHarborJob(
+          withLaunchLanguage(
+            {
+              taskPath: input.taskPath,
+              seed,
+              personaModel,
+              ...personaFields,
+              mode: "auto",
+              ...input.overrides,
+            },
+            locale,
+          ),
+        );
         setBatchJobName(launched.jobName, { taskId: input.taskId, personaPool });
         return true;
       } catch (exc) {
@@ -115,6 +123,7 @@ export function useCockpitLaunch(
       parallelTrials,
       seed,
       personaModel,
+      locale,
       setBatchJobName,
     ],
   );

--- a/application/playground/frontend/src/components/cockpit/setup/useLaunchLanguage.test.tsx
+++ b/application/playground/frontend/src/components/cockpit/setup/useLaunchLanguage.test.tsx
@@ -1,0 +1,203 @@
+// @vitest-environment jsdom
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { LOCALE_REGISTRY } from "@/i18n/registry";
+import { SOURCE_LOCALE } from "@/i18n/source";
+import { useHarborCockpitRun } from "@/lib/useHarborCockpitRun";
+
+const testState = vi.hoisted(() => ({
+  locale: "en-US",
+  launchHarborJob: vi.fn(),
+  getHarborJob: vi.fn(),
+  getHarborTrialEvents: vi.fn(),
+  getHarborTrialDebrief: vi.fn(),
+  deleteHarborJob: vi.fn(),
+  setUrlState: vi.fn(),
+  setBatchJobName: vi.fn(),
+}));
+
+vi.mock("@/i18n/I18nProvider", () => ({
+  useI18n: () => ({ locale: testState.locale }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    launchHarborJob: testState.launchHarborJob,
+    getHarborJob: testState.getHarborJob,
+    getHarborTrialEvents: testState.getHarborTrialEvents,
+    getHarborTrialDebrief: testState.getHarborTrialDebrief,
+    deleteHarborJob: testState.deleteHarborJob,
+  },
+  ApiError: class ApiError extends Error {},
+}));
+
+vi.mock("@/lib/useUrlState", () => ({
+  useUrlState: () => ({
+    state: {
+      cockpitBatch: null,
+      cockpitJob: null,
+      cockpitTrial: null,
+      pgTask: null,
+    },
+    setState: testState.setUrlState,
+  }),
+}));
+
+vi.mock("./useSetupPersonaSampling", () => ({
+  useSetupPersonaSampling: () => ({
+    personaPool: "validation-subset",
+    selectedPersonaIds: ["persona-0001"],
+    selectedCount: 1,
+    useEntirePool: false,
+    parallelTrials: 1,
+    seed: 7,
+    personaModel: "test-model",
+  }),
+}));
+
+vi.mock("./useCockpitBatchJob", () => ({
+  useCockpitBatchJob: () => ({
+    setBatchJobName: testState.setBatchJobName,
+  }),
+}));
+
+import { useCockpitLaunch } from "./useCockpitLaunch";
+
+const syntheticLocale = {
+  code: "zh-CN",
+  nativeName: "Simplified Chinese",
+  englishName: "Simplified Chinese",
+  personaLanguage: "zh-Hans",
+  dir: "ltr",
+  fallback: SOURCE_LOCALE,
+  load: async () => ({}),
+} as unknown as (typeof LOCALE_REGISTRY)[number];
+
+const mutableLocaleRegistry = LOCALE_REGISTRY as unknown as Array<
+  (typeof LOCALE_REGISTRY)[number]
+>;
+
+function expectedLanguage(locale: string) {
+  return mutableLocaleRegistry.find((entry) => entry.code === locale)?.personaLanguage ??
+    mutableLocaleRegistry.find((entry) => entry.code === SOURCE_LOCALE)?.personaLanguage;
+}
+
+const singleRunInput = {
+  taskPath: "application/tasks/example-survey_product-feedback",
+  personaId: "persona-0001",
+  personaModel: "test-model",
+  mapDebrief: () => ({ status: "done" }),
+};
+
+beforeEach(() => {
+  mutableLocaleRegistry.push(syntheticLocale);
+  testState.locale = SOURCE_LOCALE;
+  testState.launchHarborJob.mockResolvedValue({ jobName: "job-0001" });
+  testState.getHarborJob.mockImplementation(() => new Promise(() => {}));
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  const index = mutableLocaleRegistry.findIndex((entry) => entry.code === syntheticLocale.code);
+  if (index >= 0) mutableLocaleRegistry.splice(index, 1);
+});
+
+describe("single cockpit launch language", () => {
+  it("sends the registry personaLanguage and follow_ui in the final request body", async () => {
+    const { result } = renderHook(() => useHarborCockpitRun({ taskKind: "survey" }));
+
+    await act(async () => {
+      await result.current.run(singleRunInput);
+    });
+
+    expect(testState.launchHarborJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskPath: singleRunInput.taskPath,
+        personaIds: [singleRunInput.personaId],
+        language: expectedLanguage(SOURCE_LOCALE),
+        languageSource: "follow_ui",
+      }),
+    );
+  });
+
+  it("rebuilds the run callback when the UI locale changes", async () => {
+    const { result, rerender } = renderHook(() => useHarborCockpitRun({ taskKind: "survey" }));
+
+    await act(async () => {
+      await result.current.run(singleRunInput);
+    });
+
+    testState.locale = syntheticLocale.code;
+    rerender();
+
+    await act(async () => {
+      await result.current.run(singleRunInput);
+    });
+
+    expect(testState.launchHarborJob).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        language: expectedLanguage(syntheticLocale.code),
+        languageSource: "follow_ui",
+      }),
+    );
+  });
+});
+
+describe("batch cockpit launch language", () => {
+  it("sends the registry personaLanguage and follow_ui in the final request body", async () => {
+    const { result } = renderHook(() =>
+      useCockpitLaunch(null, "survey", "application/tasks/example-survey_product-feedback"),
+    );
+
+    await act(async () => {
+      await result.current.launchBatch({
+        taskPath: "application/tasks/example-survey_product-feedback",
+        taskId: "task-0001",
+      });
+    });
+
+    expect(testState.launchHarborJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskPath: "application/tasks/example-survey_product-feedback",
+        personaModel: "test-model",
+        personaIds: ["persona-0001"],
+        language: expectedLanguage(SOURCE_LOCALE),
+        languageSource: "follow_ui",
+      }),
+    );
+  });
+
+  it("rebuilds the batch callback when the UI locale changes", async () => {
+    const { result, rerender } = renderHook(() =>
+      useCockpitLaunch(null, "survey", "application/tasks/example-survey_product-feedback"),
+    );
+
+    await act(async () => {
+      await result.current.launchBatch({
+        taskPath: "application/tasks/example-survey_product-feedback",
+        taskId: "task-0001",
+      });
+    });
+
+    testState.locale = syntheticLocale.code;
+    rerender();
+
+    await act(async () => {
+      await result.current.launchBatch({
+        taskPath: "application/tasks/example-survey_product-feedback",
+        taskId: "task-0002",
+      });
+    });
+
+    expect(testState.launchHarborJob).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        language: expectedLanguage(syntheticLocale.code),
+        languageSource: "follow_ui",
+      }),
+    );
+  });
+});

--- a/application/playground/frontend/src/i18n/__tests__/foundation.test.tsx
+++ b/application/playground/frontend/src/i18n/__tests__/foundation.test.tsx
@@ -57,6 +57,7 @@ describe("locale loading", () => {
         code: "en-US",
         nativeName: "English",
         englishName: "English",
+        personaLanguage: "en",
         dir: "ltr",
         fallback: null,
         load,
@@ -87,9 +88,9 @@ describe("locale loading", () => {
       "fr-CA": { "locale.english": "Anglais canadien" },
     } as const;
     const definitions: LocaleDefinition<TestLocale>[] = [
-      { code: "en-US", nativeName: "English", englishName: "English", dir: "ltr", fallback: null, load: async () => packs["en-US"] },
-      { code: "fr", nativeName: "Français", englishName: "French", dir: "ltr", fallback: "en-US", load: async () => packs.fr },
-      { code: "fr-CA", nativeName: "Français (Canada)", englishName: "Canadian French", dir: "ltr", fallback: "fr", load: async () => packs["fr-CA"] },
+      { code: "en-US", nativeName: "English", englishName: "English", personaLanguage: "en", dir: "ltr", fallback: null, load: async () => packs["en-US"] },
+      { code: "fr", nativeName: "Français", englishName: "French", personaLanguage: "en", dir: "ltr", fallback: "en-US", load: async () => packs.fr },
+      { code: "fr-CA", nativeName: "Français (Canada)", englishName: "Canadian French", personaLanguage: "en", dir: "ltr", fallback: "fr", load: async () => packs["fr-CA"] },
     ];
     const loader = createLocalePackLoader(definitions);
 

--- a/application/playground/frontend/src/i18n/registry.ts
+++ b/application/playground/frontend/src/i18n/registry.ts
@@ -1,11 +1,13 @@
 import { SOURCE_LOCALE, SOURCE_MESSAGES } from "./source";
-import type { MessageCatalog, TextDirection } from "./types";
+import type { MessageCatalog, PersonaLanguageCode, TextDirection } from "./types";
 
 export interface LocaleDefinition<Code extends string = string> {
   code: Code;
   /** Native-script label shown in the locale popover. */
   nativeName: string;
   englishName: string;
+  /** Canonical persona/runtime language sent when this UI locale is active. */
+  personaLanguage: PersonaLanguageCode;
   dir: TextDirection;
   fallback: Code | null;
   load: () => Promise<MessageCatalog>;
@@ -16,6 +18,7 @@ export const LOCALE_REGISTRY = [
     code: SOURCE_LOCALE,
     nativeName: "English",
     englishName: "English",
+    personaLanguage: "en",
     dir: "ltr",
     fallback: null,
     load: async () => SOURCE_MESSAGES,

--- a/application/playground/frontend/src/i18n/types.ts
+++ b/application/playground/frontend/src/i18n/types.ts
@@ -8,6 +8,16 @@ export type MessageKey = keyof typeof sourceMessages;
 /** Optional locale packs may omit keys; English remains the fallback. */
 export type MessageCatalog = Partial<Record<MessageKey, string>>;
 
+/** Canonical BCP47 tags supported by persona/runtime language rendering. */
+export type PersonaLanguageCode =
+  | "en"
+  | "ko"
+  | "zh-Hans"
+  | "zh-Hant"
+  | "ja"
+  | "pt-BR"
+  | "es";
+
 export type MessageValues = Record<string, string | number | boolean | Date>;
 
 export type RichMessageValues = Record<

--- a/application/playground/frontend/src/lib/__tests__/personaLanguage.test.ts
+++ b/application/playground/frontend/src/lib/__tests__/personaLanguage.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { LOCALE_REGISTRY } from "@/i18n/registry";
+import { SOURCE_LOCALE } from "@/i18n/source";
+import {
+  resolveLaunchLanguage,
+  uiLocaleToLanguage,
+  withLaunchLanguage,
+} from "../personaLanguage";
+
+describe("persona/runtime language launch mapping", () => {
+  it("derives the runtime language from each locale registry entry", () => {
+    for (const entry of LOCALE_REGISTRY) {
+      expect(uiLocaleToLanguage(entry.code)).toBe(entry.personaLanguage);
+    }
+  });
+
+  it("falls back to the English registry entry for an unknown UI locale", () => {
+    expect(uiLocaleToLanguage("future-locale")).toBe("en");
+    expect(uiLocaleToLanguage("future-locale")).toBe(uiLocaleToLanguage(SOURCE_LOCALE));
+  });
+
+  it("records follow_ui provenance in the launch body", () => {
+    expect(resolveLaunchLanguage(SOURCE_LOCALE)).toEqual({
+      language: "en",
+      languageSource: "follow_ui",
+    });
+  });
+
+  it("adds language fields without changing the shared task payload", () => {
+    const body = {
+      taskPath: "application/tasks/example-survey_product-feedback",
+      personaIds: ["0042"],
+      nConcurrentTrials: 1,
+    };
+
+    expect(withLaunchLanguage(body, SOURCE_LOCALE)).toEqual({
+      ...body,
+      language: "en",
+      languageSource: "follow_ui",
+    });
+    expect(body).toEqual({
+      taskPath: "application/tasks/example-survey_product-feedback",
+      personaIds: ["0042"],
+      nConcurrentTrials: 1,
+    });
+  });
+
+  it("overwrites stale language fields so UI-derived provenance wins at launch", () => {
+    expect(
+      withLaunchLanguage(
+        { taskPath: "task", language: "stale", languageSource: "explicit" },
+        SOURCE_LOCALE,
+      ),
+    ).toMatchObject({ language: "en", languageSource: "follow_ui" });
+  });
+});

--- a/application/playground/frontend/src/lib/api.ts
+++ b/application/playground/frontend/src/lib/api.ts
@@ -34,6 +34,7 @@ import type {
 } from "./types";
 import { PERSONA_BENCH_POOL, PERSONA_CARD_PREVIEW_LIMIT } from "./types";
 import { normalizePersonaPoolName } from "./personaDisplay";
+import type { LaunchLanguageSource, PersonaLanguageCode } from "./personaLanguage";
 
 /** Backend `/persona-pool/personas` rejects limit > 500. */
 const PERSONA_POOL_CARDS_LIMIT_MAX = 500;
@@ -212,6 +213,8 @@ export const api = {
     useEntirePool?: boolean;
     osAppSubmissionProfile?: string | null;
     osAppBackend?: string | null;
+    language?: PersonaLanguageCode | null;
+    languageSource?: LaunchLanguageSource | null;
   }) =>
     request<HarborJobLaunchResponse>("/api/harbor/jobs", {
       method: "POST",

--- a/application/playground/frontend/src/lib/personaLanguage.ts
+++ b/application/playground/frontend/src/lib/personaLanguage.ts
@@ -1,0 +1,51 @@
+/**
+ * Resolve the persona/runtime language at the moment a Playground run starts.
+ *
+ * This is deliberately separate from task content and UI copy. The UI locale
+ * is the only input available to the Playground launch path; API/CLI callers
+ * may provide their own explicit runtime-language override elsewhere.
+ */
+
+import { LOCALE_REGISTRY } from "@/i18n/registry";
+import { SOURCE_LOCALE } from "@/i18n/source";
+import type { PersonaLanguageCode } from "@/i18n/types";
+
+export type { PersonaLanguageCode } from "@/i18n/types";
+export type LaunchLanguageSource = "follow_ui";
+
+export interface LaunchLanguageFields {
+  /** Canonical runtime/persona language for the run request. */
+  language: PersonaLanguageCode;
+  /** Provenance persisted with the run by the backend. */
+  languageSource: LaunchLanguageSource;
+}
+
+const SOURCE_PERSONA_LANGUAGE =
+  LOCALE_REGISTRY.find((entry) => entry.code === SOURCE_LOCALE)?.personaLanguage ?? "en";
+
+/** Map a registered UI locale to its registry-owned runtime language token. */
+export function uiLocaleToLanguage(uiLocale: string): PersonaLanguageCode {
+  return (
+    LOCALE_REGISTRY.find((entry) => entry.code === uiLocale)?.personaLanguage ??
+    SOURCE_PERSONA_LANGUAGE
+  );
+}
+
+/** Resolve the UI-derived language fields captured on every Playground launch. */
+export function resolveLaunchLanguage(uiLocale: string): LaunchLanguageFields {
+  return {
+    language: uiLocaleToLanguage(uiLocale),
+    languageSource: "follow_ui",
+  };
+}
+
+/** Add launch-time language provenance to any shared Harbor request body. */
+export function withLaunchLanguage<T extends object>(
+  body: T,
+  uiLocale: string,
+): T & LaunchLanguageFields {
+  return {
+    ...body,
+    ...resolveLaunchLanguage(uiLocale),
+  };
+}

--- a/application/playground/frontend/src/lib/useHarborCockpitRun.ts
+++ b/application/playground/frontend/src/lib/useHarborCockpitRun.ts
@@ -11,7 +11,9 @@ import {
   type HarborCockpitTaskKind,
 } from "./harborCockpitMappers";
 import type { PlaygroundResult } from "./types";
+import { withLaunchLanguage } from "./personaLanguage";
 import { useUrlState } from "./useUrlState";
+import { useI18n } from "@/i18n/I18nProvider";
 
 export type HarborLaunchMode = "auto" | "force_docker" | "smoke";
 export type HarborCockpitPhase = "idle" | "launching" | "running" | "done" | "error" | "timeout";
@@ -56,6 +58,7 @@ function normalizeTaskKind(value: unknown): HarborCockpitTaskKind | null {
 
 export function useHarborCockpitRun<TJob>(options: UseHarborCockpitRunOptions) {
   const { taskKind } = options;
+  const { locale } = useI18n();
   const { state: urlState, setState: setUrlState } = useUrlState();
 
   const [job, setJob] = useState<TJob | null>(null);
@@ -165,21 +168,26 @@ export function useHarborCockpitRun<TJob>(options: UseHarborCockpitRunOptions) {
       setHarborPhase("launching");
       setPhase("launching");
       try {
-        const launched = await api.launchHarborJob({
-          taskPath: input.taskPath,
-          sampleSize: 1,
-          personaIds: [input.personaId],
-          personaModel: input.personaModel,
-          agentName: input.agentName,
-          nConcurrentTrials: 1,
-          mode: input.mode ?? "auto",
-          chatDomain: input.chatDomain,
-          chatApplicationId: input.chatApplicationId,
-          chatApplicationContext: input.chatApplicationContext,
-          chatMaxTurns: input.chatMaxTurns,
-          osAppSubmissionProfile: input.osAppSubmissionProfile,
-          osAppBackend: input.osAppBackend,
-        });
+        const launched = await api.launchHarborJob(
+          withLaunchLanguage(
+            {
+              taskPath: input.taskPath,
+              sampleSize: 1,
+              personaIds: [input.personaId],
+              personaModel: input.personaModel,
+              agentName: input.agentName,
+              nConcurrentTrials: 1,
+              mode: input.mode ?? "auto",
+              chatDomain: input.chatDomain,
+              chatApplicationId: input.chatApplicationId,
+              chatApplicationContext: input.chatApplicationContext,
+              chatMaxTurns: input.chatMaxTurns,
+              osAppSubmissionProfile: input.osAppSubmissionProfile,
+              osAppBackend: input.osAppBackend,
+            },
+            locale,
+          ),
+        );
         setHarborJobName(launched.jobName);
         setUrlState({
           pgTask: taskKind,
@@ -196,7 +204,7 @@ export function useHarborCockpitRun<TJob>(options: UseHarborCockpitRunOptions) {
         clearCockpitUrl();
       }
     },
-    [clearCockpitUrl, setUrlState, taskKind],
+    [clearCockpitUrl, locale, setUrlState, taskKind],
   );
 
   // Restore a single-run job after refresh (only for this cockpit task tab).

--- a/environment/agents/matraix/agents/persona/browser_use.py
+++ b/environment/agents/matraix/agents/persona/browser_use.py
@@ -24,12 +24,16 @@ class PersonaBrowserUse(PersonaMixin, BrowserUseHarborAgent):
         logs_dir: Path,
         persona_path: str | None = None,
         persona_template_path: str | None = None,
+        persona_language: str | None = None,
+        persona_language_source: str | None = None,
         **kwargs,
     ) -> None:
         self._init_persona(
             persona_path,
             AgentName.PERSONA_BROWSER_USE.value,
             persona_template_path=persona_template_path,
+            persona_language=persona_language,
+            persona_language_source=persona_language_source,
         )
         super().__init__(logs_dir=logs_dir, **kwargs)
 

--- a/environment/agents/matraix/agents/persona/claude_code.py
+++ b/environment/agents/matraix/agents/persona/claude_code.py
@@ -32,12 +32,16 @@ class PersonaClaudeCode(PersonaMixin, ClaudeCode):
         logs_dir: Path,
         persona_path: str | None = None,
         persona_template_path: str | None = None,
+        persona_language: str | None = None,
+        persona_language_source: str | None = None,
         **kwargs,
     ) -> None:
         self._init_persona(
             persona_path,
             AgentName.PERSONA_CLAUDE_CODE.value,
             persona_template_path=persona_template_path,
+            persona_language=persona_language,
+            persona_language_source=persona_language_source,
         )
         kwargs["append_system_prompt"] = _merge_append_system_prompt(
             kwargs.get("append_system_prompt"),

--- a/environment/agents/matraix/agents/persona/cocoa.py
+++ b/environment/agents/matraix/agents/persona/cocoa.py
@@ -22,12 +22,16 @@ class PersonaCocoa(PersonaMixin, CocoaHarborAgent):
         logs_dir: Path,
         persona_path: str | None = None,
         persona_template_path: str | None = None,
+        persona_language: str | None = None,
+        persona_language_source: str | None = None,
         **kwargs,
     ) -> None:
         self._init_persona(
             persona_path,
             AgentName.PERSONA_COCOA.value,
             persona_template_path=persona_template_path,
+            persona_language=persona_language,
+            persona_language_source=persona_language_source,
         )
         super().__init__(logs_dir=logs_dir, **kwargs)
 

--- a/environment/agents/matraix/agents/persona/codex.py
+++ b/environment/agents/matraix/agents/persona/codex.py
@@ -22,12 +22,16 @@ class PersonaCodex(PersonaMixin, Codex):
         logs_dir: Path,
         persona_path: str | None = None,
         persona_template_path: str | None = None,
+        persona_language: str | None = None,
+        persona_language_source: str | None = None,
         **kwargs,
     ) -> None:
         self._init_persona(
             persona_path,
             AgentName.PERSONA_CODEX.value,
             persona_template_path=persona_template_path,
+            persona_language=persona_language,
+            persona_language_source=persona_language_source,
         )
         super().__init__(logs_dir=logs_dir, **kwargs)
 

--- a/environment/agents/matraix/agents/persona/computer_1.py
+++ b/environment/agents/matraix/agents/persona/computer_1.py
@@ -178,6 +178,8 @@ class PersonaComputer1(PersonaMixin, BaseAgent):
         model_name: str | None = None,
         persona_path: str | None = None,
         persona_template_path: str | None = None,
+        persona_language: str | None = None,
+        persona_language_source: str | None = None,
         cua_backend: str | None = None,
         cua_submission_profile: str | None = None,
         **kwargs: Any,
@@ -192,6 +194,8 @@ class PersonaComputer1(PersonaMixin, BaseAgent):
             persona_path,
             AgentName.PERSONA_COMPUTER_1.value,
             persona_template_path=persona_template_path,
+            persona_language=persona_language,
+            persona_language_source=persona_language_source,
         )
         self._cua_backend_override = cua_backend
         # Accepted for backward-compatible Harbor YAML / --ak, but ignored:

--- a/environment/agents/matraix/agents/persona/gemini_cli.py
+++ b/environment/agents/matraix/agents/persona/gemini_cli.py
@@ -22,12 +22,16 @@ class PersonaGeminiCli(PersonaMixin, GeminiCli):
         logs_dir: Path,
         persona_path: str | None = None,
         persona_template_path: str | None = None,
+        persona_language: str | None = None,
+        persona_language_source: str | None = None,
         **kwargs,
     ) -> None:
         self._init_persona(
             persona_path,
             AgentName.PERSONA_GEMINI_CLI.value,
             persona_template_path=persona_template_path,
+            persona_language=persona_language,
+            persona_language_source=persona_language_source,
         )
         super().__init__(logs_dir=logs_dir, **kwargs)
 

--- a/environment/agents/matraix/agents/persona/json_survey.py
+++ b/environment/agents/matraix/agents/persona/json_survey.py
@@ -72,17 +72,7 @@ def _load_survey_content(*, task_path: str | None, instrument_path: str | None):
 
 
 def _survey_result_payload(result) -> dict[str, object]:
-    payload: dict[str, object] = {
-        "instrument": {
-            "id": result.instrument.id,
-            "title": result.instrument.title,
-        },
-        "answers": [answer.to_dict() for answer in result.answers],
-        "trajectory": [event.to_dict() for event in result.trajectory],
-    }
-    if getattr(result, "usage", None):
-        payload["usage"] = dict(result.usage)
-    return payload
+    return result.to_dict()
 
 
 def _apply_usage_to_context(context: AgentContext, usage: dict | None) -> None:
@@ -130,6 +120,8 @@ class PersonaJsonSurvey(PersonaMixin, BaseAgent):
         logs_dir: Path,
         persona_path: str | None = None,
         persona_template_path: str | None = None,
+        persona_language: str | None = None,
+        persona_language_source: str | None = None,
         survey_task_path: str | None = None,
         survey_instrument_path: str | None = None,
         **kwargs,
@@ -138,6 +130,8 @@ class PersonaJsonSurvey(PersonaMixin, BaseAgent):
             persona_path,
             AgentName.PERSONA_JSON_SURVEY.value,
             persona_template_path=persona_template_path,
+            persona_language=persona_language,
+            persona_language_source=persona_language_source,
         )
         self._survey_task_path = survey_task_path
         self._survey_instrument_path = survey_instrument_path
@@ -213,6 +207,8 @@ class PersonaJsonSurvey(PersonaMixin, BaseAgent):
             on_event=on_event,
             persona_yaml_path=persona_yaml_path,
             job_dir=job_dir,
+            persona_language=self.effective_persona_language,
+            persona_language_source=self.persona_language_source,
         )
         _apply_usage_to_context(context, result.usage)
         payload = _survey_result_payload(result)

--- a/environment/agents/matraix/agents/persona/mixin.py
+++ b/environment/agents/matraix/agents/persona/mixin.py
@@ -8,6 +8,10 @@ from typing import TYPE_CHECKING
 
 from matraix.agents.persona.loader import Persona, load_persona
 from matraix.persona_job import SMOKE_PERSONA_PATH
+from playground.persona_language import (
+    PersonaLanguageResolution,
+    resolve_persona_language_with_source,
+)
 from matraix.agents.persona.templating import (
     PERSONA_INSTRUCTION_TEMPLATE,
     PERSONA_SYSTEM_TEMPLATE,
@@ -36,6 +40,7 @@ class PersonaMixin:
     _persona: Persona
     _persona_agent_name: str
     _persona_template_path: Path | None
+    _persona_language_resolution: PersonaLanguageResolution
 
     def _init_persona(
         self,
@@ -43,6 +48,8 @@ class PersonaMixin:
         agent_name: str,
         *,
         persona_template_path: str | None = None,
+        persona_language: str | None = None,
+        persona_language_source: str | None = None,
     ) -> None:
         if not persona_path:
             raise ValueError(
@@ -56,6 +63,20 @@ class PersonaMixin:
             if persona_template_path
             else None
         )
+        self._persona_language_resolution = resolve_persona_language_with_source(
+            persona_language,
+            requested_source=persona_language_source,
+        )
+
+    @property
+    def effective_persona_language(self) -> str:
+        """Canonical language used for persona narrative and model prompts."""
+        return self._persona_language_resolution.language
+
+    @property
+    def persona_language_source(self) -> str:
+        """Recorded provenance: follow_ui, explicit, env, or default."""
+        return self._persona_language_resolution.source
 
     def _render_persona_system(self) -> str:
         """Persona identity block for system / identity channels."""
@@ -64,7 +85,11 @@ class PersonaMixin:
             self._persona_template_path,
             PERSONA_SYSTEM_TEMPLATE,
         )
-        return render_persona_template(template, self._persona)
+        return render_persona_template(
+            template,
+            self._persona,
+            language=self.effective_persona_language,
+        )
 
     def _render_persona_instruction(self, instruction: str) -> str:
         """Single-channel fallback: identity first, then the task.
@@ -77,12 +102,19 @@ class PersonaMixin:
             self._persona_template_path,
             PERSONA_INSTRUCTION_TEMPLATE,
         )
-        return render_persona_template(template, self._persona, instruction=instruction)
+        return render_persona_template(
+            template,
+            self._persona,
+            instruction=instruction,
+            language=self.effective_persona_language,
+        )
 
     def _write_persona_meta(self) -> None:
         logs_dir: Path = self.logs_dir  # type: ignore[attr-defined]
         meta_path = logs_dir.parent / "persona_meta.json"
         meta = self._persona.to_meta(self._persona_agent_name)
+        meta["effective_language"] = self.effective_persona_language
+        meta["language_source"] = self.persona_language_source
         if self._persona_template_path is not None:
             meta["persona_template_path"] = str(self._persona_template_path)
         meta_path.write_text(

--- a/environment/agents/matraix/agents/persona/openhands_sdk.py
+++ b/environment/agents/matraix/agents/persona/openhands_sdk.py
@@ -23,12 +23,16 @@ class PersonaOpenHandsSDK(PersonaMixin, OpenHandsSDK):
         logs_dir: Path,
         persona_path: str | None = None,
         persona_template_path: str | None = None,
+        persona_language: str | None = None,
+        persona_language_source: str | None = None,
         **kwargs,
     ) -> None:
         self._init_persona(
             persona_path,
             AgentName.PERSONA_OPENHANDS_SDK.value,
             persona_template_path=persona_template_path,
+            persona_language=persona_language,
+            persona_language_source=persona_language_source,
         )
         super().__init__(logs_dir=logs_dir, **kwargs)
 

--- a/environment/agents/matraix/agents/persona/templates/persona_instruction.md.j2
+++ b/environment/agents/matraix/agents/persona/templates/persona_instruction.md.j2
@@ -22,6 +22,10 @@ You are {{ display_name }}.
 
 {{ system_prompt }}
 {%- endif %}
+{% if runtime_language_contract -%}
+
+{{ runtime_language_contract }}
+{%- endif %}
 
 ---
 

--- a/environment/agents/matraix/agents/persona/templates/persona_system.md.j2
+++ b/environment/agents/matraix/agents/persona/templates/persona_system.md.j2
@@ -21,3 +21,7 @@ You are {{ display_name }}.
 
 {{ system_prompt }}
 {%- endif %}
+{% if runtime_language_contract -%}
+
+{{ runtime_language_contract }}
+{%- endif %}

--- a/environment/agents/matraix/agents/persona/templating.py
+++ b/environment/agents/matraix/agents/persona/templating.py
@@ -8,6 +8,7 @@ from jinja2 import Environment, FileSystemLoader, StrictUndefined, TemplateNotFo
 
 from matraix.agents.persona.loader import Persona
 from matraix.persona_dimension_catalog import build_template_context_extras
+from playground.persona_language import persona_language_contract
 
 PERSONA_SYSTEM_TEMPLATE = "persona_system.md.j2"
 PERSONA_INSTRUCTION_TEMPLATE = "persona_instruction.md.j2"
@@ -46,6 +47,7 @@ def render_persona_template(
     persona: Persona,
     *,
     instruction: str | None = None,
+    language: str | None = None,
 ) -> str:
     env = Environment(
         loader=FileSystemLoader(template_path.parent),
@@ -58,7 +60,17 @@ def render_persona_template(
     except TemplateNotFound as exc:
         raise FileNotFoundError(f"Persona template not found: {template_path}") from exc
 
-    return template.render(
+    language_contract = persona_language_contract(language) if language else ""
+    rendered = template.render(
         **persona.template_context(instruction=instruction),
         **build_template_context_extras(persona.dimensions),
+        runtime_language_contract=language_contract,
     ).strip()
+    # Bundled templates place the contract inside the identity section. Put the
+    # fallback before custom templates so it can never trail task-owned content.
+    if language_contract and language_contract not in rendered:
+        rendered = "{}\n\n{}".format(
+            language_contract,
+            rendered,
+        ).strip()
+    return rendered

--- a/environment/agents/matraix/agents/persona/user_sim.py
+++ b/environment/agents/matraix/agents/persona/user_sim.py
@@ -33,12 +33,16 @@ class PersonaUserSim(PersonaMixin, BaseAgent):
         logs_dir: Path,
         persona_path: str | None = None,
         persona_template_path: str | None = None,
+        persona_language: str | None = None,
+        persona_language_source: str | None = None,
         **kwargs,
     ) -> None:
         self._init_persona(
             persona_path,
             AgentName.PERSONA_USER_SIM.value,
             persona_template_path=persona_template_path,
+            persona_language=persona_language,
+            persona_language_source=persona_language_source,
         )
         super().__init__(logs_dir=logs_dir, **kwargs)
 
@@ -63,6 +67,8 @@ class PersonaUserSim(PersonaMixin, BaseAgent):
             self._persona,
             model_name=self.model_name,
             on_event=on_event,
+            persona_language=self.effective_persona_language,
+            persona_language_source=self.persona_language_source,
         )
         from playground.llm_usage import apply_usage_dict_to_context
 

--- a/packages/playground/src/playground/harbor/chat_eval.py
+++ b/packages/playground/src/playground/harbor/chat_eval.py
@@ -8,6 +8,7 @@ import os
 import shlex
 import tempfile
 import textwrap
+from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
@@ -31,6 +32,7 @@ from playground.task_content_bundle import (
     load_task_content_bundle_for_task_path,
 )
 from playground.persona_model import resolve_persona_model
+from playground.persona_language import resolve_persona_language_with_source
 from playground.types import (
     Persona,
     PlaygroundConfig,
@@ -112,6 +114,7 @@ def harbor_chat_config_from_env(
     )
     resolved_context = application_context or domain or "chatbot"
     resolved_domain = domain
+    language_resolution = resolve_persona_language_with_source()
     return PlaygroundConfig(
         domain=resolved_domain,
         application_id=application_id,
@@ -119,6 +122,8 @@ def harbor_chat_config_from_env(
         engine=engine,
         persona_model=persona_model,
         max_turns=max_turns,
+        persona_language=language_resolution.language,
+        persona_language_source=language_resolution.source,
     )
 
 
@@ -464,6 +469,8 @@ def harbor_output_artifacts_from_result(
         "applicationId": result.config.application_id,
         "applicationContext": application_context,
         "turnCount": len(result.transcript),
+        "config": result.config.to_dict(),
+        "prompts": dict(result.prompts),
     }
     return {
         "transcript.json": transcript_payload,
@@ -526,9 +533,28 @@ async def run_harbor_chat_eval(
     persona_yaml_path: Optional[str] = None,
     repo_root: Optional[Any] = None,
     job_dir: Optional[Any] = None,
+    persona_language: Optional[str] = None,
+    persona_language_source: Optional[str] = None,
 ) -> PlaygroundResult:
     """Async chat eval loop using a Harbor sidecar session."""
     from playground.user_sim.runner import run_playground_async
+
+    if persona_language is not None or persona_language_source is not None:
+        language_resolution = resolve_persona_language_with_source(
+            persona_language,
+            requested_source=persona_language_source,
+        )
+        config = replace(
+            config,
+            persona_language=language_resolution.language,
+            persona_language_source=language_resolution.source,
+        )
+    else:
+        config = replace(
+            config,
+            persona_language=config.effective_language or "en",
+            persona_language_source=config.language_source or "default",
+        )
 
     return await run_playground_async(
         session,
@@ -541,6 +567,8 @@ async def run_harbor_chat_eval(
         persona_yaml_path=persona_yaml_path,
         repo_root=repo_root,
         job_dir=job_dir,
+        persona_language=config.effective_language,
+        persona_language_source=config.language_source,
     )
 
 
@@ -550,6 +578,8 @@ async def run_harbor_chat_eval_for_persona(
     *,
     model_name: str | None = None,
     on_event: Optional[Callable[[Dict[str, Any]], None]] = None,
+    persona_language: str | None = None,
+    persona_language_source: str | None = None,
 ) -> tuple[PlaygroundResult, str]:
     """End-to-end Harbor chat eval for one loaded Harbor persona object."""
     from playground.harbor.playground import _repo_root
@@ -593,6 +623,8 @@ async def run_harbor_chat_eval_for_persona(
         persona_yaml_path=persona_path,
         repo_root=repo_root,
         job_dir=trial_dir.parent,
+        persona_language=persona_language,
+        persona_language_source=persona_language_source,
     )
     if on_event is not None:
         on_event({"type": "phase", "phase": "harbor_collecting_artifacts"})

--- a/packages/playground/src/playground/harbor/playground.py
+++ b/packages/playground/src/playground/harbor/playground.py
@@ -23,6 +23,7 @@ import yaml
 from backend.service.config import harbor_persona_model
 from playground.structured_exposure import coerce_turn_view
 from playground.feedback import questionnaire_from_feedback
+from playground.persona_language import persona_language_contract
 from playground.types import Persona, PlaygroundConfig
 from matraix.persona_agent_context import apply_persona_context_to_agent_spec
 
@@ -189,9 +190,20 @@ def harbor_persona_system_prompt(persona: Persona) -> str:
     return persona.context or persona.summary or persona.name
 
 
-def _prompt_bundle(persona: Persona, task_prompt: str) -> Dict[str, str]:
+def _prompt_bundle(
+    persona: Persona,
+    task_prompt: str,
+    *,
+    persona_language: str | None = None,
+) -> Dict[str, str]:
+    harbor_prompt = harbor_persona_system_prompt(persona)
+    if persona_language:
+        harbor_prompt = "{}\n\n{}".format(
+            harbor_prompt,
+            persona_language_contract(persona_language),
+        )
     return {
-        "harborPrompt": harbor_persona_system_prompt(persona),
+        "harborPrompt": harbor_prompt,
         "taskPrompt": task_prompt,
     }
 
@@ -221,9 +233,13 @@ def _json_env(value: Dict[str, Any]) -> str:
 def _verifier_env_assignments(
     *, persona: Persona, sut_description: str, config: PlaygroundConfig
 ) -> Dict[str, str]:
+    persona_language = config.effective_language or "en"
+    persona_language_source = config.language_source or "default"
     return {
         "OPENAI_API_KEY": "${OPENAI_API_KEY}",
         "OPENAI_BASE_URL": "${OPENAI_BASE_URL:-https://api.openai.com/v1}",
+        "MATRIX_PERSONA_LANGUAGE": persona_language,
+        "MATRIX_PERSONA_LANGUAGE_SOURCE": persona_language_source,
         "MATRIX_SCORER_PACKAGE_PARENT": SCORER_PACKAGE_PARENT,
         "MATRIX_SCORER_MODULE": "playground.scoring",
         "MATRIX_SCORER_OUTPUT_PATH": SCORER_OUTPUT_PATH,
@@ -248,13 +264,21 @@ def _agent_env_args(assignments: Dict[str, str]) -> List[str]:
 
 
 def _normalize_prompts(
-    prompts: Optional[Dict[str, Any]], *, persona: Persona
+    prompts: Optional[Dict[str, Any]],
+    *,
+    persona: Persona,
+    persona_language: str | None = None,
 ) -> Dict[str, str]:
     data = prompts or {}
+    harbor_prompt = str(data.get("harborPrompt") or "").strip()
+    if not harbor_prompt:
+        harbor_prompt = _prompt_bundle(
+            persona,
+            "",
+            persona_language=persona_language,
+        )["harborPrompt"]
     return {
-        "harborPrompt": str(
-            data.get("harborPrompt") or harbor_persona_system_prompt(persona)
-        ),
+        "harborPrompt": harbor_prompt,
         "taskPrompt": str(data.get("taskPrompt") or ""),
     }
 
@@ -382,7 +406,11 @@ class HarborPlaygroundRunner:
             sut_description=sut_description,
         )
         task_prompt_path.write_text(task_prompt, encoding="utf-8")
-        prompts = _prompt_bundle(persona, task_prompt)
+        prompts = _prompt_bundle(
+            persona,
+            task_prompt,
+            persona_language=config.effective_language,
+        )
 
         job_config_path = run_dir / "harbor_job.yaml"
         job_config = {
@@ -406,7 +434,12 @@ class HarborPlaygroundRunner:
                     {
                         "name": "persona-claude-code",
                         "model_name": config.persona_model or harbor_persona_model(),
-                        "kwargs": {"persona_path": str(persona_path)},
+                        "kwargs": {
+                            "persona_path": str(persona_path),
+                            "persona_language": config.effective_language or "en",
+                            "persona_language_source": config.language_source
+                            or "default",
+                        },
                     }
                 )
             ],
@@ -452,6 +485,9 @@ class HarborPlaygroundRunner:
             "MATRIX_CHATBOT_API_URL": "http://chatbot-api:8000",
             "MATRIX_CHATBOT_PERSONA_MODEL": config.persona_model
             or harbor_persona_model(),
+            "MATRIX_PERSONA_LANGUAGE": config.effective_language or "en",
+            "MATRIX_PERSONA_LANGUAGE_SOURCE": config.language_source
+            or "default",
         }
         if config.max_turns is not None:
             agent_env["MATRIX_CHATBOT_MAX_TURNS"] = str(config.max_turns)
@@ -464,6 +500,13 @@ class HarborPlaygroundRunner:
             "--agent-env",
             "CLAUDE_CODE_TMPDIR=/logs/agent/claude-tmp",
             *_agent_env_args(agent_env),
+            *_verifier_env_args(
+                _verifier_env_assignments(
+                    persona=persona,
+                    sut_description=sut_description,
+                    config=config,
+                )
+            ),
             "-y",
         ]
         if env_file.is_file():
@@ -537,7 +580,14 @@ def _application_result_payload(output_dir: Path) -> Dict[str, Any]:
         return {}
     payload = _read_json(path)
     summary: Dict[str, Any] = {}
-    for key in ("sessionId", "applicationId", "applicationContext", "turnCount"):
+    for key in (
+        "sessionId",
+        "applicationId",
+        "applicationContext",
+        "turnCount",
+        "config",
+        "prompts",
+    ):
         if key in payload:
             summary[key] = payload[key]
     return summary
@@ -781,9 +831,22 @@ def build_result_from_harbor_artifacts(
     """Map Harbor task artifacts into the existing Playground UI result."""
     transcript = _read_json(output_dir / "transcript.json")
     turn_views = _turn_views(transcript)
-    _application_result_payload(output_dir)
+    application_result = _application_result_payload(output_dir)
     feedback_path = _feedback_path(output_dir)
     feedback = _read_json(feedback_path) if feedback_path is not None else {}
+    artifact_prompts = application_result.get("prompts")
+    if prompts is None and isinstance(artifact_prompts, dict):
+        result_prompts = {
+            str(key): str(value)
+            for key, value in artifact_prompts.items()
+            if isinstance(key, str) and isinstance(value, str) and value.strip()
+        }
+    else:
+        result_prompts = _normalize_prompts(
+            prompts,
+            persona=persona,
+            persona_language=config.effective_language,
+        )
 
     metric_scores = {
         "numTurns": len(turn_views),
@@ -796,5 +859,5 @@ def build_result_from_harbor_artifacts(
         questionnaire=_questionnaire(feedback),
         metric_scores=metric_scores,
         created_at=created_at,
-        prompts=_normalize_prompts(prompts, persona=persona),
+        prompts=result_prompts,
     )

--- a/packages/playground/src/playground/inprocess/survey_eval.py
+++ b/packages/playground/src/playground/inprocess/survey_eval.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Dict, List, Optional
 
@@ -21,13 +22,21 @@ from backend.service.survey_types import (
 )
 from playground.budget import assert_budget_allows_request, record_trial_cost
 from playground.model_client import build_json_client
+from playground.persona_language import resolve_persona_language_with_source
 from playground.types import Persona
 from playground.user_sim.prompt import render_persona_block
 
 
-def persona_system_prompt(persona: Persona, *, persona_yaml_path: str) -> str:
+def persona_system_prompt(
+    persona: Persona,
+    *,
+    persona_yaml_path: str,
+    persona_language: str | None = None,
+) -> str:
     persona_body = render_persona_block(
-        persona, persona_yaml_path=persona_yaml_path
+        persona,
+        persona_yaml_path=persona_yaml_path,
+        persona_language=persona_language,
     ).strip()
     if not persona_body:
         raise ValueError(f"empty persona render for yaml path: {persona_yaml_path}")
@@ -85,6 +94,8 @@ class InprocessSurveyEvalRunner:
         persona_yaml_path: str,
         on_event: Optional[Callable[[Dict[str, Any]], None]] = None,
         job_dir: Optional[Any] = None,
+        persona_language: str | None = None,
+        persona_language_source: str | None = None,
         client: Any | None = None,
         client_factory: Optional[Callable[[str], Any]] = None,
     ) -> SurveyEvalResult:
@@ -94,9 +105,28 @@ class InprocessSurveyEvalRunner:
             if on_event is not None:
                 on_event(event)
 
+        if persona_language is None:
+            requested_language = config.persona_language
+            requested_source = config.persona_language_source
+        else:
+            requested_language = persona_language
+            requested_source = persona_language_source
+        language = resolve_persona_language_with_source(
+            requested_language,
+            requested_source=requested_source,
+            environ={},
+        )
+        config = replace(
+            config,
+            persona_language=language.language,
+            persona_language_source=language.source,
+        )
+
         task_prompt = build_survey_task_prompt(instrument=instrument)
         persona_prompt = persona_system_prompt(
-            persona, persona_yaml_path=persona_yaml_path
+            persona,
+            persona_yaml_path=persona_yaml_path,
+            persona_language=language.language,
         )
         prompts = {
             "personaPrompt": persona_prompt,

--- a/packages/playground/src/playground/persona_language.py
+++ b/packages/playground/src/playground/persona_language.py
@@ -1,0 +1,136 @@
+"""Runtime persona-language resolution and prompt contract helpers.
+
+This module deliberately owns runtime language only.  It does not translate
+persona dimension labels, task content, artifact keys, or protocol fields.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Mapping
+
+from matraix.launch_env import (
+    PERSONA_LANGUAGE_ENV as MATRIX_PERSONA_LANGUAGE_ENV,
+    PERSONA_LANGUAGE_OVERRIDE_ENV as MATRIX_PERSONA_LANGUAGE_OVERRIDE_ENV,
+    PERSONA_LANGUAGE_SOURCE_ENV as MATRIX_PERSONA_LANGUAGE_SOURCE_ENV,
+    PERSONA_LANGUAGE_TOKENS,
+    canonicalize_persona_language,
+)
+
+SUPPORTED_PERSONA_LANGUAGES = frozenset(PERSONA_LANGUAGE_TOKENS)
+PERSONA_LANGUAGE_SOURCES = frozenset(
+    {"follow_ui", "explicit", "env", "default"}
+)
+
+_LANGUAGE_NAMES = {
+    "en": "English",
+    "ko": "Korean",
+    "zh-Hans": "Simplified Chinese",
+    "zh-Hant": "Traditional Chinese",
+    "ja": "Japanese",
+    "pt-BR": "Brazilian Portuguese",
+    "es": "Spanish",
+}
+
+
+@dataclass(frozen=True)
+class PersonaLanguageResolution:
+    language: str
+    source: str
+
+
+def normalize_persona_language(value: object) -> str | None:
+    """Return a supported canonical runtime language, or ``None``."""
+    if value is None:
+        return None
+    return canonicalize_persona_language(str(value))
+
+
+def _runtime_environment(environ: Mapping[str, str] | None) -> Mapping[str, str]:
+    return os.environ if environ is None else environ
+
+
+def _normalize_source_hint(value: object) -> str | None:
+    raw = str(value or "").strip().lower()
+    return raw if raw in PERSONA_LANGUAGE_SOURCES else None
+
+
+def _environment_language(environ: Mapping[str, str]) -> tuple[str | None, str | None]:
+    """Resolve language env values without trusting a provenance label."""
+    language = normalize_persona_language(environ.get(MATRIX_PERSONA_LANGUAGE_ENV))
+    if language is None:
+        return None, None
+    source_hint = _normalize_source_hint(
+        environ.get(MATRIX_PERSONA_LANGUAGE_SOURCE_ENV)
+    )
+    return language, source_hint or "env"
+
+
+def resolve_persona_language_with_source(
+    requested_language: object = None,
+    *,
+    requested_source: object = None,
+    environ: Mapping[str, str] | None = None,
+) -> PersonaLanguageResolution:
+    """Resolve runtime language with explicit values taking precedence.
+
+    A CLI override marker has highest precedence so ``matraix run
+    --persona-language`` can replace language kwargs in an existing generated
+    job. ``requested_language`` otherwise represents a direct runtime/agent
+    argument. A valid source supplied with a direct agent argument is retained.
+    This is how Harbor preserves ``follow_ui``, ``explicit``, ``env``, and
+    ``default`` from launch metadata through the trial artifact. A direct
+    language without a source is an explicit override. Environment provenance
+    is read only from a paired runtime value; legacy language-only values are
+    marked ``env``.
+    """
+    runtime_environment = _runtime_environment(environ)
+    cli_override = normalize_persona_language(
+        runtime_environment.get(MATRIX_PERSONA_LANGUAGE_OVERRIDE_ENV)
+    )
+    if cli_override is not None:
+        return PersonaLanguageResolution(language=cli_override, source="explicit")
+
+    explicit = normalize_persona_language(requested_language)
+    if explicit is not None:
+        requested_source_hint = _normalize_source_hint(requested_source)
+        return PersonaLanguageResolution(
+            language=explicit,
+            source=requested_source_hint or "explicit",
+        )
+
+    env_language, env_source = _environment_language(runtime_environment)
+    if env_language is not None:
+        return PersonaLanguageResolution(language=env_language, source=env_source or "env")
+    return PersonaLanguageResolution(language="en", source="default")
+
+
+def resolve_persona_language(
+    requested_language: object = None,
+    *,
+    requested_source: object = None,
+    environ: Mapping[str, str] | None = None,
+) -> str:
+    """Resolve and return only the canonical runtime language value."""
+    return resolve_persona_language_with_source(
+        requested_language,
+        requested_source=requested_source,
+        environ=environ,
+    ).language
+
+
+def persona_language_contract(language: object) -> str:
+    """Stable system/persona instruction contract for model-facing prompts."""
+    resolved = normalize_persona_language(language) or "en"
+    display = _LANGUAGE_NAMES.get(resolved, "English")
+    return "\n".join(
+        [
+            "## Runtime persona language contract",
+            "",
+            f"Effective persona language: {display} ({resolved}).",
+            "Write persona narrative, simulated user messages, and persona self-reports in this language.",
+            "Keep task instructions, task context, questionnaires, quoted task content, JSON keys, and protocol fields in their task-owned/original form; do not translate or couple task content to this persona-language setting.",
+            "If the task explicitly requires another language for task content, follow that task requirement only for the required task content.",
+        ]
+    )

--- a/packages/playground/src/playground/post_run_feedback.py
+++ b/packages/playground/src/playground/post_run_feedback.py
@@ -10,6 +10,7 @@ from backend.service.harbor_trial_debrief import (
     _application_type_from_task_toml,
     _load_playground_persona,
     _persona_path_from_trial,
+    _recorded_persona_language,
     _task_path_from_trial,
     find_trial_logs_dir,
     find_trial_output_dir,
@@ -225,6 +226,7 @@ def maybe_write_trial_user_feedback(*, repo_root: Path, trial_dir: Path) -> Path
         persona,
         persona_yaml_path=persona_rel,
         task_bundle=task_bundle,
+        persona_language=_recorded_persona_language(trial_dir).language,
     )
     user_prompt = _REFLECTION_USER.format(
         application_label=_application_label(app_type),

--- a/packages/playground/src/playground/scoring.py
+++ b/packages/playground/src/playground/scoring.py
@@ -100,6 +100,29 @@ def _config_from_dict(value: Dict[str, Any]) -> PlaygroundConfig:
             value.get("resourceMode", value.get("resource_mode", "recai_resources"))
         ),
         max_turns=int(raw_max_turns) if raw_max_turns not in (None, "") else None,
+        persona_language=str(
+            value.get(
+                "effectiveLanguage",
+                value.get(
+                    "effective_language",
+                    value.get("personaLanguage", value.get("persona_language", "en")),
+                ),
+            )
+            or "en"
+        ),
+        persona_language_source=str(
+            value.get(
+                "languageSource",
+                value.get(
+                    "language_source",
+                    value.get(
+                        "personaLanguageSource",
+                        value.get("persona_language_source", "default"),
+                    ),
+                ),
+            )
+            or "default"
+        ),
     )
 
 
@@ -200,7 +223,11 @@ class OriginalPromptFeedbackScorer:
             if task_path
             else None
         )
-        system_prompt = assemble_report_system_prompt(persona, task_bundle=task_bundle)
+        system_prompt = assemble_report_system_prompt(
+            persona,
+            task_bundle=task_bundle,
+            persona_language=config.effective_language,
+        )
         transcript = [
             _turn_from_view(index, turn) for index, turn in enumerate(turn_views)
         ]

--- a/packages/playground/src/playground/tests/test_persona_language.py
+++ b/packages/playground/src/playground/tests/test_persona_language.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from matraix.agents.persona.loader import load_persona
+from matraix.agents.persona.templating import (
+    PERSONA_INSTRUCTION_TEMPLATE,
+    render_persona_template,
+    resolve_persona_template,
+)
+from matraix.launch_env import canonicalize_persona_language
+from playground.persona_language import (
+    PERSONA_LANGUAGE_SOURCES,
+    SUPPORTED_PERSONA_LANGUAGES,
+    normalize_persona_language,
+    persona_language_contract,
+    resolve_persona_language_with_source,
+)
+
+
+@pytest.mark.parametrize("source", ["follow_ui", "explicit", "env", "default"])
+def test_direct_agent_language_precedes_environment_and_preserves_source(
+    source: str,
+) -> None:
+    resolution = resolve_persona_language_with_source(
+        "zh-CN",
+        requested_source=source,
+        environ={
+            "MATRIX_PERSONA_LANGUAGE": "ja",
+            "MATRIX_PERSONA_LANGUAGE_SOURCE": "cli",
+        },
+    )
+    assert resolution.language == "zh-Hans"
+    assert resolution.source == source
+
+
+def test_api_agent_follow_ui_source_is_preserved() -> None:
+    resolution = resolve_persona_language_with_source(
+        "zh-CN",
+        requested_source="follow_ui",
+        environ={"MATRIX_PERSONA_LANGUAGE": "ja"},
+    )
+    assert resolution.language == "zh-Hans"
+    assert resolution.source == "follow_ui"
+
+
+def test_cli_source_companion_is_explicit() -> None:
+    resolution = resolve_persona_language_with_source(
+        environ={
+            "MATRIX_PERSONA_LANGUAGE": "zh",
+            "MATRIX_PERSONA_LANGUAGE_SOURCE": "explicit",
+        }
+    )
+    assert resolution.language == "zh-Hans"
+    assert resolution.source == "explicit"
+
+
+def test_unknown_env_source_is_derived_as_env() -> None:
+    resolution = resolve_persona_language_with_source(
+        environ={
+            "MATRIX_PERSONA_LANGUAGE": "pt",
+            "MATRIX_PERSONA_LANGUAGE_SOURCE": "cli",
+        }
+    )
+    assert resolution.language == "pt-BR"
+    assert resolution.source == "env"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("en", "en"),
+        ("en-US", "en"),
+        ("ko", "ko"),
+        ("ko-KR", "ko"),
+        ("zh", "zh-Hans"),
+        ("zh-CN", "zh-Hans"),
+        ("zh-Hans-CN", "zh-Hans"),
+        ("zh-Hant", "zh-Hant"),
+        ("zh-TW", "zh-Hant"),
+        ("zh-HK", "zh-Hant"),
+        ("ja", "ja"),
+        ("ja-JP", "ja"),
+        ("pt", "pt-BR"),
+        ("pt-BR", "pt-BR"),
+        ("es", "es"),
+        ("es-ES", "es"),
+        ("es-419", "es"),
+    ],
+)
+def test_canonical_tags_and_legacy_aliases_share_one_resolver(
+    value: str, expected: str
+) -> None:
+    assert normalize_persona_language(value) == expected
+    assert canonicalize_persona_language(value) == expected
+
+
+def test_supported_language_and_source_sets_are_canonical() -> None:
+    assert SUPPORTED_PERSONA_LANGUAGES == {
+        "en",
+        "ko",
+        "zh-Hans",
+        "zh-Hant",
+        "ja",
+        "pt-BR",
+        "es",
+    }
+    assert PERSONA_LANGUAGE_SOURCES == {
+        "follow_ui",
+        "explicit",
+        "env",
+        "default",
+    }
+
+
+@pytest.mark.parametrize("value", [None, "", "fr", "pt-PT", "zh-XX"])
+def test_unknown_languages_are_not_silently_relabelled(value: object) -> None:
+    assert normalize_persona_language(value) is None
+
+
+def test_plain_env_and_default_provenance() -> None:
+    env_resolution = resolve_persona_language_with_source(
+        environ={"MATRIX_PERSONA_LANGUAGE": "pt-BR"}
+    )
+    assert env_resolution.language == "pt-BR"
+    assert env_resolution.source == "env"
+
+    default_resolution = resolve_persona_language_with_source(environ={})
+    assert default_resolution.language == "en"
+    assert default_resolution.source == "default"
+
+
+def test_paired_environment_source_is_preserved() -> None:
+    resolution = resolve_persona_language_with_source(
+        environ={
+            "MATRIX_PERSONA_LANGUAGE": "ja-JP",
+            "MATRIX_PERSONA_LANGUAGE_SOURCE": "follow_ui",
+        }
+    )
+    assert resolution.language == "ja"
+    assert resolution.source == "follow_ui"
+
+
+def test_contract_keeps_task_content_outside_persona_language_scope() -> None:
+    contract = persona_language_contract("zh")
+    assert "Simplified Chinese (zh-Hans)" in contract
+    assert "do not translate" in contract
+    assert "JSON keys" in contract
+
+
+def test_single_channel_contract_stays_in_identity_before_task_body() -> None:
+    repo_root = Path(__file__).resolve().parents[5]
+    persona = load_persona(
+        repo_root / "persona/datasets/matraix-persona-dev-sample/persona_0001.yaml"
+    )
+    template = resolve_persona_template(
+        persona,
+        None,
+        PERSONA_INSTRUCTION_TEMPLATE,
+    )
+    rendered = render_persona_template(
+        template,
+        persona,
+        instruction="TASK_BODY_SENTINEL",
+        language="zh-Hans",
+    )
+
+    assert rendered.index("## Runtime persona language contract") < rendered.index(
+        "## Task instruction"
+    )
+    assert "TASK_BODY_SENTINEL" in rendered
+
+
+def test_custom_template_fallback_contract_precedes_task_body(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[5]
+    persona = load_persona(
+        repo_root / "persona/datasets/matraix-persona-dev-sample/persona_0001.yaml"
+    )
+    template = tmp_path / "custom_persona.md.j2"
+    template.write_text(
+        "Persona: {{ display_name }}\n\nTask: {{ instruction }}",
+        encoding="utf-8",
+    )
+
+    rendered = render_persona_template(
+        template,
+        persona,
+        instruction="TASK_BODY_SENTINEL",
+        language="zh-Hans",
+    )
+
+    assert rendered.index("## Runtime persona language contract") < rendered.index(
+        "TASK_BODY_SENTINEL"
+    )

--- a/packages/playground/src/playground/tests/test_scoring.py
+++ b/packages/playground/src/playground/tests/test_scoring.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 import json
 
-from playground.scoring import OriginalPromptFeedbackScorer, score_harbor_artifacts
+from playground.scoring import (
+    OriginalPromptFeedbackScorer,
+    _config_from_dict,
+    score_harbor_artifacts,
+)
 from playground.types import Persona, PlaygroundConfig
 
 
@@ -60,6 +64,33 @@ def test_original_prompt_feedback_scorer_reuses_canonical_feedback_prompt():
     assert "RecAI: Try Movie A." in call["user"]
     assert "Recommended items" not in call["user"]
     assert "Name: Persona One" in call["system"]
+
+
+def test_scoring_deserializes_and_uses_effective_persona_language():
+    config = _config_from_dict(
+        {
+            "domain": "movie",
+            "engine": "gpt-4o-mini",
+            "effectiveLanguage": "zh-Hans",
+            "languageSource": "follow_ui",
+        }
+    )
+    assert config.persona_language == "zh-Hans"
+    assert config.persona_language_source == "follow_ui"
+
+    fake_client = FakeClient()
+    OriginalPromptFeedbackScorer(
+        client_factory=lambda _model: fake_client
+    )(
+        persona=Persona(id="p1", name="Persona One", context="A careful user."),
+        sut_description="A movie recommender.",
+        config=config,
+        turn_views=[],
+    )
+
+    assert "Effective persona language: Simplified Chinese (zh-Hans)." in (
+        fake_client.calls[0]["system"]
+    )
 
 
 def test_score_harbor_artifacts_writes_original_questionnaire(tmp_path):

--- a/packages/playground/src/playground/tests/test_types.py
+++ b/packages/playground/src/playground/tests/test_types.py
@@ -98,3 +98,27 @@ def test_config_to_dict_mirrors_application_context_when_domain_missing():
 
     assert cfg.to_dict()["applicationContext"] == "meal_planning"
     assert cfg.to_dict()["domain"] == "meal_planning"
+
+
+def test_config_persists_effective_persona_language_and_source():
+    default = PlaygroundConfig()
+    assert default.persona_language == "en"
+    assert default.persona_language_source == "default"
+    assert default.effective_language == "en"
+    assert default.language_source == "default"
+    assert default.to_dict()["effectiveLanguage"] == "en"
+    assert default.to_dict()["languageSource"] == "default"
+
+    cfg = PlaygroundConfig(
+        persona_language="zh-Hant",
+        persona_language_source="follow_ui",
+    )
+    assert cfg.to_dict()["effectiveLanguage"] == "zh-Hant"
+    assert cfg.to_dict()["languageSource"] == "follow_ui"
+    assert cfg.effective_language == "zh-Hant"
+    assert cfg.language_source == "follow_ui"
+
+    cfg.effective_language = "ja"
+    cfg.language_source = "explicit"
+    assert cfg.persona_language == "ja"
+    assert cfg.persona_language_source == "explicit"

--- a/packages/playground/src/playground/tests/test_user_sim.py
+++ b/packages/playground/src/playground/tests/test_user_sim.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
 
 from playground.task_content_bundle import TaskContentBundle
 from playground.types import Persona, PlaygroundConfig, Questionnaire
-from playground.user_sim.runner import run_playground
+from playground.user_sim.runner import run_playground, run_playground_async
 from playground.user_sim.session import UserSimSession
 from playground.user_sim.tool_client import FakeToolStepClient
 from playground.user_sim.tools import ToolCall, normalize_sim_message, parse_tool_calls
@@ -28,8 +29,18 @@ class FakeSession:
         return self._turns.pop(0)
 
 
+class AsyncFakeSession(FakeSession):
+    async def run_turn_sync(self, message):
+        self.calls.append(message)
+        return self._turns.pop(0)
+
+
 class FakeSelfReportClient:
+    def __init__(self):
+        self.calls = []
+
     def complete_json(self, system, user):
+        self.calls.append({"system": system, "user": user})
         return {
             "needConstraintSatisfaction": "yes",
             "personalPreferenceSatisfaction": "yes",
@@ -73,12 +84,20 @@ def test_user_sim_session_stores_natural_assistant_memory():
     client = FakeToolStepClient(
         [[ToolCall("send_message", {"message": "Hi, need a movie recommendation"})]]
     )
-    session = UserSimSession(client, _persona())
+    session = UserSimSession(
+        client,
+        _persona(),
+        persona_language="zh-Hans",
+        persona_language_source="follow_ui",
+    )
     session.opening_action()
     assistant_turn = session.messages[-1]
     assert assistant_turn["role"] == "assistant"
     assert assistant_turn["content"] == "Hi, need a movie recommendation"
     assert "Tool send_message" not in assistant_turn["content"]
+    assert session.effective_persona_language == "zh-Hans"
+    assert session.persona_language_source == "follow_ui"
+    assert "Simplified Chinese (zh-Hans)" in session.system_prompt
 
 
 def test_parse_tool_calls_send_and_end():
@@ -105,9 +124,11 @@ def test_user_sim_session_opening_action():
 
 
 def test_run_playground_tool_loop(monkeypatch):
+    monkeypatch.delenv("MATRIX_PERSONA_LANGUAGE", raising=False)
+    report_client = FakeSelfReportClient()
     monkeypatch.setattr(
         "playground.user_sim.runner.build_json_client",
-        lambda *_args, **_kwargs: FakeSelfReportClient(),
+        lambda *_args, **_kwargs: report_client,
     )
     session = FakeSession(
         [
@@ -149,6 +170,8 @@ def test_run_playground_tool_loop(monkeypatch):
     assert isinstance(result.questionnaire, Questionnaire)
     assert result.prompts["taskPrompt"]
     assert len(client.calls) >= 3
+    assert "Effective persona language: English (en)." in client.calls[0][0]["content"]
+    assert "Effective persona language: English (en)." in report_client.calls[0]["system"]
     second_step = client.calls[1]
     assert second_step[-1]["role"] == "user"
     assert 'Meal Planning Nutrition Answer:\n"""What genre?"""' in second_step[-1]["content"]
@@ -173,10 +196,12 @@ def test_prompt_bundle_separates_persona_and_task():
         persona,
         task_bundle=task_bundle,
         task_prompt="Kickoff instruction.",
+        persona_language="zh-Hans",
     )
     report_prompt = assemble_report_system_prompt(
         persona,
         task_bundle=task_bundle,
+        persona_language="zh-Hans",
     )
     assert "Progressive disclosure" not in bundle["personaPrompt"]
     assert "Bio line" in bundle["personaPrompt"]
@@ -193,15 +218,116 @@ def test_prompt_bundle_separates_persona_and_task():
         "Progressive disclosure"
     )
     assert "Keep messages short and natural (usually 1-3 sentences)." in bundle["harborPrompt"]
+    assert "Simplified Chinese (zh-Hans)" in bundle["personaPrompt"]
+    assert "Simplified Chinese (zh-Hans)" in report_prompt
+    assert "Judge the chatbot honestly." in bundle["taskPrompt"]
+    assert "do not translate" not in bundle["taskPrompt"]
     assert "Prefer plainspoken end-user language" in bundle["harborPrompt"]
     assert "simulating" not in bundle["harborPrompt"].lower()
     assert "assigned persona" not in bundle["harborPrompt"].lower()
+
+    english_bundle = prompt_bundle(
+        persona,
+        task_bundle=task_bundle,
+        task_prompt="Kickoff instruction.",
+        persona_language="en",
+    )
+    assert bundle["taskPrompt"] == english_bundle["taskPrompt"]
     assert "stay in character" not in bundle["harborPrompt"].lower()
     assert "## Task instruction" in bundle["harborPrompt"]
     assert "## Task context" in bundle["harborPrompt"]
     assert "## Task instruction" in report_prompt
     assert "## Task context" in report_prompt
     assert "## Output schema" not in report_prompt
+
+
+def test_runner_uses_one_effective_language_for_persona_and_self_report(monkeypatch):
+    report_client = FakeSelfReportClient()
+    monkeypatch.setattr(
+        "playground.user_sim.runner.build_json_client",
+        lambda *_args, **_kwargs: report_client,
+    )
+    tool_client = FakeToolStepClient(
+        [
+            [ToolCall("send_message", {"message": "ZH-HANS USER MESSAGE"})],
+            [ToolCall("end_conversation", {"reason": "satisfied"})],
+        ]
+    )
+    monkeypatch.setattr(
+        "playground.user_sim.runner.build_tool_step_client",
+        lambda *_args, **_kwargs: tool_client,
+    )
+
+    events = []
+    result = run_playground(
+        FakeSession([{"assistantMessage": "ZH-HANS ASSISTANT MESSAGE", "recommendedItems": []}]),
+        _persona(),
+        "A test chatbot",
+        PlaygroundConfig(domain="movie", max_turns=1),
+        created_at="2026-06-30T00:00:00Z",
+        persona_language="zh-Hans",
+        persona_language_source="follow_ui",
+        on_event=events.append,
+    )
+
+    assert len(tool_client.calls) == 2
+    persona_prompt = tool_client.calls[0][0]["content"]
+    assert len(report_client.calls) == 1
+    report_prompt = report_client.calls[0]["system"]
+    marker = "Effective persona language: Simplified Chinese (zh-Hans)."
+    assert marker in persona_prompt
+    assert marker in report_prompt
+    assert "Write persona narrative, simulated user messages, and persona self-reports" in report_prompt
+    assert "Keep task instructions, task context, questionnaires" in report_prompt
+    assert "How well did the chatbot satisfy your core need or constraints?" in report_client.calls[0]["user"]
+    assert result.config.effective_language == "zh-Hans"
+    assert result.config.language_source == "follow_ui"
+    prompt_event = next(event for event in events if event["type"] == "prompts")
+    assert prompt_event["effectiveLanguage"] == "zh-Hans"
+    assert prompt_event["languageSource"] == "follow_ui"
+
+
+def test_async_runner_preserves_language_provenance_and_task_prompt(monkeypatch):
+    report_client = FakeSelfReportClient()
+    monkeypatch.setattr(
+        "playground.user_sim.runner.build_json_client",
+        lambda *_args, **_kwargs: report_client,
+    )
+    tool_client = FakeToolStepClient(
+        [
+            [ToolCall("send_message", {"message": "ZH-HANS USER MESSAGE"})],
+            [ToolCall("end_conversation", {"reason": "satisfied"})],
+        ]
+    )
+    monkeypatch.setattr(
+        "playground.user_sim.runner.build_tool_step_client",
+        lambda *_args, **_kwargs: tool_client,
+    )
+    events = []
+
+    result = asyncio.run(
+        run_playground_async(
+            AsyncFakeSession(
+                [{"assistantMessage": "ZH-HANS ASSISTANT MESSAGE", "recommendedItems": []}]
+            ),
+            _persona(),
+            "A test chatbot",
+            PlaygroundConfig(domain="movie", max_turns=1),
+            created_at="2026-06-30T00:00:00Z",
+            persona_language="zh-Hant",
+            persona_language_source="explicit",
+            on_event=events.append,
+        )
+    )
+
+    assert result.config.effective_language == "zh-Hant"
+    assert result.config.language_source == "explicit"
+    assert "Traditional Chinese (zh-Hant)" in tool_client.calls[0][0]["content"]
+    assert "Traditional Chinese (zh-Hant)" in report_client.calls[0]["system"]
+    prompt_event = next(event for event in events if event["type"] == "prompts")
+    assert prompt_event["effectiveLanguage"] == "zh-Hant"
+    assert prompt_event["languageSource"] == "explicit"
+    assert result.prompts["taskPrompt"]
 
 
 def test_current_date_block_uses_provided_moment():

--- a/packages/playground/src/playground/types.py
+++ b/packages/playground/src/playground/types.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
+from playground.persona_language import resolve_persona_language_with_source
+
 _DECISIONS = {"continue", "satisfied", "give_up"}
 DEFAULT_PERSONA_MODEL = "anthropic/claude-haiku-4-5"
 
@@ -63,6 +65,35 @@ class PlaygroundConfig:
     ranker_mode: str = "native"
     resource_mode: str = "recai_resources"
     max_turns: Optional[int] = None
+    persona_language: str = "en"
+    persona_language_source: str = "default"
+
+    def __post_init__(self) -> None:
+        language = resolve_persona_language_with_source(
+            self.persona_language,
+            requested_source=self.persona_language_source,
+            environ={},
+        )
+        self.persona_language = language.language
+        self.persona_language_source = language.source
+
+    @property
+    def effective_language(self) -> str:
+        """Compatibility alias used by Harbor launch/runtime metadata."""
+        return self.persona_language
+
+    @effective_language.setter
+    def effective_language(self, value: str) -> None:
+        self.persona_language = str(value or "en")
+
+    @property
+    def language_source(self) -> str:
+        """Compatibility alias used by Harbor launch/runtime metadata."""
+        return self.persona_language_source
+
+    @language_source.setter
+    def language_source(self, value: str) -> None:
+        self.persona_language_source = str(value or "default")
 
     def to_dict(self) -> Dict[str, Any]:
         application_context = self.application_context or self.domain
@@ -76,6 +107,8 @@ class PlaygroundConfig:
             "rankerMode": self.ranker_mode,
             "resourceMode": self.resource_mode,
             "maxTurns": self.max_turns,
+            "effectiveLanguage": self.persona_language,
+            "languageSource": self.persona_language_source,
         }
 
 

--- a/packages/playground/src/playground/user_sim/prompt.py
+++ b/packages/playground/src/playground/user_sim/prompt.py
@@ -6,12 +6,14 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
+from playground.persona_language import (
+    persona_language_contract,
+    resolve_persona_language,
+)
 from playground.task_content_bundle import TaskContentBundle
 from playground.types import Persona
 
 _GUIDELINES_PATH = Path(__file__).resolve().parent / "sim_guidelines.md"
-
-
 def load_sim_guidelines() -> str:
     return _GUIDELINES_PATH.read_text(encoding="utf-8").strip()
 
@@ -43,7 +45,13 @@ def _persona_context(persona: Persona) -> str:
     return "\n".join(parts)
 
 
-def render_persona_block(persona: Persona, *, persona_yaml_path: Optional[str] = None) -> str:
+def render_persona_block(
+    persona: Persona,
+    *,
+    persona_yaml_path: Optional[str] = None,
+    persona_language: Optional[str] = None,
+) -> str:
+    effective_language = resolve_persona_language(persona_language)
     if persona_yaml_path:
         try:
             from matraix.agents.persona.loader import load_persona
@@ -55,10 +63,17 @@ def render_persona_block(persona: Persona, *, persona_yaml_path: Optional[str] =
 
             loaded = load_persona(persona_yaml_path)
             template = resolve_persona_template(loaded, None, PERSONA_SYSTEM_TEMPLATE)
-            return render_persona_template(template, loaded).strip()
+            return render_persona_template(
+                template,
+                loaded,
+                language=effective_language,
+            ).strip()
         except Exception:
             pass
-    return _persona_context(persona)
+    return "{}\n\n{}".format(
+        _persona_context(persona),
+        persona_language_contract(effective_language),
+    ).strip()
 
 
 def _section(title: str, body: str) -> str:
@@ -73,10 +88,15 @@ def assemble_system_prompt(
     *,
     persona_yaml_path: Optional[str] = None,
     task_bundle: Optional[TaskContentBundle] = None,
+    persona_language: Optional[str] = None,
 ) -> str:
     task_bundle = task_bundle or TaskContentBundle()
     blocks = [
-        render_persona_block(persona, persona_yaml_path=persona_yaml_path),
+        render_persona_block(
+            persona,
+            persona_yaml_path=persona_yaml_path,
+            persona_language=persona_language,
+        ),
         current_date_block(),
         load_sim_guidelines(),
         _section("Task instruction", task_bundle.instruction_markdown),
@@ -90,10 +110,15 @@ def assemble_report_system_prompt(
     *,
     persona_yaml_path: Optional[str] = None,
     task_bundle: Optional[TaskContentBundle] = None,
+    persona_language: Optional[str] = None,
 ) -> str:
     task_bundle = task_bundle or TaskContentBundle()
     blocks = [
-        render_persona_block(persona, persona_yaml_path=persona_yaml_path),
+        render_persona_block(
+            persona,
+            persona_yaml_path=persona_yaml_path,
+            persona_language=persona_language,
+        ),
         current_date_block(),
         _section("Task instruction", task_bundle.instruction_markdown),
         _section("Task context", task_bundle.context_markdown),
@@ -107,13 +132,19 @@ def prompt_bundle(
     persona_yaml_path: Optional[str] = None,
     task_bundle: Optional[TaskContentBundle] = None,
     task_prompt: str = "",
+    persona_language: Optional[str] = None,
 ) -> dict[str, str]:
     task_bundle = task_bundle or TaskContentBundle()
-    persona_block = render_persona_block(persona, persona_yaml_path=persona_yaml_path)
+    persona_block = render_persona_block(
+        persona,
+        persona_yaml_path=persona_yaml_path,
+        persona_language=persona_language,
+    )
     system = assemble_system_prompt(
         persona,
         persona_yaml_path=persona_yaml_path,
         task_bundle=task_bundle,
+        persona_language=persona_language,
     )
 
     task_parts: list[str] = []

--- a/packages/playground/src/playground/user_sim/runner.py
+++ b/packages/playground/src/playground/user_sim/runner.py
@@ -18,6 +18,10 @@ from playground.task_content_bundle import (
     load_task_content_bundle_for_task_path,
 )
 from playground.model_client import build_json_client
+from playground.persona_language import (
+    PersonaLanguageResolution,
+    resolve_persona_language_with_source,
+)
 from playground.types import (
     MetricScores,
     Persona,
@@ -49,6 +53,45 @@ def _tool_client_usage(tool_client: Any):
     if callable(getter):
         return getter()
     return None
+
+
+def _resolve_run_persona_language(
+    config: PlaygroundConfig,
+    persona_language: Optional[str],
+    persona_language_source: Optional[str],
+) -> PersonaLanguageResolution:
+    """Resolve one language/source pair for every prompt in a run.
+
+    A persisted config is useful when replaying an existing run, while an
+    explicit function argument remains the highest-priority override.  Older
+    ``PlaygroundConfig`` defaults provide the legacy English/default behavior.
+    """
+    requested_language = (
+        persona_language
+        if persona_language is not None
+        else config.persona_language
+    )
+    requested_source = (
+        persona_language_source
+        if persona_language_source is not None
+        else config.persona_language_source
+    )
+    return resolve_persona_language_with_source(
+        requested_language,
+        requested_source=requested_source,
+    )
+
+
+def _record_run_persona_language(
+    config: PlaygroundConfig,
+    resolution: PersonaLanguageResolution,
+) -> None:
+    """Attach reproducible runtime-language provenance to the run config.
+
+    The config serializer owns the wire/artifact field names.
+    """
+    config.persona_language = resolution.language
+    config.persona_language_source = resolution.source
 
 
 def _chat_result_with_usage(
@@ -167,6 +210,8 @@ def run_playground(
     persona_yaml_path: Optional[str] = None,
     repo_root: Optional[Path] = None,
     job_dir: Optional[Path] = None,
+    persona_language: Optional[str] = None,
+    persona_language_source: Optional[str] = None,
 ) -> PlaygroundResult:
     def emit(event: Dict[str, Any]) -> None:
         if on_event is not None:
@@ -181,6 +226,12 @@ def run_playground(
         task_path or "",
         repo_root=repo_root or Path("."),
     )
+    language = _resolve_run_persona_language(
+        config,
+        persona_language,
+        persona_language_source,
+    )
+    _record_run_persona_language(config, language)
 
     tool_client = build_tool_step_client(
         config.persona_model,
@@ -191,19 +242,30 @@ def run_playground(
         persona,
         persona_yaml_path=persona_yaml_path,
         task_bundle=task_bundle,
+        persona_language=language.language,
+        persona_language_source=language.source,
     )
     prompts = prompt_bundle(
         persona,
         persona_yaml_path=persona_yaml_path,
         task_bundle=task_bundle,
+        persona_language=language.language,
         task_prompt=goal_context.description,
     )
     report_prompt = assemble_report_system_prompt(
         persona,
         persona_yaml_path=persona_yaml_path,
         task_bundle=task_bundle,
+        persona_language=language.language,
     )
-    emit({"type": "prompts", "prompts": prompts})
+    emit(
+        {
+            "type": "prompts",
+            "prompts": prompts,
+            "effectiveLanguage": language.language,
+            "languageSource": language.source,
+        }
+    )
 
     transcript: List[PlaygroundTurn] = []
     action = sim.opening_action()
@@ -292,6 +354,8 @@ async def run_playground_async(
     persona_yaml_path: Optional[str] = None,
     repo_root: Optional[Path] = None,
     job_dir: Optional[Path] = None,
+    persona_language: Optional[str] = None,
+    persona_language_source: Optional[str] = None,
 ) -> PlaygroundResult:
     """Like :func:`run_playground` but awaits async Harbor sidecar turns."""
 
@@ -308,6 +372,12 @@ async def run_playground_async(
         task_path or "",
         repo_root=repo_root or Path("."),
     )
+    language = _resolve_run_persona_language(
+        config,
+        persona_language,
+        persona_language_source,
+    )
+    _record_run_persona_language(config, language)
 
     tool_client = build_tool_step_client(
         config.persona_model,
@@ -318,19 +388,30 @@ async def run_playground_async(
         persona,
         persona_yaml_path=persona_yaml_path,
         task_bundle=task_bundle,
+        persona_language=language.language,
+        persona_language_source=language.source,
     )
     prompts = prompt_bundle(
         persona,
         persona_yaml_path=persona_yaml_path,
         task_bundle=task_bundle,
+        persona_language=language.language,
         task_prompt=goal_context.description,
     )
     report_prompt = assemble_report_system_prompt(
         persona,
         persona_yaml_path=persona_yaml_path,
         task_bundle=task_bundle,
+        persona_language=language.language,
     )
-    emit({"type": "prompts", "prompts": prompts})
+    emit(
+        {
+            "type": "prompts",
+            "prompts": prompts,
+            "effectiveLanguage": language.language,
+            "languageSource": language.source,
+        }
+    )
 
     transcript: List[PlaygroundTurn] = []
     action = sim.opening_action()

--- a/packages/playground/src/playground/user_sim/session.py
+++ b/packages/playground/src/playground/user_sim/session.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
+from playground.persona_language import resolve_persona_language_with_source
 from playground.task_content_bundle import TaskContentBundle
 from playground.types import Persona
 from playground.user_sim.prompt import assemble_system_prompt
@@ -48,14 +49,23 @@ class UserSimSession:
         *,
         persona_yaml_path: Optional[str] = None,
         task_bundle: Optional[TaskContentBundle] = None,
+        persona_language: Optional[str] = None,
+        persona_language_source: Optional[str] = None,
     ) -> None:
         self._client = client
         self._persona = persona
         self._persona_yaml_path = persona_yaml_path
+        language = resolve_persona_language_with_source(
+            persona_language,
+            requested_source=persona_language_source,
+        )
+        self.effective_persona_language = language.language
+        self.persona_language_source = language.source
         system = assemble_system_prompt(
             persona,
             persona_yaml_path=persona_yaml_path,
             task_bundle=task_bundle,
+            persona_language=self.effective_persona_language,
         )
         self._messages: List[Dict[str, Any]] = [{"role": "system", "content": system}]
         self.system_prompt = system

--- a/src/matraix/cli.py
+++ b/src/matraix/cli.py
@@ -15,6 +15,7 @@ import sys
 from pathlib import Path
 
 from matraix.launch_env import (
+    PERSONA_LANGUAGE_OVERRIDE_ENV,
     build_persona_language_override_env,
     find_repo_root,
     merge_pythonpath,
@@ -157,6 +158,9 @@ def _cmd_run(args: argparse.Namespace, passthrough: list[str]) -> None:
         if args.max_cost_usd < 0:
             sys.exit("matraix run: --max-cost-usd must be >= 0")
         env_updates["MATRIX_MAX_COST_USD"] = f"{args.max_cost_usd:g}"
+    had_persona_override = PERSONA_LANGUAGE_OVERRIDE_ENV in os.environ
+    previous_persona_override = os.environ.get(PERSONA_LANGUAGE_OVERRIDE_ENV)
+    scopes_persona_override = PERSONA_LANGUAGE_OVERRIDE_ENV in env_updates
     os.environ.update(env_updates)
     explicit_persona_env = build_persona_language_override_env(args.persona_language)
     for name, value in env_updates.items():
@@ -178,7 +182,16 @@ def _cmd_run(args: argparse.Namespace, passthrough: list[str]) -> None:
 
     from harbor.cli.main import app as harbor_app
 
-    harbor_app(args=argv, prog_name="harbor")
+    try:
+        harbor_app(args=argv, prog_name="harbor")
+    finally:
+        # The override marker is authority for this CLI invocation only.  Do
+        # not let an in-process Harbor run leak it into later runs or tests.
+        if scopes_persona_override:
+            if had_persona_override and previous_persona_override is not None:
+                os.environ[PERSONA_LANGUAGE_OVERRIDE_ENV] = previous_persona_override
+            else:
+                os.environ.pop(PERSONA_LANGUAGE_OVERRIDE_ENV, None)
 
 
 def _cmd_results(args: argparse.Namespace) -> None:

--- a/src/matraix/cli.py
+++ b/src/matraix/cli.py
@@ -15,8 +15,10 @@ import sys
 from pathlib import Path
 
 from matraix.launch_env import (
+    build_persona_language_override_env,
     find_repo_root,
     merge_pythonpath,
+    normalize_persona_language,
     required_pythonpath_entries,
 )
 from matraix.job_results import (
@@ -72,15 +74,27 @@ def _task_env_from_header(config_path: Path) -> dict[str, str]:
     return env
 
 
+def _persona_language_arg(value: str) -> str:
+    """Argparse converter for canonical runtime/persona language tokens."""
+    try:
+        normalized = normalize_persona_language(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+    assert normalized is not None
+    return normalized
+
+
 def resolve_run_invocation(
     config_path: Path | None,
     repo_root: Path,
     passthrough: list[str] | None = None,
+    persona_language: str | None = None,
 ) -> tuple[list[str], dict[str, str]]:
     """Return ``harbor`` argv and the env updates for a ``matraix run`` call.
 
     Environment variables already exported by the user always win over
-    values derived from the generated job files.
+    values derived from the generated job files.  A CLI persona-language
+    override is explicit and wins over both sources.
     """
     env_updates: dict[str, str] = {}
     config_args: list[str] = []
@@ -98,6 +112,10 @@ def resolve_run_invocation(
     env_updates["PYTHONPATH"] = merge_pythonpath(
         os.environ.get("PYTHONPATH"), repo_root
     )
+    if persona_language is not None:
+        # Apply this after generated task exports and existing-env filtering so
+        # the explicit CLI flag is the highest-precedence launch input.
+        env_updates.update(build_persona_language_override_env(persona_language))
     argv = ["run", *config_args, *(passthrough or [])]
     return argv, env_updates
 
@@ -129,17 +147,25 @@ def _cmd_run(args: argparse.Namespace, passthrough: list[str]) -> None:
         if args.repo_root
         else find_repo_root(config_path.parent if config_path else None)
     )
-    argv, env_updates = resolve_run_invocation(config_path, repo_root, passthrough)
+    argv, env_updates = resolve_run_invocation(
+        config_path,
+        repo_root,
+        passthrough,
+        persona_language=args.persona_language,
+    )
     if args.max_cost_usd is not None:
         if args.max_cost_usd < 0:
             sys.exit("matraix run: --max-cost-usd must be >= 0")
         env_updates["MATRIX_MAX_COST_USD"] = f"{args.max_cost_usd:g}"
     os.environ.update(env_updates)
+    explicit_persona_env = build_persona_language_override_env(args.persona_language)
     for name, value in env_updates.items():
         if name == "PYTHONPATH":
             continue
         if name == "MATRIX_MAX_COST_USD":
             print(f"matraix run: budget gate MATRIX_MAX_COST_USD={value}", file=sys.stderr)
+        elif name in explicit_persona_env:
+            print(f"matraix run: {name}={value} (from --persona-language)", file=sys.stderr)
         else:
             print(f"matraix run: {name}={value} (from generated job)", file=sys.stderr)
     # Make the injected paths visible to this process too, since Harbor loads
@@ -274,6 +300,18 @@ def main(argv: list[str] | None = None) -> None:
             "recorded spend meets this limit. Web/OS agents already report "
             "tokens/cost via their runtimes; this gate applies to host-native "
             "Survey/Chat today."
+        ),
+    )
+    run_parser.add_argument(
+        "--persona-language",
+        type=_persona_language_arg,
+        metavar="{en,ko,zh-Hans,zh-Hant,ja,pt-BR,es}",
+        default=None,
+        help=(
+            "Explicit runtime/persona language override. Emits the controlled "
+            "language/source launch fields plus a CLI authority marker so the "
+            "flag also overrides generated agent kwargs. Without this flag, "
+            "existing job/env/default resolution is unchanged."
         ),
     )
 

--- a/src/matraix/launch_env.py
+++ b/src/matraix/launch_env.py
@@ -24,6 +24,100 @@ REQUIRED_PYTHONPATH_SUBDIRS: tuple[str, ...] = (
 
 _REPO_ROOT_MARKER = Path("environment") / "runtime" / "harbor"
 
+# Runtime/persona language is deliberately carried on MATRIX_* fields. Remote
+# dispatch already admits the MATRIX_* namespace, so this feature does not
+# need to change remote-runner environment policy.
+PERSONA_LANGUAGE_ENV = "MATRIX_PERSONA_LANGUAGE"
+PERSONA_LANGUAGE_SOURCE_ENV = "MATRIX_PERSONA_LANGUAGE_SOURCE"
+# CLI-only authority marker. The normal language/source pair remains the
+# persisted runtime contract; this field only establishes override precedence.
+PERSONA_LANGUAGE_OVERRIDE_ENV = "MATRIX_PERSONA_LANGUAGE_OVERRIDE"
+PERSONA_LANGUAGE_TOKENS: tuple[str, ...] = (
+    "en",
+    "ko",
+    "zh-Hans",
+    "zh-Hant",
+    "ja",
+    "pt-BR",
+    "es",
+)
+PERSONA_LANGUAGE_SOURCE_TOKENS: tuple[str, ...] = ("follow_ui", "explicit")
+
+_PERSONA_LANGUAGE_ALIASES: dict[str, str] = {
+    "en": "en",
+    "en-us": "en",
+    "en-gb": "en",
+    "ko": "ko",
+    "ko-kr": "ko",
+    "zh": "zh-Hans",
+    "zh-cn": "zh-Hans",
+    "zh-hans": "zh-Hans",
+    "zh-hans-cn": "zh-Hans",
+    "zh-tw": "zh-Hant",
+    "zh-hk": "zh-Hant",
+    "zh-hant": "zh-Hant",
+    "ja": "ja",
+    "ja-jp": "ja",
+    "pt": "pt-BR",
+    "pt-br": "pt-BR",
+    "es": "es",
+    "es-es": "es",
+    "es-419": "es",
+}
+
+
+def canonicalize_persona_language(language: str | None) -> str | None:
+    """Return the canonical runtime token, or ``None`` if unsupported."""
+    if language is None:
+        return None
+    candidate = str(language).strip().replace("_", "-").casefold()
+    return _PERSONA_LANGUAGE_ALIASES.get(candidate)
+
+
+def normalize_persona_language(language: str | None) -> str | None:
+    """Validate and return a canonical runtime language token."""
+    if language is None:
+        return None
+    canonical = canonicalize_persona_language(language)
+    if canonical is None:
+        supported = ", ".join(PERSONA_LANGUAGE_TOKENS)
+        raise ValueError(
+            f"persona language must be one of: {supported}; received {language!r}"
+        )
+    return canonical
+
+
+def normalize_persona_language_source(source: str | None) -> str | None:
+    """Validate the caller-owned language provenance contract."""
+    if source is None:
+        return None
+    normalized = str(source).strip().casefold()
+    if normalized in PERSONA_LANGUAGE_SOURCE_TOKENS:
+        return normalized
+    supported = ", ".join(PERSONA_LANGUAGE_SOURCE_TOKENS)
+    raise ValueError(
+        f"persona language source must be one of: {supported}; received {source!r}"
+    )
+
+
+def build_persona_language_env(language: str | None) -> dict[str, str]:
+    """Build the explicit runtime-language env contract for a CLI override."""
+    normalized = normalize_persona_language(language)
+    if normalized is None:
+        return {}
+    return {
+        PERSONA_LANGUAGE_ENV: normalized,
+        PERSONA_LANGUAGE_SOURCE_ENV: "explicit",
+    }
+
+
+def build_persona_language_override_env(language: str | None) -> dict[str, str]:
+    """Build the highest-precedence language contract for a CLI override."""
+    env = build_persona_language_env(language)
+    if env:
+        env[PERSONA_LANGUAGE_OVERRIDE_ENV] = env[PERSONA_LANGUAGE_ENV]
+    return env
+
 
 def required_pythonpath_entries(repo_root: Path | str) -> list[str]:
     """Absolute ``PYTHONPATH`` entries every Harbor launcher must inject."""

--- a/tests/environment/test_persona_agents.py
+++ b/tests/environment/test_persona_agents.py
@@ -372,3 +372,103 @@ def test_persona_computer_1_docker_uses_identity_channel(monkeypatch, tmp_path) 
     assert "schema" not in identity.lower()
     assert "Open Settings and enable Do Not Disturb." not in identity
 
+
+def test_persona_json_survey_uploads_complete_reproducible_result(
+    monkeypatch, tmp_path
+) -> None:
+    import asyncio
+    import json
+
+    from backend.service.survey_types import (
+        SurveyAnswer,
+        SurveyEvalConfig,
+        SurveyEvalResult,
+        SurveyInstrument,
+        SurveyMetrics,
+        SurveyQuestion,
+        SurveyTaskContent,
+        TrajectoryEvent,
+    )
+    from harbor.models.agent.context import AgentContext
+    from matraix.agents.persona import json_survey as json_survey_mod
+    from playground.types import Persona
+
+    instrument = SurveyInstrument(
+        id="artifact-language-contract",
+        title="Artifact language contract",
+        questions=[SurveyQuestion(id="q1", prompt="Choose", type="likert")],
+    )
+    content = SurveyTaskContent(
+        title=instrument.title,
+        instruction_markdown="Answer the questionnaire.",
+        instrument=instrument,
+    )
+    expected_result = SurveyEvalResult(
+        config=SurveyEvalConfig(
+            persona_model="dashscope/qwen-flash",
+            persona_language="zh-Hans",
+            persona_language_source="explicit",
+        ),
+        persona=Persona(id="0001", name="Tomas Horvat", source="wiki"),
+        instrument=instrument,
+        answers=[SurveyAnswer(question_id="q1", value=4)],
+        trajectory=[
+            TrajectoryEvent(
+                timestamp="2026-08-18T00:00:00Z",
+                actor="system",
+                action="survey_completed",
+            )
+        ],
+        metrics=SurveyMetrics(num_questions=1, num_answered=1, mean_likert=4.0),
+        created_at="2026-08-18T00:00:00Z",
+        prompts={
+            "personaPrompt": "Reply in Simplified Chinese (zh-Hans).",
+            "harborPrompt": "Reply in Simplified Chinese (zh-Hans).",
+            "taskPrompt": "Answer the questionnaire.",
+        },
+    )
+
+    monkeypatch.setattr(
+        json_survey_mod,
+        "_load_survey_content",
+        lambda **_kwargs: (instrument, content),
+    )
+
+    class _FakeRunner:
+        def __call__(self, *_args, **_kwargs):
+            return expected_result
+
+    monkeypatch.setattr(json_survey_mod, "InprocessSurveyEvalRunner", _FakeRunner)
+
+    uploaded: dict[str, dict] = {}
+
+    class _Environment:
+        async def upload_file(self, source_path, target_path):
+            if target_path == "/app/output/survey_result.json":
+                uploaded[target_path] = json.loads(
+                    pathlib.Path(source_path).read_text(encoding="utf-8")
+                )
+
+    logs_dir = tmp_path / "job" / "trial" / "agent"
+    logs_dir.mkdir(parents=True)
+    agent = json_survey_mod.PersonaJsonSurvey(
+        logs_dir=logs_dir,
+        model_name="dashscope/qwen-flash",
+        persona_path=str(
+            ROOT / "persona/datasets/matraix-persona-dev-sample/persona_0001.yaml"
+        ),
+        persona_language="zh-CN",
+        persona_language_source="explicit",
+        survey_task_path="application/tasks/example-survey_product-feedback",
+    )
+
+    asyncio.run(agent.run("", _Environment(), AgentContext()))
+
+    payload = uploaded["/app/output/survey_result.json"]
+    assert payload["effectiveLanguage"] == "zh-Hans"
+    assert payload["languageSource"] == "explicit"
+    assert payload["config"]["effectiveLanguage"] == "zh-Hans"
+    assert payload["prompts"] == expected_result.prompts
+    assert payload["persona"]["id"] == "0001"
+    assert payload["metrics"]["numAnswered"] == 1
+    assert payload["createdAt"] == "2026-08-18T00:00:00Z"

--- a/tests/unit/matraix/test_launch_env.py
+++ b/tests/unit/matraix/test_launch_env.py
@@ -1,12 +1,49 @@
 import os
 from pathlib import Path
 
+import pytest
+
 from matraix.launch_env import (
     build_launch_env,
     find_repo_root,
     merge_pythonpath,
+    normalize_persona_language,
+    normalize_persona_language_source,
     required_pythonpath_entries,
 )
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("en", "en"),
+        ("en-US", "en"),
+        ("ko", "ko"),
+        ("ko-KR", "ko"),
+        ("zh", "zh-Hans"),
+        ("zh-CN", "zh-Hans"),
+        ("zh-Hans-CN", "zh-Hans"),
+        ("zh-Hant", "zh-Hant"),
+        ("zh-TW", "zh-Hant"),
+        ("ja", "ja"),
+        ("ja-JP", "ja"),
+        ("pt", "pt-BR"),
+        ("pt-BR", "pt-BR"),
+        ("es", "es"),
+        ("es-ES", "es"),
+        ("es-419", "es"),
+    ],
+)
+def test_normalize_persona_language_uses_canonical_tags(value: str, expected: str) -> None:
+    assert normalize_persona_language(value) == expected
+
+
+@pytest.mark.parametrize("source", ["ui", "env", "default", "cli"])
+def test_normalize_persona_language_source_rejects_internal_or_legacy_sources(
+    source: str,
+) -> None:
+    with pytest.raises(ValueError, match="follow_ui, explicit"):
+        normalize_persona_language_source(source)
 
 
 def test_required_entries_cover_all_monorepo_import_roots(tmp_path: Path) -> None:

--- a/tests/unit/matraix/test_matraix_cli.py
+++ b/tests/unit/matraix/test_matraix_cli.py
@@ -341,6 +341,7 @@ tasks: []
                 "zh-Hant",
             ]
         )
+        assert "MATRIX_PERSONA_LANGUAGE_OVERRIDE" not in os.environ
     finally:
         os.chdir(original_cwd)
         sys.path[:] = original_sys_path

--- a/tests/unit/matraix/test_matraix_cli.py
+++ b/tests/unit/matraix/test_matraix_cli.py
@@ -5,9 +5,16 @@ import types
 from pathlib import Path
 
 import pytest
+import yaml
 
 from matraix import cli
-from matraix.launch_env import required_pythonpath_entries
+from matraix.launch_env import (
+    PERSONA_LANGUAGE_ENV,
+    PERSONA_LANGUAGE_SOURCE_ENV,
+    build_persona_language_env,
+    required_pythonpath_entries,
+)
+from playground.persona_language import resolve_persona_language_with_source
 
 
 def _write_job(
@@ -96,6 +103,54 @@ def test_resolve_run_invocation_respects_user_exported_env(
     assert "MATRIX_SURVEY_TASK_PATH" not in env_updates
 
 
+def test_persona_language_env_normalizes_tokens_and_records_explicit_source() -> None:
+    assert build_persona_language_env(" zh-cn ") == {
+        PERSONA_LANGUAGE_ENV: "zh-Hans",
+        PERSONA_LANGUAGE_SOURCE_ENV: "explicit",
+    }
+
+
+def test_persona_language_validation_rejects_unknown_tokens() -> None:
+    with pytest.raises(ValueError, match="en, ko, zh-Hans, zh-Hant, ja, pt-BR, es"):
+        build_persona_language_env("fr")
+
+
+def test_resolve_run_invocation_explicit_language_overrides_env_and_generated_config(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv(PERSONA_LANGUAGE_ENV, "en")
+    monkeypatch.setenv(PERSONA_LANGUAGE_SOURCE_ENV, "env")
+    config = _write_job(
+        tmp_path,
+        header_exports=[
+            "#   export MATRIX_PERSONA_LANGUAGE=ko",
+            "#   export MATRIX_PERSONA_LANGUAGE_SOURCE=task",
+        ],
+    )
+
+    _, env_updates = cli.resolve_run_invocation(
+        config, tmp_path, persona_language="ZH-hant"
+    )
+
+    assert env_updates[PERSONA_LANGUAGE_ENV] == "zh-Hant"
+    assert env_updates[PERSONA_LANGUAGE_SOURCE_ENV] == "explicit"
+
+
+def test_resolve_run_invocation_without_language_preserves_existing_env_behavior(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv(PERSONA_LANGUAGE_ENV, "ko")
+    monkeypatch.setenv(PERSONA_LANGUAGE_SOURCE_ENV, "env")
+    config = _write_job(tmp_path)
+
+    _, env_updates = cli.resolve_run_invocation(config, tmp_path)
+
+    assert PERSONA_LANGUAGE_ENV not in env_updates
+    assert PERSONA_LANGUAGE_SOURCE_ENV not in env_updates
+    assert os.environ[PERSONA_LANGUAGE_ENV] == "ko"
+    assert os.environ[PERSONA_LANGUAGE_SOURCE_ENV] == "env"
+
+
 def test_main_run_delegates_to_harbor_with_launch_env(
     tmp_path: Path, monkeypatch
 ) -> None:
@@ -160,6 +215,10 @@ def _stub_harbor(monkeypatch) -> dict[str, object]:
     def fake_app(*, args: list[str], prog_name: str) -> None:
         calls["args"] = args
         calls["pythonpath"] = os.environ.get("PYTHONPATH", "")
+        calls["persona_language"] = os.environ.get(PERSONA_LANGUAGE_ENV)
+        calls["persona_language_source"] = os.environ.get(
+            PERSONA_LANGUAGE_SOURCE_ENV
+        )
 
     stub = types.ModuleType("harbor.cli.main")
     stub.app = fake_app
@@ -191,6 +250,119 @@ def test_main_run_accepts_positional_config(tmp_path: Path, monkeypatch) -> None
         "configs/jobs/application-task-job-recipe/example-survey-auto-n1.yaml",
         "--yes",
     ]
+
+
+def test_main_run_accepts_persona_language_override(tmp_path: Path, monkeypatch) -> None:
+    root = _fake_checkout(tmp_path)
+    config = _write_job(root)
+    calls = _stub_harbor(monkeypatch)
+    monkeypatch.delenv(PERSONA_LANGUAGE_ENV, raising=False)
+    monkeypatch.delenv(PERSONA_LANGUAGE_SOURCE_ENV, raising=False)
+
+    original_cwd = Path.cwd()
+    original_sys_path = list(sys.path)
+    try:
+        cli.main(
+            [
+                "run",
+                "-c",
+                str(config),
+                "--persona-language",
+                "ZH-hant",
+                "--yes",
+            ]
+        )
+    finally:
+        os.chdir(original_cwd)
+        sys.path[:] = original_sys_path
+        monkeypatch.delenv(PERSONA_LANGUAGE_ENV, raising=False)
+        monkeypatch.delenv(PERSONA_LANGUAGE_SOURCE_ENV, raising=False)
+
+    assert calls["args"] == [
+        "run",
+        "-c",
+        str(
+            Path("configs")
+            / "jobs"
+            / "application-task-job-recipe"
+            / "example-survey-auto-n1.yaml"
+        ),
+        "--yes",
+    ]
+    assert calls["persona_language"] == "zh-Hant"
+    assert calls["persona_language_source"] == "explicit"
+
+
+def test_cli_language_override_beats_generated_agent_kwargs(
+    tmp_path: Path, monkeypatch
+) -> None:
+    root = _fake_checkout(tmp_path)
+    config = _write_job(root)
+    config.write_text(
+        """job_name: example
+agents:
+- name: persona-json-survey
+  kwargs:
+    persona_language: en
+    persona_language_source: follow_ui
+tasks: []
+""",
+        encoding="utf-8",
+    )
+    calls: dict[str, object] = {}
+
+    def fake_app(*, args: list[str], prog_name: str) -> None:
+        config_arg = Path(args[args.index("-c") + 1])
+        payload = yaml.safe_load(config_arg.read_text(encoding="utf-8"))
+        kwargs = payload["agents"][0]["kwargs"]
+        resolution = resolve_persona_language_with_source(
+            kwargs["persona_language"],
+            requested_source=kwargs["persona_language_source"],
+        )
+        calls["language"] = resolution.language
+        calls["source"] = resolution.source
+
+    stub = types.ModuleType("harbor.cli.main")
+    stub.app = fake_app
+    monkeypatch.setitem(sys.modules, "harbor.cli.main", stub)
+    monkeypatch.delenv(PERSONA_LANGUAGE_ENV, raising=False)
+    monkeypatch.delenv("MATRIX_PERSONA_LANGUAGE_OVERRIDE", raising=False)
+    monkeypatch.delenv(PERSONA_LANGUAGE_SOURCE_ENV, raising=False)
+
+    original_cwd = Path.cwd()
+    original_sys_path = list(sys.path)
+    try:
+        cli.main(
+            [
+                "run",
+                "-c",
+                str(config),
+                "--persona-language",
+                "zh-Hant",
+            ]
+        )
+    finally:
+        os.chdir(original_cwd)
+        sys.path[:] = original_sys_path
+        monkeypatch.delenv(PERSONA_LANGUAGE_ENV, raising=False)
+        monkeypatch.delenv("MATRIX_PERSONA_LANGUAGE_OVERRIDE", raising=False)
+        monkeypatch.delenv(PERSONA_LANGUAGE_SOURCE_ENV, raising=False)
+
+    assert calls == {"language": "zh-Hant", "source": "explicit"}
+
+
+def test_main_rejects_unknown_persona_language(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(
+            [
+                "run",
+                "--repo-root",
+                str(tmp_path),
+                "--persona-language",
+                "fr",
+            ]
+        )
+    assert excinfo.value.code == 2
 
 
 def test_main_run_without_config_passes_args_through(


### PR DESCRIPTION
## Summary

Implements **PR 3 — Runtime persona language** from #66 on top of current upstream `main` (`07bb6a4`).

- Maps the active Playground UI locale to a canonical runtime/persona language at launch.
- Keeps Playground behavior as **always follow UI**; there is no persona-language selector or separate localStorage setting.
- Preserves explicit API and CLI overrides for reproducible evals.
- Propagates language and truthful provenance through API requests, generated Harbor configs, all persona-agent paths, prompts, persisted artifacts, retries, and debrief reconstruction.
- Covers the `local_appworld_eval` path and Survey/Chat/Web/OS task profiles.

## Scope and boundaries

- English remains the source language and shipped default.
- No optional locale packs, translated UI copy, persona-dimension assets, generated translation files, or task-content changes are included.
- UI locale, runtime/persona language, and task-owned content remain separate.
- Task instructions, questionnaires, IDs, JSON keys, protocol fields, and user-authored content are not translated.
- Runtime tokens use canonical BCP 47 forms (`en`, `ko`, `zh-Hans`, `zh-Hant`, `ja`, `pt-BR`, `es`); supported legacy locale aliases normalize at the boundary.

## Override and provenance contract

- Playground launches record `languageSource=follow_ui`.
- API requests with a language and no source are recorded as `explicit`.
- `matraix run --persona-language ...` has highest precedence, including over language kwargs already embedded in a generated job YAML.
- Backend-derived environment/default provenance cannot be claimed by callers.
- Every run persists the effective language and source in launch metadata and runtime artifacts; debrief reconstruction prefers recorded prompts and language metadata without consulting browser locale.

## Validation

- Frontend Node contract tests: **18/18 passed**
- Frontend Vitest: **41/41 passed**
- `npm run typecheck`: passed
- `npm run i18n:check`: passed (**1,417** English source keys)
- `npm run build`: passed
- Focused language/CLI regression suite: **66 passed**
- Changed Python test matrix: **220 passed**
- `ruff check`: passed
- `git diff --check origin/main...HEAD`: passed

The Python matrix has 11 Windows-local failures. The exact same 11 tests fail on a clean detached `origin/main` checkout: Windows path-separator assertions plus existing environment-dependent AppWorld/scoring tests. No candidate-only Python failure remains.

## Real runtime verification

- Real Playground UI Survey launch succeeded with `en / follow_ui` using a configured provider.
- Real API Survey launch succeeded with `zh-Hans / explicit`; the canonical `survey_result.json` persisted `config`, effective language/source, persona, prompts, metrics, timestamps, answers, trajectory, and usage.
- The persona prompt contained the runtime-language contract; the task prompt remained unchanged.
- CLI generated-YAML override is covered through the real CLI entry point and final shared agent-language resolver.

Real provider E2E was performed for Survey. Chat, Web, OS-app, and Remote Runner paths are covered by focused automated propagation/persistence tests but were not exercised as live external-runtime E2E in this environment.