### PR TITLE
fix(playground): pin MCP client SDK and make the sidecar client testable

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -63,6 +63,7 @@ jobs:
             application/playground/backend/tests/test_harbor_survey_eval.py \
             application/playground/backend/tests/test_harbor_web_trace.py \
             application/playground/backend/tests/test_job_aggregation.py \
+            application/playground/backend/tests/test_mcp_client_contract.py \
             application/playground/backend/tests/test_persona_1m_index.py \
             application/playground/backend/tests/test_persona_1m_pool.py \
             application/playground/backend/tests/test_persona_pool_service.py \

--- a/application/playground/backend/tests/test_harbor_chat_mcp_session.py
+++ b/application/playground/backend/tests/test_harbor_chat_mcp_session.py
@@ -33,16 +33,16 @@ def test_payload_from_result_joins_text_blocks() -> None:
     assert payload_from_result(result) == {"text": "Hello there", "isError": False}
 
 
-def test_payload_from_result_reads_current_is_error_attribute() -> None:
+def test_payload_from_result_reports_tool_errors() -> None:
     result = SimpleNamespace(content=[SimpleNamespace(text="boom")], is_error=True)
 
     assert payload_from_result(result)["isError"] is True
 
 
-def test_payload_from_result_falls_back_to_legacy_is_error_spelling() -> None:
-    result = SimpleNamespace(content=[SimpleNamespace(text="boom")], isError=True)
+def test_payload_from_result_defaults_to_success_without_an_error_flag() -> None:
+    result = SimpleNamespace(content=[SimpleNamespace(text="ok")])
 
-    assert payload_from_result(result)["isError"] is True
+    assert payload_from_result(result) == {"text": "ok", "isError": False}
 
 
 def test_payload_from_result_handles_empty_content() -> None:

--- a/application/playground/backend/tests/test_harbor_chat_mcp_session.py
+++ b/application/playground/backend/tests/test_harbor_chat_mcp_session.py
@@ -12,19 +12,44 @@ import playground.harbor.chat_eval as chat_eval_module
 from playground.chatbot_task_config import ChatbotTaskConfig
 from playground.harbor.chat_eval import create_harbor_chat_session
 from playground.harbor.chat_mcp_session import (
+    MCP_CLIENT_REQUIREMENT,
     HarborMcpChatSession,
-    _MCP_CALL_SCRIPT,
     harbor_chat_mcp_url_from_task_path,
 )
+from playground.harbor.mcp_call_client import payload_from_result
 from playground.types import PlaygroundConfig
 
 
-def test_mcp_call_script_uses_current_streamable_http_client_name() -> None:
-    assert "streamable_http_client" in _MCP_CALL_SCRIPT
-    assert "streamablehttp_client" not in _MCP_CALL_SCRIPT
-    assert "as (read, write):" in _MCP_CALL_SCRIPT
-    assert "as (read, write, _):" not in _MCP_CALL_SCRIPT
-    assert 'getattr(result, "is_error"' in _MCP_CALL_SCRIPT
+def test_payload_from_result_joins_text_blocks() -> None:
+    result = SimpleNamespace(
+        content=[
+            SimpleNamespace(text="Hello "),
+            SimpleNamespace(text="there"),
+            SimpleNamespace(data=b"ignored"),
+        ],
+        is_error=False,
+    )
+
+    assert payload_from_result(result) == {"text": "Hello there", "isError": False}
+
+
+def test_payload_from_result_reads_current_is_error_attribute() -> None:
+    result = SimpleNamespace(content=[SimpleNamespace(text="boom")], is_error=True)
+
+    assert payload_from_result(result)["isError"] is True
+
+
+def test_payload_from_result_falls_back_to_legacy_is_error_spelling() -> None:
+    result = SimpleNamespace(content=[SimpleNamespace(text="boom")], isError=True)
+
+    assert payload_from_result(result)["isError"] is True
+
+
+def test_payload_from_result_handles_empty_content() -> None:
+    assert payload_from_result(SimpleNamespace(content=None)) == {
+        "text": "",
+        "isError": False,
+    }
 
 
 def test_harbor_chat_mcp_url_from_task_path_reads_task_toml(tmp_path: Path) -> None:
