### PR TITLE
docs: split README News into Recognition vs Releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,17 @@ The name nods to *The Matrix*: a simulated world useful for exploration, stress
 testing, and hypothesis generation, **not a replacement for evidence from real
 people**.
 
-## News
+## News & Recognition
 
-- **[2026-08-11]** Academic commentary: [*Can we simulate the world?*](https://aiscientist.substack.com/p/can-we-simulate-the-world) by Mayank Kejriwal ([*AI Scientist*](https://aiscientist.substack.com/)).
-- **[2026-08-10]** Featured as an [X Trending Story](https://x.com/i/trending/2086626337561911419): *Harvard and MIT Unveil MatrAIx with 8.3 Billion Virtual Personas*. Also covered across tech media, including [36Kr](https://eu.36kr.com/en/p/3932853833759876), [Numerama](https://www.numerama.com/tech/2308727-ces-chercheurs-ont-cree-83-milliards-dhumains-virtuels-pour-tester-des-produits-a-notre-place.html), [Infobae](https://www.infobae.com/tecno/2026/08/10/asi-prueba-la-ia-un-mundo-con-8300-millones-de-personas-digitales-matraix-es-el-metaverso/), [AI타임스](https://www.aitimes.com/news/articleView.html?idxno=213824), [CryptoBriefing](https://cryptobriefing.com/matraix-simulation-harvard-mit-ai-personas/), and [Startup Fortune](https://startupfortune.com/harvard-and-mit-built-an-ai-model-of-83-billion-people-to-test-products-on/), among others. Also discussed by Cisco VP & CTO [Gianpaolo Barozzi](https://lnkd.in/p/gE9cV2nw).
-- **[2026-08-04]** Technical report on arXiv: [MatrAIx: Simulating the World with 8.3 Billion Persona Agents](https://arxiv.org/abs/2608.04205) (`2608.04205`). Also featured on [Hugging Face Daily Papers](https://huggingface.co/papers/date/2026-08-10) ([paper page](https://huggingface.co/papers/2608.04205)).
+- **Academic commentary** — [*Can We Simulate the World?*](https://aiscientist.substack.com/p/can-we-simulate-the-world) — Mayank Kejriwal, [*AI Scientist*](https://aiscientist.substack.com/)
+- **Research discovery** — Featured on [Hugging Face Papers](https://huggingface.co/papers/2608.04205) ([Daily Papers, 2026-08-10](https://huggingface.co/papers/date/2026-08-10))
+- **Media** — [36Kr](https://www.36kr.com/p/3932853833759876) · [Numerama](https://www.numerama.com/tech/2308727-ces-chercheurs-ont-cree-83-milliards-dhumains-virtuels-pour-tester-des-produits-a-notre-place.html) · [Infobae](https://www.infobae.com/tecno/2026/08/10/asi-prueba-la-ia-un-mundo-con-8300-millones-de-personas-digitales-matraix-es-el-metaverso/) · [AI타임스](https://www.aitimes.com/news/articleView.html?idxno=213824) · [Startup Fortune](https://startupfortune.com/harvard-and-mit-built-an-ai-model-of-83-billion-people-to-test-products-on/) · [Forbes Türkiye](https://www.forbes.com.tr/saglik/hastaya-dokunmadan-once-8-3-milyar-kez-denemek-sagligin-yeni-test-dunyasi-matraix) · [WIRED Czech](https://www.wired.cz/news-beat/harvard-a-mit-vytvorily-ai-simulaci-obsahujici-83-miliardy-virtualnich-lidi)
+- **Industry commentary** — Discussed by Cisco VP & CTO [Gianpaolo Barozzi](https://lnkd.in/p/gE9cV2nw)
+- **Social** — Featured as an [X Trending Story](https://x.com/i/trending/2086626337561911419)
+
+## Releases
+
+- **[2026-08-04]** Technical report on arXiv: [MatrAIx: Simulating the World with 8.3 Billion Persona Agents](https://arxiv.org/abs/2608.04205) (`2608.04205`).
 - **[2026-08-01]** Released [Persona 1M](https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release) on Hugging Face (~1M quality-filtered personas).
 - **[2026-07-31]** Open-sourced the Playground and task library: [MatrAIx-Persona-8B](https://github.com/MatrAIx-ai/MatrAIx-Persona-8B).
 - **[2026-07-29]** Position note: [From Personas to Simulated Users](https://matraix.ai/research/survey-from-personas-to-simulated-users.html).

--- a/docs/i18n/README.es.md
+++ b/docs/i18n/README.es.md
@@ -59,11 +59,17 @@ El nombre alude a *The Matrix*: un mundo simulado útil para exploración,
 pruebas de estrés y generación de hipótesis — **no un sustituto de la evidencia
 de personas reales**.
 
-## Novedades
+## Novedades y reconocimiento
 
-- **[2026-08-11]** Comentario académico: [*Can we simulate the world?*](https://aiscientist.substack.com/p/can-we-simulate-the-world) por Mayank Kejriwal ([*AI Scientist*](https://aiscientist.substack.com/)).
-- **[2026-08-10]** Destacado como [X Trending Story](https://x.com/i/trending/2086626337561911419): *Harvard and MIT Unveil MatrAIx with 8.3 Billion Virtual Personas*. También cubierto en medios tecnológicos, incluidos [36Kr](https://eu.36kr.com/en/p/3932853833759876), [Numerama](https://www.numerama.com/tech/2308727-ces-chercheurs-ont-cree-83-milliards-dhumains-virtuels-pour-tester-des-produits-a-notre-place.html), [Infobae](https://www.infobae.com/tecno/2026/08/10/asi-prueba-la-ia-un-mundo-con-8300-millones-de-personas-digitales-matraix-es-el-metaverso/), [AI타임스](https://www.aitimes.com/news/articleView.html?idxno=213824), [CryptoBriefing](https://cryptobriefing.com/matraix-simulation-harvard-mit-ai-personas/) y [Startup Fortune](https://startupfortune.com/harvard-and-mit-built-an-ai-model-of-83-billion-people-to-test-products-on/), entre otros. También comentado por el VP y CTO de Cisco [Gianpaolo Barozzi](https://lnkd.in/p/gE9cV2nw).
-- **[2026-08-04]** Informe técnico en arXiv: [MatrAIx: Simulating the World with 8.3 Billion Persona Agents](https://arxiv.org/abs/2608.04205) (`2608.04205`). También destacado en [Hugging Face Daily Papers](https://huggingface.co/papers/date/2026-08-10) ([página del paper](https://huggingface.co/papers/2608.04205)).
+- **Comentario académico** — [*Can We Simulate the World?*](https://aiscientist.substack.com/p/can-we-simulate-the-world) — Mayank Kejriwal ([*AI Scientist*](https://aiscientist.substack.com/))
+- **Descubrimiento en investigación** — Destacado en [Hugging Face Papers](https://huggingface.co/papers/2608.04205) ([Daily Papers, 2026-08-10](https://huggingface.co/papers/date/2026-08-10))
+- **Medios** — [36Kr](https://www.36kr.com/p/3932853833759876) · [Numerama](https://www.numerama.com/tech/2308727-ces-chercheurs-ont-cree-83-milliards-dhumains-virtuels-pour-tester-des-produits-a-notre-place.html) · [Infobae](https://www.infobae.com/tecno/2026/08/10/asi-prueba-la-ia-un-mundo-con-8300-millones-de-personas-digitales-matraix-es-el-metaverso/) · [AI타임스](https://www.aitimes.com/news/articleView.html?idxno=213824) · [Startup Fortune](https://startupfortune.com/harvard-and-mit-built-an-ai-model-of-83-billion-people-to-test-products-on/) · [Forbes Türkiye](https://www.forbes.com.tr/saglik/hastaya-dokunmadan-once-8-3-milyar-kez-denemek-sagligin-yeni-test-dunyasi-matraix) · [WIRED Czech](https://www.wired.cz/news-beat/harvard-a-mit-vytvorily-ai-simulaci-obsahujici-83-miliardy-virtualnich-lidi)
+- **Comentario de la industria** — Comentado por el VP y CTO de Cisco [Gianpaolo Barozzi](https://lnkd.in/p/gE9cV2nw)
+- **Social** — Destacado como [X Trending Story](https://x.com/i/trending/2086626337561911419)
+
+## Lanzamientos
+
+- **[2026-08-04]** Informe técnico en arXiv: [MatrAIx: Simulating the World with 8.3 Billion Persona Agents](https://arxiv.org/abs/2608.04205) (`2608.04205`).
 - **[2026-08-01]** Publicado [Persona 1M](https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release) en Hugging Face (~1M personas filtradas por calidad).
 - **[2026-07-31]** Código abierto del Playground y la biblioteca de tareas: [MatrAIx-Persona-8B](https://github.com/MatrAIx-ai/MatrAIx-Persona-8B).
 - **[2026-07-29]** Nota de posición: [From Personas to Simulated Users](https://matraix.ai/research/survey-from-personas-to-simulated-users.html).

--- a/docs/i18n/README.ja.md
+++ b/docs/i18n/README.ja.md
@@ -54,11 +54,17 @@
 名前は *The Matrix* に由来します。探索・ストレステスト・仮説生成に有用なシミュレーション世界であり、
 **実在の人々から得られるエビデンスの代替ではありません**。
 
-## ニュース
+## ニュース & 注目
 
-- **[2026-08-11]** 学術コメント: Mayank Kejriwal（[*AI Scientist*](https://aiscientist.substack.com/)）による [*Can we simulate the world?*](https://aiscientist.substack.com/p/can-we-simulate-the-world)。
-- **[2026-08-10]** [X Trending Story](https://x.com/i/trending/2086626337561911419) に掲載: *Harvard and MIT Unveil MatrAIx with 8.3 Billion Virtual Personas*。[36Kr](https://eu.36kr.com/en/p/3932853833759876)、[Numerama](https://www.numerama.com/tech/2308727-ces-chercheurs-ont-cree-83-milliards-dhumains-virtuels-pour-tester-des-produits-a-notre-place.html)、[Infobae](https://www.infobae.com/tecno/2026/08/10/asi-prueba-la-ia-un-mundo-con-8300-millones-de-personas-digitales-matraix-es-el-metaverso/)、[AI타임스](https://www.aitimes.com/news/articleView.html?idxno=213824)、[CryptoBriefing](https://cryptobriefing.com/matraix-simulation-harvard-mit-ai-personas/)、[Startup Fortune](https://startupfortune.com/harvard-and-mit-built-an-ai-model-of-83-billion-people-to-test-products-on/) などのテックメディアでも報じられました。Cisco VP & CTO の [Gianpaolo Barozzi](https://lnkd.in/p/gE9cV2nw) も言及しています。
-- **[2026-08-04]** arXiv 技術レポート: [MatrAIx: Simulating the World with 8.3 Billion Persona Agents](https://arxiv.org/abs/2608.04205) (`2608.04205`)。[Hugging Face Daily Papers](https://huggingface.co/papers/date/2026-08-10) にも掲載（[論文ページ](https://huggingface.co/papers/2608.04205)）。
+- **学術コメント** — [*Can We Simulate the World?*](https://aiscientist.substack.com/p/can-we-simulate-the-world) — Mayank Kejriwal（[*AI Scientist*](https://aiscientist.substack.com/)）
+- **研究ディスカバリー** — [Hugging Face Papers](https://huggingface.co/papers/2608.04205) に掲載（[Daily Papers, 2026-08-10](https://huggingface.co/papers/date/2026-08-10)）
+- **メディア** — [36Kr](https://www.36kr.com/p/3932853833759876) · [Numerama](https://www.numerama.com/tech/2308727-ces-chercheurs-ont-cree-83-milliards-dhumains-virtuels-pour-tester-des-produits-a-notre-place.html) · [Infobae](https://www.infobae.com/tecno/2026/08/10/asi-prueba-la-ia-un-mundo-con-8300-millones-de-personas-digitales-matraix-es-el-metaverso/) · [AI타임스](https://www.aitimes.com/news/articleView.html?idxno=213824) · [Startup Fortune](https://startupfortune.com/harvard-and-mit-built-an-ai-model-of-83-billion-people-to-test-products-on/) · [Forbes Türkiye](https://www.forbes.com.tr/saglik/hastaya-dokunmadan-once-8-3-milyar-kez-denemek-sagligin-yeni-test-dunyasi-matraix) · [WIRED Czech](https://www.wired.cz/news-beat/harvard-a-mit-vytvorily-ai-simulaci-obsahujici-83-miliardy-virtualnich-lidi)
+- **業界コメント** — Cisco VP & CTO [Gianpaolo Barozzi](https://lnkd.in/p/gE9cV2nw) が言及
+- **ソーシャル** — [X Trending Story](https://x.com/i/trending/2086626337561911419) に掲載
+
+## リリース
+
+- **[2026-08-04]** arXiv 技術レポート: [MatrAIx: Simulating the World with 8.3 Billion Persona Agents](https://arxiv.org/abs/2608.04205) (`2608.04205`)。
 - **[2026-08-01]** Hugging Face で [Persona 1M](https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release) を公開（約 100 万件の品質フィルタ済みペルソナ）。
 - **[2026-07-31]** Playground とタスクライブラリをオープンソース化: [MatrAIx-Persona-8B](https://github.com/MatrAIx-ai/MatrAIx-Persona-8B)。
 - **[2026-07-29]** ポジションノート: [From Personas to Simulated Users](https://matraix.ai/research/survey-from-personas-to-simulated-users.html)。

--- a/docs/i18n/README.ko.md
+++ b/docs/i18n/README.ko.md
@@ -54,11 +54,17 @@
 이름은 *The Matrix*에서 따온 것입니다. 탐색·스트레스 테스트·가설 생성에 유용한 시뮬레이션
 세계이며, **실제 사람으로부터의 증거를 대체하지 않습니다**.
 
-## 소식
+## 소식 & 주목
 
-- **[2026-08-11]** 학술 코멘터리: Mayank Kejriwal([*AI Scientist*](https://aiscientist.substack.com/))의 [*Can we simulate the world?*](https://aiscientist.substack.com/p/can-we-simulate-the-world).
-- **[2026-08-10]** [X Trending Story](https://x.com/i/trending/2086626337561911419)에 선정: *Harvard and MIT Unveil MatrAIx with 8.3 Billion Virtual Personas*. 테크 미디어에서도 다뤄졌으며, [36Kr](https://eu.36kr.com/en/p/3932853833759876), [Numerama](https://www.numerama.com/tech/2308727-ces-chercheurs-ont-cree-83-milliards-dhumains-virtuels-pour-tester-des-produits-a-notre-place.html), [Infobae](https://www.infobae.com/tecno/2026/08/10/asi-prueba-la-ia-un-mundo-con-8300-millones-de-personas-digitales-matraix-es-el-metaverso/), [AI타임스](https://www.aitimes.com/news/articleView.html?idxno=213824), [CryptoBriefing](https://cryptobriefing.com/matraix-simulation-harvard-mit-ai-personas/), [Startup Fortune](https://startupfortune.com/harvard-and-mit-built-an-ai-model-of-83-billion-people-to-test-products-on/) 등이 포함됩니다. Cisco VP & CTO [Gianpaolo Barozzi](https://lnkd.in/p/gE9cV2nw)도 이를 언급했습니다.
-- **[2026-08-04]** arXiv 기술 보고서: [MatrAIx: Simulating the World with 8.3 Billion Persona Agents](https://arxiv.org/abs/2608.04205) (`2608.04205`). [Hugging Face Daily Papers](https://huggingface.co/papers/date/2026-08-10)에도 선정([논문 페이지](https://huggingface.co/papers/2608.04205)).
+- **학술 코멘터리** — [*Can We Simulate the World?*](https://aiscientist.substack.com/p/can-we-simulate-the-world) — Mayank Kejriwal([*AI Scientist*](https://aiscientist.substack.com/))
+- **연구 디스커버리** — [Hugging Face Papers](https://huggingface.co/papers/2608.04205) 선정([Daily Papers, 2026-08-10](https://huggingface.co/papers/date/2026-08-10))
+- **미디어** — [36Kr](https://www.36kr.com/p/3932853833759876) · [Numerama](https://www.numerama.com/tech/2308727-ces-chercheurs-ont-cree-83-milliards-dhumains-virtuels-pour-tester-des-produits-a-notre-place.html) · [Infobae](https://www.infobae.com/tecno/2026/08/10/asi-prueba-la-ia-un-mundo-con-8300-millones-de-personas-digitales-matraix-es-el-metaverso/) · [AI타임스](https://www.aitimes.com/news/articleView.html?idxno=213824) · [Startup Fortune](https://startupfortune.com/harvard-and-mit-built-an-ai-model-of-83-billion-people-to-test-products-on/) · [Forbes Türkiye](https://www.forbes.com.tr/saglik/hastaya-dokunmadan-once-8-3-milyar-kez-denemek-sagligin-yeni-test-dunyasi-matraix) · [WIRED Czech](https://www.wired.cz/news-beat/harvard-a-mit-vytvorily-ai-simulaci-obsahujici-83-miliardy-virtualnich-lidi)
+- **산업 코멘터리** — Cisco VP & CTO [Gianpaolo Barozzi](https://lnkd.in/p/gE9cV2nw)가 언급
+- **소셜** — [X Trending Story](https://x.com/i/trending/2086626337561911419)에 선정
+
+## 릴리스
+
+- **[2026-08-04]** arXiv 기술 보고서: [MatrAIx: Simulating the World with 8.3 Billion Persona Agents](https://arxiv.org/abs/2608.04205) (`2608.04205`).
 - **[2026-08-01]** Hugging Face에 [Persona 1M](https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release) 공개(약 100만 품질 필터 페르소나).
 - **[2026-07-31]** Playground와 태스크 라이브러리 오픈소스: [MatrAIx-Persona-8B](https://github.com/MatrAIx-ai/MatrAIx-Persona-8B).
 - **[2026-07-29]** 포지션 노트: [From Personas to Simulated Users](https://matraix.ai/research/survey-from-personas-to-simulated-users.html).

--- a/docs/i18n/README.pt-BR.md
+++ b/docs/i18n/README.pt-BR.md
@@ -58,11 +58,17 @@ O nome remete a *The Matrix*: um mundo simulado útil para exploração, testes 
 estresse e geração de hipóteses — **não um substituto para evidências de pessoas
 reais**.
 
-## Novidades
+## Novidades & reconhecimento
 
-- **[2026-08-11]** Comentário acadêmico: [*Can we simulate the world?*](https://aiscientist.substack.com/p/can-we-simulate-the-world) por Mayank Kejriwal ([*AI Scientist*](https://aiscientist.substack.com/)).
-- **[2026-08-10]** Destaque como [X Trending Story](https://x.com/i/trending/2086626337561911419): *Harvard and MIT Unveil MatrAIx with 8.3 Billion Virtual Personas*. Também coberto pela mídia de tecnologia, incluindo [36Kr](https://eu.36kr.com/en/p/3932853833759876), [Numerama](https://www.numerama.com/tech/2308727-ces-chercheurs-ont-cree-83-milliards-dhumains-virtuels-pour-tester-des-produits-a-notre-place.html), [Infobae](https://www.infobae.com/tecno/2026/08/10/asi-prueba-la-ia-un-mundo-con-8300-millones-de-personas-digitales-matraix-es-el-metaverso/), [AI타임스](https://www.aitimes.com/news/articleView.html?idxno=213824), [CryptoBriefing](https://cryptobriefing.com/matraix-simulation-harvard-mit-ai-personas/) e [Startup Fortune](https://startupfortune.com/harvard-and-mit-built-an-ai-model-of-83-billion-people-to-test-products-on/), entre outros. Também discutido pelo VP e CTO da Cisco [Gianpaolo Barozzi](https://lnkd.in/p/gE9cV2nw).
-- **[2026-08-04]** Relatório técnico no arXiv: [MatrAIx: Simulating the World with 8.3 Billion Persona Agents](https://arxiv.org/abs/2608.04205) (`2608.04205`). Também em destaque no [Hugging Face Daily Papers](https://huggingface.co/papers/date/2026-08-10) ([página do paper](https://huggingface.co/papers/2608.04205)).
+- **Comentário acadêmico** — [*Can We Simulate the World?*](https://aiscientist.substack.com/p/can-we-simulate-the-world) — Mayank Kejriwal ([*AI Scientist*](https://aiscientist.substack.com/))
+- **Descoberta em pesquisa** — Destaque no [Hugging Face Papers](https://huggingface.co/papers/2608.04205) ([Daily Papers, 2026-08-10](https://huggingface.co/papers/date/2026-08-10))
+- **Mídia** — [36Kr](https://www.36kr.com/p/3932853833759876) · [Numerama](https://www.numerama.com/tech/2308727-ces-chercheurs-ont-cree-83-milliards-dhumains-virtuels-pour-tester-des-produits-a-notre-place.html) · [Infobae](https://www.infobae.com/tecno/2026/08/10/asi-prueba-la-ia-un-mundo-con-8300-millones-de-personas-digitales-matraix-es-el-metaverso/) · [AI타임스](https://www.aitimes.com/news/articleView.html?idxno=213824) · [Startup Fortune](https://startupfortune.com/harvard-and-mit-built-an-ai-model-of-83-billion-people-to-test-products-on/) · [Forbes Türkiye](https://www.forbes.com.tr/saglik/hastaya-dokunmadan-once-8-3-milyar-kez-denemek-sagligin-yeni-test-dunyasi-matraix) · [WIRED Czech](https://www.wired.cz/news-beat/harvard-a-mit-vytvorily-ai-simulaci-obsahujici-83-miliardy-virtualnich-lidi)
+- **Comentário da indústria** — Discutido pelo VP e CTO da Cisco [Gianpaolo Barozzi](https://lnkd.in/p/gE9cV2nw)
+- **Social** — Destaque como [X Trending Story](https://x.com/i/trending/2086626337561911419)
+
+## Lançamentos
+
+- **[2026-08-04]** Relatório técnico no arXiv: [MatrAIx: Simulating the World with 8.3 Billion Persona Agents](https://arxiv.org/abs/2608.04205) (`2608.04205`).
 - **[2026-08-01]** Publicado o [Persona 1M](https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release) no Hugging Face (~1M personas filtradas por qualidade).
 - **[2026-07-31]** Playground e biblioteca de tarefas em código aberto: [MatrAIx-Persona-8B](https://github.com/MatrAIx-ai/MatrAIx-Persona-8B).
 - **[2026-07-29]** Nota de posição: [From Personas to Simulated Users](https://matraix.ai/research/survey-from-personas-to-simulated-users.html).

--- a/docs/i18n/README.zh-CN.md
+++ b/docs/i18n/README.zh-CN.md
@@ -45,11 +45,17 @@
 
 名称致敬 *The Matrix*：这是一个便于探索、压力测试与假设生成的模拟世界，**不能替代来自真实人群的证据**。
 
-## 动态
+## 动态与认可
 
-- **[2026-08-11]** 学术评论：Mayank Kejriwal（[*AI Scientist*](https://aiscientist.substack.com/)）撰写 [*Can we simulate the world?*](https://aiscientist.substack.com/p/can-we-simulate-the-world)。
-- **[2026-08-10]** 登上 [X Trending Story](https://x.com/i/trending/2086626337561911419)：*Harvard and MIT Unveil MatrAIx with 8.3 Billion Virtual Personas*。科技媒体亦有报道，包括 [36氪](https://www.36kr.com/p/3932853833759876)（[英文版](https://eu.36kr.com/en/p/3932853833759876)）、[Numerama](https://www.numerama.com/tech/2308727-ces-chercheurs-ont-cree-83-milliards-dhumains-virtuels-pour-tester-des-produits-a-notre-place.html)、[Infobae](https://www.infobae.com/tecno/2026/08/10/asi-prueba-la-ia-un-mundo-con-8300-millones-de-personas-digitales-matraix-es-el-metaverso/)、[AI타임스](https://www.aitimes.com/news/articleView.html?idxno=213824)、[CryptoBriefing](https://cryptobriefing.com/matraix-simulation-harvard-mit-ai-personas/)、[Startup Fortune](https://startupfortune.com/harvard-and-mit-built-an-ai-model-of-83-billion-people-to-test-products-on/) 等。亦有 Cisco VP & CTO [Gianpaolo Barozzi](https://lnkd.in/p/gE9cV2nw) 的讨论。
-- **[2026-08-04]** 技术报告发布于 arXiv：[MatrAIx: Simulating the World with 8.3 Billion Persona Agents](https://arxiv.org/abs/2608.04205)（`2608.04205`）。亦登上 [Hugging Face Daily Papers](https://huggingface.co/papers/date/2026-08-10)（[论文页](https://huggingface.co/papers/2608.04205)）。
+- **学术评论** — [*Can We Simulate the World?*](https://aiscientist.substack.com/p/can-we-simulate-the-world) — Mayank Kejriwal，[*AI Scientist*](https://aiscientist.substack.com/)
+- **研究发现** — 登上 [Hugging Face Papers](https://huggingface.co/papers/2608.04205)（[Daily Papers, 2026-08-10](https://huggingface.co/papers/date/2026-08-10)）
+- **媒体** — [36氪](https://www.36kr.com/p/3932853833759876) · [Numerama](https://www.numerama.com/tech/2308727-ces-chercheurs-ont-cree-83-milliards-dhumains-virtuels-pour-tester-des-produits-a-notre-place.html) · [Infobae](https://www.infobae.com/tecno/2026/08/10/asi-prueba-la-ia-un-mundo-con-8300-millones-de-personas-digitales-matraix-es-el-metaverso/) · [AI타임스](https://www.aitimes.com/news/articleView.html?idxno=213824) · [Startup Fortune](https://startupfortune.com/harvard-and-mit-built-an-ai-model-of-83-billion-people-to-test-products-on/) · [Forbes Türkiye](https://www.forbes.com.tr/saglik/hastaya-dokunmadan-once-8-3-milyar-kez-denemek-sagligin-yeni-test-dunyasi-matraix) · [WIRED Czech](https://www.wired.cz/news-beat/harvard-a-mit-vytvorily-ai-simulaci-obsahujici-83-miliardy-virtualnich-lidi)
+- **产业评论** — Cisco VP & CTO [Gianpaolo Barozzi](https://lnkd.in/p/gE9cV2nw) 有讨论
+- **社交** — 登上 [X Trending Story](https://x.com/i/trending/2086626337561911419)
+
+## 发布
+
+- **[2026-08-04]** 技术报告发布于 arXiv：[MatrAIx: Simulating the World with 8.3 Billion Persona Agents](https://arxiv.org/abs/2608.04205)（`2608.04205`）。
 - **[2026-08-01]** 在 Hugging Face 发布 [Persona 1M](https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release)（约 100 万条经质量过滤的人格）。
 - **[2026-07-31]** 开源 Playground 与任务库：[MatrAIx-Persona-8B](https://github.com/MatrAIx-ai/MatrAIx-Persona-8B)。
 - **[2026-07-29]** 立场短文：[From Personas to Simulated Users](https://matraix.ai/research/survey-from-personas-to-simulated-users.html)。

--- a/docs/i18n/README.zh-TW.md
+++ b/docs/i18n/README.zh-TW.md
@@ -45,11 +45,17 @@
 
 名稱致敬 *The Matrix*：這是一個便於探索、壓力測試與假設生成的模擬世界，**不能取代來自真實人群的證據**。
 
-## 動態
+## 動態與認可
 
-- **[2026-08-11]** 學術評論：Mayank Kejriwal（[*AI Scientist*](https://aiscientist.substack.com/)）撰寫 [*Can we simulate the world?*](https://aiscientist.substack.com/p/can-we-simulate-the-world)。
-- **[2026-08-10]** 登上 [X Trending Story](https://x.com/i/trending/2086626337561911419)：*Harvard and MIT Unveil MatrAIx with 8.3 Billion Virtual Personas*。科技媒體亦有報導，包括 [36氪](https://www.36kr.com/p/3932853833759876)（[英文版](https://eu.36kr.com/en/p/3932853833759876)）、[Numerama](https://www.numerama.com/tech/2308727-ces-chercheurs-ont-cree-83-milliards-dhumains-virtuels-pour-tester-des-produits-a-notre-place.html)、[Infobae](https://www.infobae.com/tecno/2026/08/10/asi-prueba-la-ia-un-mundo-con-8300-millones-de-personas-digitales-matraix-es-el-metaverso/)、[AI타임스](https://www.aitimes.com/news/articleView.html?idxno=213824)、[CryptoBriefing](https://cryptobriefing.com/matraix-simulation-harvard-mit-ai-personas/)、[Startup Fortune](https://startupfortune.com/harvard-and-mit-built-an-ai-model-of-83-billion-people-to-test-products-on/) 等。亦有 Cisco VP & CTO [Gianpaolo Barozzi](https://lnkd.in/p/gE9cV2nw) 的討論。
-- **[2026-08-04]** 技術報告發布於 arXiv：[MatrAIx: Simulating the World with 8.3 Billion Persona Agents](https://arxiv.org/abs/2608.04205)（`2608.04205`）。亦登上 [Hugging Face Daily Papers](https://huggingface.co/papers/date/2026-08-10)（[論文頁](https://huggingface.co/papers/2608.04205)）。
+- **學術評論** — [*Can We Simulate the World?*](https://aiscientist.substack.com/p/can-we-simulate-the-world) — Mayank Kejriwal，[*AI Scientist*](https://aiscientist.substack.com/)
+- **研究發現** — 登上 [Hugging Face Papers](https://huggingface.co/papers/2608.04205)（[Daily Papers, 2026-08-10](https://huggingface.co/papers/date/2026-08-10)）
+- **媒體** — [36氪](https://www.36kr.com/p/3932853833759876) · [Numerama](https://www.numerama.com/tech/2308727-ces-chercheurs-ont-cree-83-milliards-dhumains-virtuels-pour-tester-des-produits-a-notre-place.html) · [Infobae](https://www.infobae.com/tecno/2026/08/10/asi-prueba-la-ia-un-mundo-con-8300-millones-de-personas-digitales-matraix-es-el-metaverso/) · [AI타임스](https://www.aitimes.com/news/articleView.html?idxno=213824) · [Startup Fortune](https://startupfortune.com/harvard-and-mit-built-an-ai-model-of-83-billion-people-to-test-products-on/) · [Forbes Türkiye](https://www.forbes.com.tr/saglik/hastaya-dokunmadan-once-8-3-milyar-kez-denemek-sagligin-yeni-test-dunyasi-matraix) · [WIRED Czech](https://www.wired.cz/news-beat/harvard-a-mit-vytvorily-ai-simulaci-obsahujici-83-miliardy-virtualnich-lidi)
+- **產業評論** — Cisco VP & CTO [Gianpaolo Barozzi](https://lnkd.in/p/gE9cV2nw) 有討論
+- **社交** — 登上 [X Trending Story](https://x.com/i/trending/2086626337561911419)
+
+## 發布
+
+- **[2026-08-04]** 技術報告發布於 arXiv：[MatrAIx: Simulating the World with 8.3 Billion Persona Agents](https://arxiv.org/abs/2608.04205)（`2608.04205`）。
 - **[2026-08-01]** 在 Hugging Face 發布 [Persona 1M](https://huggingface.co/datasets/MatrAIx2026/MatrAIx_Persona_1M_Public_Release)（約 100 萬條經品質過濾的人格）。
 - **[2026-07-31]** 開源 Playground 與任務庫：[MatrAIx-Persona-8B](https://github.com/MatrAIx-ai/MatrAIx-Persona-8B)。
 - **[2026-07-29]** 立場短文：[From Personas to Simulated Users](https://matraix.ai/research/survey-from-personas-to-simulated-users.html)。


### PR DESCRIPTION
## Summary
- Split the flat README `News` list into **News & Recognition** (academic, HF Papers, curated media, industry, social) and **Releases** (arXiv / Persona 1M / open source / position note).
- Curate media outlets (add Forbes Türkiye + WIRED Czech; drop CryptoBriefing + The Agent Times).
- Mirror the same structure and outlet list across all `docs/i18n` READMEs.

## Test plan
- [ ] Preview English README News & Recognition + Releases on GitHub
- [ ] Spot-check one i18n README (e.g. zh-CN) for matching structure and links
- [ ] Confirm no CryptoBriefing / The Agent Times links remain in README*.md


Made with [Cursor](https://cursor.com)