### PR TITLE
fix(playground): support current MCP streamable HTTP client

### DIFF
--- a/application/playground/backend/tests/test_harbor_chat_mcp_session.py
+++ b/application/playground/backend/tests/test_harbor_chat_mcp_session.py
@@ -13,9 +13,18 @@ from playground.chatbot_task_config import ChatbotTaskConfig
 from playground.harbor.chat_eval import create_harbor_chat_session
 from playground.harbor.chat_mcp_session import (
     HarborMcpChatSession,
+    _MCP_CALL_SCRIPT,
     harbor_chat_mcp_url_from_task_path,
 )
 from playground.types import PlaygroundConfig
+
+
+def test_mcp_call_script_uses_current_streamable_http_client_name() -> None:
+    assert "streamable_http_client" in _MCP_CALL_SCRIPT
+    assert "streamablehttp_client" not in _MCP_CALL_SCRIPT
+    assert "as (read, write):" in _MCP_CALL_SCRIPT
+    assert "as (read, write, _):" not in _MCP_CALL_SCRIPT
+    assert 'getattr(result, "is_error"' in _MCP_CALL_SCRIPT
 
 
 def test_harbor_chat_mcp_url_from_task_path_reads_task_toml(tmp_path: Path) -> None:

--- a/packages/playground/src/playground/harbor/chat_mcp_session.py
+++ b/packages/playground/src/playground/harbor/chat_mcp_session.py
@@ -27,12 +27,12 @@ _MCP_CALL_SCRIPT = textwrap.dedent(
 
     async def main() -> None:
         from mcp.client.session import ClientSession
-        from mcp.client.streamable_http import streamablehttp_client
+        from mcp.client.streamable_http import streamable_http_client
 
         mcp_url = sys.argv[1]
         tool_name = sys.argv[2]
         arguments = json.loads(sys.argv[3])
-        async with streamablehttp_client(mcp_url) as (read, write, _):
+        async with streamable_http_client(mcp_url) as (read, write):
             async with ClientSession(read, write) as session:
                 await session.initialize()
                 result = await session.call_tool(tool_name, arguments)
@@ -43,7 +43,9 @@ _MCP_CALL_SCRIPT = textwrap.dedent(
                         chunks.append(text)
                 payload = {
                     "text": "".join(chunks),
-                    "isError": bool(getattr(result, "isError", False)),
+                    "isError": bool(
+                        getattr(result, "is_error", getattr(result, "isError", False))
+                    ),
                 }
                 print(json.dumps(payload))
 


### PR DESCRIPTION
## Module

Select the owning module:

- [ ] `persona/`
- [ ] `application/`
- [ ] `environment/`
- [x] `packages/`
- [ ] `apps/`
- [ ] docs or migration metadata only

## Summary

Update the Playground MCP chat client for compatibility with the current Python MCP SDK.

- Import `streamable_http_client` using its current public name.
- Unpack the two streams returned by its async context manager.
- Read the current `CallToolResult.is_error` attribute while retaining compatibility with the legacy `isError` spelling.
- Add a regression test covering the generated MCP tool-call script.

This fixes failures such as:

- `ImportError: cannot import name 'streamablehttp_client'`
- `ValueError: not enough values to unpack (expected 3, got 2)`

## Validation

Commands run:

```bash
PYTHONPATH=packages/playground/src:application/playground \
  uv run --with pytest pytest \
  application/playground/backend/tests/test_harbor_chat_mcp_session.py \
  application/playground/backend/tests/test_harbor_chat_eval.py -q
```

Result: `12 passed`.

## Data Policy

- [x] No large generated outputs or raw dumps were added.
- [x] Any fixtures are small and necessary for tests or docs.