@@ -157,11 +182,17 @@ async def test_harbor_mcp_chat_session_calls_tools_via_environment_exec(
     tmp_path: Path,
 ) -> None:
     calls: list[tuple[str, dict[str, str]]] = []
+    uploads: list[tuple[str, str]] = []
 
     class FakeEnvironment:
+        async def upload_file(self, source_path, target_path: str) -> None:
+            uploads.append((Path(source_path).name, target_path))
+
         async def exec(self, command: str, timeout_sec: int = 200):
             del timeout_sec
-            assert "uvx --with mcp python3 -c" in command
+            assert "uvx --with {}".format(MCP_CLIENT_REQUIREMENT) in command
+            assert "/tmp/matraix_mcp_call_client.py" in command
+            assert "python3 -c" not in command
             if "send_message" in command:
                 calls.append(("send_message", {"message": "Hello there"}))
                 payload = {"text": "Hi, how can I help?", "isError": False}
@@ -194,6 +225,7 @@ async def test_harbor_mcp_chat_session_calls_tools_via_environment_exec(
     assert transcript["turns"][0]["assistantMessage"] == "Hi, how can I help?"
     assert calls[0][0] == "send_message"
     assert calls[1][0] == "get_conversation_history"
+    assert uploads == [("mcp_call_client.py", "/tmp/matraix_mcp_call_client.py")]
 
 
 @pytest.mark.anyio

--- a/application/playground/backend/tests/test_harbor_chat_mcp_session.py
+++ b/application/playground/backend/tests/test_harbor_chat_mcp_session.py
@@ -13,9 +13,18 @@ from playground.chatbot_task_config import ChatbotTaskConfig
 from playground.harbor.chat_eval import create_harbor_chat_session
 from playground.harbor.chat_mcp_session import (
     HarborMcpChatSession,
+    _MCP_CALL_SCRIPT,
     harbor_chat_mcp_url_from_task_path,
 )
 from playground.types import PlaygroundConfig
+
+
+def test_mcp_call_script_uses_current_streamable_http_client_name() -> None:
+    assert "streamable_http_client" in _MCP_CALL_SCRIPT
+    assert "streamablehttp_client" not in _MCP_CALL_SCRIPT
+    assert "as (read, write):" in _MCP_CALL_SCRIPT
+    assert "as (read, write, _):" not in _MCP_CALL_SCRIPT
+    assert 'getattr(result, "is_error"' in _MCP_CALL_SCRIPT
 
 
 def test_harbor_chat_mcp_url_from_task_path_reads_task_toml(tmp_path: Path) -> None:

--- a/application/playground/backend/tests/test_mcp_client_contract.py
+++ b/application/playground/backend/tests/test_mcp_client_contract.py
@@ -1,0 +1,81 @@
+"""Contract test for the pinned ``mcp`` SDK used by the chat MCP sidecar client.
+
+The rest of the suite exercises ``mcp_call_client`` against stand-in objects, so
+it cannot catch the SDK moving a symbol or renaming a field. This one resolves
+``MCP_CLIENT_REQUIREMENT`` the same way the environment does and runs the client
+helper against a real ``CallToolResult``, which is what makes a version bump
+fail loudly instead of at trial time. It needs ``uvx`` and network access, and
+skips when ``uvx`` is unavailable.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from playground.harbor import mcp_call_client
+from playground.harbor.chat_mcp_session import MCP_CLIENT_REQUIREMENT
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("uvx") is None,
+    reason="uvx is required to resolve the pinned mcp SDK",
+)
+
+_PROBE = """
+import importlib.metadata
+import importlib.util
+import json
+import sys
+
+import mcp.types as types
+from mcp.client.session import ClientSession
+from mcp.client.streamable_http import streamable_http_client
+
+spec = importlib.util.spec_from_file_location("mcp_call_client", sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+result = types.CallToolResult(
+    content=[types.TextContent(type="text", text="hi")],
+    is_error=True,
+)
+print(
+    json.dumps(
+        {
+            "version": importlib.metadata.version("mcp"),
+            "session": ClientSession.__name__,
+            "transport": streamable_http_client.__name__,
+            "payload": module.payload_from_result(result),
+        }
+    )
+)
+"""
+
+
+def test_pinned_mcp_sdk_satisfies_the_sidecar_client_contract() -> None:
+    client_path = Path(mcp_call_client.__file__)
+    completed = subprocess.run(
+        [
+            "uvx",
+            "--with",
+            MCP_CLIENT_REQUIREMENT,
+            "python3",
+            "-c",
+            _PROBE,
+            str(client_path),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    probe = json.loads(completed.stdout.strip().splitlines()[-1])
+    assert probe["version"] == MCP_CLIENT_REQUIREMENT.split("==", 1)[1]
+    assert probe["session"] == "ClientSession"
+    assert probe["transport"] == "streamable_http_client"
+    assert probe["payload"] == {"text": "hi", "isError": True}

--- a/packages/playground/src/playground/harbor/chat_mcp_session.py
+++ b/packages/playground/src/playground/harbor/chat_mcp_session.py
@@ -18,9 +18,8 @@ from playground.types import PlaygroundConfig
 if TYPE_CHECKING:
     from harbor.environments.base import BaseEnvironment
 
-# Pinned so a trial's MCP behavior is reproducible: the client API is part of
-# the evaluation contract, not something to inherit from whatever PyPI serves
-# today. Bump deliberately, with the client tests as the gate.
+# The client API is part of the evaluation contract: an unpinned resolve lets
+# identical trials behave differently across machines and dates.
 MCP_CLIENT_REQUIREMENT = "mcp==2.0.0"
 
 _LOCAL_CLIENT_PATH = Path(__file__).with_name("mcp_call_client.py")

--- a/packages/playground/src/playground/harbor/chat_mcp_session.py
+++ b/packages/playground/src/playground/harbor/chat_mcp_session.py
@@ -27,12 +27,12 @@ _MCP_CALL_SCRIPT = textwrap.dedent(
 
     async def main() -> None:
         from mcp.client.session import ClientSession
-        from mcp.client.streamable_http import streamablehttp_client
+        from mcp.client.streamable_http import streamable_http_client
 
         mcp_url = sys.argv[1]
         tool_name = sys.argv[2]
         arguments = json.loads(sys.argv[3])
-        async with streamablehttp_client(mcp_url) as (read, write, _):
+        async with streamable_http_client(mcp_url) as (read, write):
             async with ClientSession(read, write) as session:
                 await session.initialize()
                 result = await session.call_tool(tool_name, arguments)
@@ -43,7 +43,9 @@ _MCP_CALL_SCRIPT = textwrap.dedent(
                         chunks.append(text)
                 payload = {
                     "text": "".join(chunks),
-                    "isError": bool(getattr(result, "isError", False)),
+                    "isError": bool(
+                        getattr(result, "is_error", getattr(result, "isError", False))
+                    ),
                 }
                 print(json.dumps(payload))
 

--- a/packages/playground/src/playground/harbor/chat_mcp_session.py
+++ b/packages/playground/src/playground/harbor/chat_mcp_session.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import json
 import shlex
-import textwrap
 import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List
@@ -19,39 +18,13 @@ from playground.types import PlaygroundConfig
 if TYPE_CHECKING:
     from harbor.environments.base import BaseEnvironment
 
-_MCP_CALL_SCRIPT = textwrap.dedent(
-    """
-    import asyncio
-    import json
-    import sys
+# Pinned so a trial's MCP behavior is reproducible: the client API is part of
+# the evaluation contract, not something to inherit from whatever PyPI serves
+# today. Bump deliberately, with the client tests as the gate.
+MCP_CLIENT_REQUIREMENT = "mcp==2.0.0"
 
-    async def main() -> None:
-        from mcp.client.session import ClientSession
-        from mcp.client.streamable_http import streamable_http_client
-
-        mcp_url = sys.argv[1]
-        tool_name = sys.argv[2]
-        arguments = json.loads(sys.argv[3])
-        async with streamable_http_client(mcp_url) as (read, write):
-            async with ClientSession(read, write) as session:
-                await session.initialize()
-                result = await session.call_tool(tool_name, arguments)
-                chunks = []
-                for block in result.content or []:
-                    text = getattr(block, "text", None)
-                    if text:
-                        chunks.append(text)
-                payload = {
-                    "text": "".join(chunks),
-                    "isError": bool(
-                        getattr(result, "is_error", getattr(result, "isError", False))
-                    ),
-                }
-                print(json.dumps(payload))
-
-    asyncio.run(main())
-    """
-).strip()
+_LOCAL_CLIENT_PATH = Path(__file__).with_name("mcp_call_client.py")
+_REMOTE_CLIENT_PATH = "/tmp/matraix_mcp_call_client.py"
 
 
 def harbor_chat_mcp_url_from_task_path(task_path: str, *, repo_root: Path) -> str | None:
@@ -73,7 +46,7 @@ def harbor_chat_mcp_url_from_task_path(task_path: str, *, repo_root: Path) -> st
 
 
 class HarborMcpChatSession:
-    """Drive an MCP chat sidecar via ``environment.exec`` + ``uvx --with mcp``."""
+    """Drive an MCP chat sidecar via ``environment.exec`` + a pinned ``mcp`` client."""
 
     def __init__(
         self,
@@ -92,7 +65,14 @@ class HarborMcpChatSession:
         self._send_message_tool = send_message_tool
         self._history_tool = history_tool
         self._session_id = "mcp-{}".format(uuid.uuid4().hex[:12])
+        self._client_uploaded = False
         self.turns: List[Dict[str, Any]] = []
+
+    async def _ensure_client_uploaded(self) -> None:
+        if self._client_uploaded:
+            return
+        await self._environment.upload_file(_LOCAL_CLIENT_PATH, _REMOTE_CLIENT_PATH)
+        self._client_uploaded = True
 
     async def _call_tool(
         self,
@@ -101,8 +81,10 @@ class HarborMcpChatSession:
         *,
         timeout_sec: int = 200,
     ) -> Dict[str, Any]:
-        command = "uvx --with mcp python3 -c {} {} {} {}".format(
-            shlex.quote(_MCP_CALL_SCRIPT),
+        await self._ensure_client_uploaded()
+        command = "uvx --with {} python3 {} {} {} {}".format(
+            shlex.quote(MCP_CLIENT_REQUIREMENT),
+            shlex.quote(_REMOTE_CLIENT_PATH),
             shlex.quote(self._mcp_url),
             shlex.quote(tool_name),
             shlex.quote(json.dumps(arguments, ensure_ascii=False)),

--- a/packages/playground/src/playground/harbor/mcp_call_client.py
+++ b/packages/playground/src/playground/harbor/mcp_call_client.py
@@ -20,10 +20,8 @@ def payload_from_result(result: Any) -> Dict[str, Any]:
         text = getattr(block, "text", None)
         if text:
             chunks.append(str(text))
-    is_error = getattr(result, "is_error", None)
-    if is_error is None:
-        is_error = getattr(result, "isError", False)
-    return {"text": "".join(chunks), "isError": bool(is_error)}
+    # Result types other than CallToolResult carry no error flag.
+    return {"text": "".join(chunks), "isError": bool(getattr(result, "is_error", False))}
 
 
 async def call_tool(

--- a/packages/playground/src/playground/harbor/mcp_call_client.py
+++ b/packages/playground/src/playground/harbor/mcp_call_client.py
@@ -1,8 +1,8 @@
 """Single MCP tool call, executed inside the Harbor environment.
 
-This module is uploaded into the environment and run against a pinned ``mcp``
-release (see ``MCP_CLIENT_REQUIREMENT``). ``mcp`` is imported lazily so the host
-test suite can exercise the payload helpers without installing the SDK.
+Uploaded into the environment and run against the ``mcp`` release pinned in
+``chat_mcp_session.MCP_CLIENT_REQUIREMENT``. ``mcp`` is imported lazily because
+this module must also import on hosts that do not have the SDK installed.
 """
 
 from __future__ import annotations

--- a/packages/playground/src/playground/harbor/mcp_call_client.py
+++ b/packages/playground/src/playground/harbor/mcp_call_client.py
@@ -1,0 +1,54 @@
+"""Single MCP tool call, executed inside the Harbor environment.
+
+This module is uploaded into the environment and run against a pinned ``mcp``
+release (see ``MCP_CLIENT_REQUIREMENT``). ``mcp`` is imported lazily so the host
+test suite can exercise the payload helpers without installing the SDK.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from typing import Any, Dict
+
+
+def payload_from_result(result: Any) -> Dict[str, Any]:
+    """Flatten an MCP ``CallToolResult`` into the sidecar stdout contract."""
+    chunks: list[str] = []
+    for block in getattr(result, "content", None) or []:
+        text = getattr(block, "text", None)
+        if text:
+            chunks.append(str(text))
+    is_error = getattr(result, "is_error", None)
+    if is_error is None:
+        is_error = getattr(result, "isError", False)
+    return {"text": "".join(chunks), "isError": bool(is_error)}
+
+
+async def call_tool(
+    mcp_url: str,
+    tool_name: str,
+    arguments: Dict[str, Any],
+) -> Dict[str, Any]:
+    from mcp.client.session import ClientSession
+    from mcp.client.streamable_http import streamable_http_client
+
+    async with streamable_http_client(mcp_url) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            result = await session.call_tool(tool_name, arguments)
+            return payload_from_result(result)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 4:
+        print("usage: mcp_call_client.py MCP_URL TOOL_NAME JSON_ARGUMENTS", file=sys.stderr)
+        return 2
+    payload = asyncio.run(call_tool(argv[1], argv[2], json.loads(argv[3])))
+    print(json.dumps(payload))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Credit

The breakage here was found and correctly diagnosed by @Burni3 in #90 — thank you. That commit is included in this branch, so the API correction is attributed in history and will carry a `Co-authored-by` trailer on squash merge. This PR keeps that fix and addresses the reason the breakage was possible in the first place, which makes #90 redundant once this lands.

## Why

The MCP tool-call client was a Python source string (`_MCP_CALL_SCRIPT`) inside `chat_mcp_session.py`, executed as `uvx --with mcp python3 -c "<string>"`. Two consequences:

- **Unpinned**: every trial resolved whatever `mcp` release PyPI served that day. When the SDK renamed `streamablehttp_client` → `streamable_http_client` and dropped the third yielded value, MCP chat evals broke on machines that happened to install the new release — same task, same commit, different result depending on the day.
- **Untestable**: because the client only existed as a string, the only way to check it was grepping its own source text (`assert "streamable_http_client" in _MCP_CALL_SCRIPT`). That kind of test restates the code; it cannot catch a wrong result shape.

## What

- Pin `MCP_CLIENT_REQUIREMENT = "mcp==2.0.0"`. The client API is part of the evaluation contract, so identical trials no longer depend on the resolve date.
- Move the client into `packages/playground/src/playground/harbor/mcp_call_client.py` and upload it into the environment (once per session) instead of shipping source through the shell. `mcp` is imported lazily so the module stays importable on hosts without the SDK.
- Cover result flattening with behavior tests, and add `test_mcp_client_contract.py`, which resolves the pin the way the environment does and runs `payload_from_result` against a real `CallToolResult`. This is what makes a bump fail in CI rather than at trial time — verified by pointing the same probe at `mcp==1.9.0`, which fails with the original `ImportError`.

## Test plan

- `uvx ruff@0.15.20 check .` — clean.
- CI's curated pytest suite locally (contract test included): 1495 passed, 6 skipped.
- Contract test discrimination: the probe passes on `mcp==2.0.0` and fails on `mcp==1.9.0` with `ImportError: cannot import name 'streamable_http_client'`.
- Live sidecar path: `uvx --with 'mcp==2.0.0' python3 .../mcp_call_client.py http://127.0.0.1:9/mcp send_message '{"message":"hi"}'` reaches the HTTP layer and fails with `ConnectError`, so imports, context manager, and tuple unpacking are all valid under the pin.

## Follow-ups (not in this PR)

- Record the resolved `mcp` version in trial artifacts; this touches the artifact schema that verifiers read, so it deserves its own change.
- Reuse one `ClientSession` per conversation instead of a fresh `uvx` process per tool call.
- Replace the substring-based transient-error detection in `_call_tool` with a structured signal from the client.