### PR TITLE
fix(browser-use): expose mounted task inputs

### DIFF
--- a/environment/agents/matraix/agents/installed/browser_use_runner.py
+++ b/environment/agents/matraix/agents/installed/browser_use_runner.py
@@ -14,6 +14,7 @@ from typing import Any
 from uuid import uuid4
 
 OUTPUT_DIR = Path("/app/output")
+TASK_INPUT_DIR = Path("/app/input")
 
 _IMAGE_MEDIA_TYPES = {
     ".png": "image/png",
@@ -52,6 +53,31 @@ def _create_llm(model: str):
         return ChatOpenAI(model=bare, api_key=api_key, base_url=base_url)
 
     return ChatOpenAI(model=bare)
+
+
+def available_task_input_paths(input_dir: Path = TASK_INPUT_DIR) -> list[str]:
+    """Return mounted task inputs that browser-use may safely read.
+
+    Harbor mounts task-owned inputs under ``/app/input`` while browser-use
+    limits file reads to explicitly allowed paths outside its output sandbox.
+    Include both the canonical mount path and the task-facing ``input/...``
+    spelling used by task instructions.
+    """
+    if not input_dir.is_dir():
+        return []
+
+    available: list[str] = []
+    for path in sorted(
+        candidate for candidate in input_dir.rglob("*") if candidate.is_file()
+    ):
+        relative = path.relative_to(input_dir)
+        available.extend(
+            [
+                (Path("input") / relative).as_posix(),
+                path.as_posix(),
+            ]
+        )
+    return available
 
 
 def promote_browser_use_outputs(agent: Any) -> list[str]:
@@ -344,6 +370,9 @@ async def _run(args: argparse.Namespace) -> int:
         "browser": browser,
         "file_system_path": str(OUTPUT_DIR),
     }
+    task_input_paths = available_task_input_paths()
+    if task_input_paths:
+        agent_kwargs["available_file_paths"] = task_input_paths
     if extend:
         agent_kwargs["extend_system_message"] = extend
 

--- a/tests/unit/agents/test_web_live_trajectory_flush.py
+++ b/tests/unit/agents/test_web_live_trajectory_flush.py
@@ -71,6 +71,21 @@ _install_openhands_stubs()
 from harbor.agents.installed import openhands_sdk_runner as oh  # noqa: E402
 
 
+def test_browser_use_allow_lists_mounted_task_inputs(tmp_path):
+    input_dir = tmp_path / "input"
+    nested_dir = input_dir / "nested"
+    nested_dir.mkdir(parents=True)
+    (input_dir / "context.md").write_text("Task context", encoding="utf-8")
+    (nested_dir / "options.json").write_text("{}", encoding="utf-8")
+
+    assert bu.available_task_input_paths(input_dir) == [
+        "input/context.md",
+        (input_dir / "context.md").as_posix(),
+        "input/nested/options.json",
+        (nested_dir / "options.json").as_posix(),
+    ]
+
+
 def test_browser_use_flush_writes_atomic_trajectory(tmp_path):
     history = SimpleNamespace(
         history=[],


### PR DESCRIPTION
## Module

Select the owning module:

- [ ] `persona/`
- [ ] `application/`
- [x] `environment/`
- [ ] `packages/`
- [ ] `apps/`
- [ ] docs or migration metadata only

## Summary

Expose Harbor's mounted task inputs to the browser-use agent's file tools.

Harbor mounts task-owned files under `/app/input`, while browser-use restricts reads outside its output sandbox to `available_file_paths`. The runner now enumerates files that actually exist under the input mount and passes both supported spellings:

- the task-facing `input/...` path used in instructions;
- the canonical `/app/input/...` mount path.

The allow-list is omitted when no task input directory exists, preserving the current behavior for tasks without mounted inputs.

## Validation

Commands run:

```bash
uv run --with pytest pytest \
  tests/unit/agents/test_web_live_trajectory_flush.py -q

uvx ruff@0.15.20 check .
```

Results: `5 passed`; Ruff passed. The current browser-use `Agent` signature was also checked to confirm support for `available_file_paths: list[str] | None`.

## Data Policy

- [x] No large generated outputs or raw dumps were added.
- [x] Any fixtures are small and necessary for tests or docs.
