### PR TITLE
fix(playground): tolerate scalar chatbot turn metadata

### DIFF
--- a/application/playground/backend/tests/test_harbor_chat_eval.py
+++ b/application/playground/backend/tests/test_harbor_chat_eval.py
@@ -11,6 +11,7 @@ import pytest
 import playground.harbor.chat_eval as chat_eval_module
 from playground.harbor.chat_eval import (
     ChatbotTaskConfig,
+    _normalize_turn_view,
     harbor_chat_config_from_env,
     harbor_output_artifacts_from_result,
     run_harbor_chat_eval_for_persona,
@@ -142,6 +143,33 @@ def test_parse_json_stdout_skips_shell_profile_noise():
     parsed = parse_json_stdout(raw)
     assert parsed["sessionId"] == "abc"
     assert parsed["reply"] == "hi"
+
+
+def test_normalize_turn_view_accepts_scalar_turn_counter():
+    view = _normalize_turn_view(
+        {"sessionId": "sess-1", "reply": "Your order is in transit.", "turn": 1},
+        "Where is order #4521?",
+        ChatbotTaskConfig(),
+    )
+
+    assert view == {
+        "assistantMessage": "Your order is in transit.",
+        "userMessage": "Where is order #4521?",
+        "structuredExposure": [],
+    }
+
+
+def test_normalize_turn_view_prefers_structured_turn_reply():
+    view = _normalize_turn_view(
+        {
+            "reply": "top-level fallback",
+            "turn": {"index": 1, "assistantReply": "structured reply"},
+        },
+        "Hello",
+        ChatbotTaskConfig(),
+    )
+
+    assert view["assistantMessage"] == "structured reply"
 
 
 def test_harbor_chat_config_from_env_defaults_to_unlimited_turns(tmp_path, monkeypatch):

--- a/environment/task-environments/application/chatbot-api-sidecar_acme-support-api/support-api/server.py
+++ b/environment/task-environments/application/chatbot-api-sidecar_acme-support-api/support-api/server.py
@@ -111,7 +111,12 @@ def post_message():
         messages.append({"role": "support", "content": reply})
         snapshot = list(messages)
 
-    return jsonify({"sessionId": session_id, "reply": reply, "turn": len(snapshot) // 2})
+    turn = {
+        "index": len(snapshot) // 2,
+        "userMessage": customer_message,
+        "assistantReply": reply,
+    }
+    return jsonify({"sessionId": session_id, "reply": reply, "turn": turn})
 
 
 @app.get("/v1/conversation")

--- a/environment/task-environments/application/chatbot-api-sidecar_acme-support-api/support-api/test_server.py
+++ b/environment/task-environments/application/chatbot-api-sidecar_acme-support-api/support-api/test_server.py
@@ -1,0 +1,49 @@
+"""Contract tests for the Acme support REST sidecar."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("flask")
+
+import server  # noqa: E402
+
+
+def test_post_message_returns_structured_turn() -> None:
+    server._sessions.clear()
+    client = server.app.test_client()
+
+    response = client.post(
+        "/v1/messages",
+        json={"sessionId": "trial-a", "message": "Where is order #4521?"},
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["sessionId"] == "trial-a"
+    assert payload["reply"]
+    assert payload["turn"] == {
+        "index": 1,
+        "userMessage": "Where is order #4521?",
+        "assistantReply": payload["reply"],
+    }
+
+
+def test_sessions_remain_isolated() -> None:
+    server._sessions.clear()
+    client = server.app.test_client()
+    client.post(
+        "/v1/messages",
+        json={"sessionId": "trial-a", "message": "Order #4521 is late"},
+    )
+    client.post(
+        "/v1/messages",
+        json={"sessionId": "trial-b", "message": "Hello"},
+    )
+
+    first = client.get("/v1/conversation?sessionId=trial-a").get_json()
+    second = client.get("/v1/conversation?sessionId=trial-b").get_json()
+
+    assert len(first["messages"]) == 2
+    assert len(second["messages"]) == 2
+    assert first["messages"] != second["messages"]

--- a/packages/playground/src/playground/harbor/chat_eval.py
+++ b/packages/playground/src/playground/harbor/chat_eval.py
@@ -174,7 +174,11 @@ def _normalize_turn_view(
     runtime: ChatbotTaskConfig,
 ) -> Dict[str, Any]:
     protocol = runtime.protocol
-    turn = dict(response.get(protocol.response_turn_field) or {})
+    raw_turn = response.get(protocol.response_turn_field)
+    # Some chat APIs expose a scalar turn counter rather than a structured
+    # turn object. Keep using the top-level reply instead of failing while
+    # normalizing an otherwise valid response.
+    turn = dict(raw_turn) if isinstance(raw_turn, dict) else {}
     assistant = str(
         turn.get("assistantMessage")
         or turn.get("assistantReply")


### PR DESCRIPTION
## Module

Select the owning module:

- [ ] `persona/`
- [x] `application/`
- [ ] `environment/`
- [ ] `packages/`
- [ ] `apps/`
- [ ] docs or migration metadata only

## Summary

Harden HTTP chatbot response normalization and align the bundled Acme support sidecar with the structured turn contract.

- Treat scalar or missing `turn` metadata as optional and fall back to the top-level reply.
- Return a structured turn object from the Acme support REST sidecar.
- Add regression coverage for scalar and structured responses.
- Add sidecar contract coverage for structured turns and per-session isolation.

This prevents otherwise valid chatbot responses such as `{"reply": "...", "turn": 1}` from failing with `TypeError: 'int' object is not iterable`.

## Validation

Commands run:

```bash
PYTHONPATH=packages/playground/src:application/playground \
  uv run --with pytest --with flask pytest \
  application/playground/backend/tests/test_harbor_chat_eval.py \
  environment/task-environments/application/chatbot-api-sidecar_acme-support-api/support-api/test_server.py -q

uvx ruff@0.15.20 check .
```

Results: `9 passed`; Ruff passed.

## Data Policy

- [x] No large generated outputs or raw dumps were added.
- [x] Any fixtures are small and necessary for tests or docs.
