### PR TITLE
feat(persona): follow profile language in outputs

### DIFF
--- a/src/matraix/persona_dimension_catalog.py
+++ b/src/matraix/persona_dimension_catalog.py
@@ -151,6 +151,19 @@ _STATE_IDS = frozenset(
     }
 )
 
+PRIMARY_LANGUAGE_OUTPUT_INSTRUCTION = (
+    "Default written language: use your primary language for outputs."
+)
+
+
+def _primary_language_output_instruction(
+    dimensions: dict[str, Any],
+) -> str | None:
+    primary_language = _dim_value(dimensions, "primary_language")
+    if primary_language is None:
+        return None
+    return PRIMARY_LANGUAGE_OUTPUT_INSTRUCTION
+
 
 @lru_cache(maxsize=4)
 def load_dimension_catalog(catalog_path: str) -> dict[str, Any]:
@@ -364,6 +377,13 @@ def build_dimension_narrative(
             block = _format_section(
                 heading, [(label, value) for _dim_id, label, value in items]
             )
+            required_instruction = (
+                _primary_language_output_instruction(dimensions)
+                if heading == "Language & communication"
+                else None
+            )
+            if required_instruction and required_instruction not in block:
+                block = f"{block}\n{required_instruction}"
 
         rendered.append(block)
         used_chars += len(block) + 2  # blank line between sections

--- a/tests/environment/test_persona_agents.py
+++ b/tests/environment/test_persona_agents.py
@@ -232,7 +232,7 @@ def test_persona_system_template_is_identity_only() -> None:
     )
 
     persona = load_persona(
-        ROOT / "persona/datasets/matraix-persona-dev-sample/persona_0042.yaml"
+        ROOT / "persona/datasets/matraix-persona-dev-sample/persona_0004.yaml"
     )
     system = render_persona_template(
         resolve_persona_template(persona, None, PERSONA_SYSTEM_TEMPLATE),
@@ -244,7 +244,11 @@ def test_persona_system_template_is_identity_only() -> None:
         instruction="Pick a book on the site.",
     )
 
-    assert "You are Casey Brooks." in system
+    assert "You are Sienna Carter." in system
+    assert (
+        "Default written language: use your primary language for outputs."
+        in system
+    )
     assert "## Who you are" in system
     assert "## Task instruction" not in system
     assert "Pick a book on the site." not in system
@@ -253,11 +257,15 @@ def test_persona_system_template_is_identity_only() -> None:
     assert "stay in character" not in system.lower()
     assert "embody" not in system.lower()
 
-    assert "You are Casey Brooks." in instruction
+    assert "You are Sienna Carter." in instruction
+    assert (
+        "Default written language: use your primary language for outputs."
+        in instruction
+    )
     assert "## Task instruction" in instruction
     assert "Pick a book on the site." in instruction
     assert "Simulated person" not in instruction
-    assert instruction.index("You are Casey Brooks.") < instruction.index(
+    assert instruction.index("You are Sienna Carter.") < instruction.index(
         "## Task instruction"
     )
 
@@ -302,9 +310,23 @@ def test_persona_computer_1_docker_uses_identity_channel(monkeypatch, tmp_path) 
     import asyncio
     from types import SimpleNamespace
 
+    from matraix.agents.persona.loader import load_persona
     from matraix.agents.persona.computer_1 import PersonaComputer1
+    from matraix.agents.persona.templating import (
+        PERSONA_SYSTEM_TEMPLATE,
+        render_persona_template,
+        resolve_persona_template,
+    )
 
     captured: dict[str, object] = {}
+    persona_path = (
+        ROOT / "persona/datasets/matraix-persona-dev-sample/persona_0004.yaml"
+    )
+    persona = load_persona(persona_path)
+    expected_identity = render_persona_template(
+        resolve_persona_template(persona, None, PERSONA_SYSTEM_TEMPLATE),
+        persona,
+    )
 
     class _FakeComputer1:
         def __init__(self, **kwargs):
@@ -340,9 +362,7 @@ def test_persona_computer_1_docker_uses_identity_channel(monkeypatch, tmp_path) 
     agent = PersonaComputer1(
         logs_dir=logs_dir,
         model_name="openai/gpt-4o",
-        persona_path=str(
-            ROOT / "persona/datasets/matraix-persona-dev-sample/persona_0042.yaml"
-        ),
+        persona_path=str(persona_path),
         cua_backend="docker",
     )
     agent.logger = SimpleNamespace(
@@ -367,8 +387,12 @@ def test_persona_computer_1_docker_uses_identity_channel(monkeypatch, tmp_path) 
     assert captured["instruction"] == "Open Settings and enable Do Not Disturb."
     identity = captured["identity_prompt"]
     assert isinstance(identity, str)
-    assert "You are Casey Brooks." in identity
+    assert identity == expected_identity
+    assert "You are Sienna Carter." in identity
+    assert (
+        "Default written language: use your primary language for outputs."
+        in identity
+    )
     assert "Simulated person" not in identity
     assert "schema" not in identity.lower()
     assert "Open Settings and enable Do Not Disturb." not in identity
-

--- a/tests/unit/matraix/test_persona_dimension_narrative.py
+++ b/tests/unit/matraix/test_persona_dimension_narrative.py
@@ -26,6 +26,30 @@ def test_communication_style_uses_label_value_pairs():
     assert "visual vs verbal thinking: mixed" in joined
 
 
+def test_primary_language_adds_output_instruction_to_language_section():
+    paragraphs = build_dimension_narrative({"primary_language": "Mandarin"})
+    text = "\n\n".join(paragraphs)
+
+    assert "### Language & communication" in text
+    assert (
+        "Default written language: use your primary language for outputs."
+        in text
+    )
+    assert text.index("### Language & communication") < text.index(
+        "Default written language: use your primary language for outputs."
+    )
+
+
+def test_missing_primary_language_does_not_add_output_instruction():
+    paragraphs = build_dimension_narrative({"primary_language": None})
+    text = "\n\n".join(paragraphs)
+
+    assert (
+        "Default written language: use your primary language for outputs."
+        not in text
+    )
+
+
 def test_full_schema_render_skips_null_and_default_without_truncation():
     persona = load_persona(
         "persona/datasets/matraix-persona-dev-sample/persona_0182.yaml"


### PR DESCRIPTION
## Summary

Reworks PR 3 from #66 around the maintainer's updated product boundary and supersedes #86.

- Derives persona speech behavior only from the profile's `primary_language`.
- Adds the requested fixed line under the Language section during default, unlimited identity-narrative rendering:
  `Default written language: use your primary language for outputs.`
- Skips the instruction when `primary_language` is missing or nullish.
- Verifies the full rendered identity prompt is passed unchanged to Computer1.

## Scope

This PR intentionally contains no UI-locale coupling, launch/API/CLI language fields, environment overrides, BCP 47 mapping, provenance metadata, compatibility shims, locale packs, or task-content translation.

It does not special-case optional `max_chars` trimming; profile-size policy remains owned by #95. The diff is limited to one implementation file and two focused test files, rebased directly onto `main` at `311362b6d8d0bf0d6bbc32b930afd6929e5a8eff`.

## Validation

- Focused persona narrative unit tests: **7 passed**
- Ruff on all three changed files: passed
- `git diff --check`: passed
- Fresh Standards and Spec review of the revised candidate: PASS

The existing Computer1 integration assertions are unchanged by the review fix. Two local environment tests require a newer Harbor API than the installed local `0.16.1`; the repository's Python CI is the authoritative clean-environment check for that path.

Closes the requested rework from #86.