### PR TITLE
fix(playground): align home subtitle with supported task types

### DIFF
--- a/application/playground/frontend/src/i18n/messages/en-US.json
+++ b/application/playground/frontend/src/i18n/messages/en-US.json
@@ -1296,7 +1296,7 @@
   "shell.footer.connected": "Connected",
   "shell.footer.finishingSetup": "Finishing setup",
   "shell.home.personas": "personas",
-  "shell.home.subtitle": "Simulate real users across chatbots, surveys, browsers, and agents with evaluation reporting",
+  "shell.home.subtitle": "Simulate real users across surveys, AI chatbots, web, and native os-app with evaluation reporting",
   "shell.home.title": "Planetary-scale",
   "shell.home.titleAccent": "digital humans",
   "shell.nav.application": "Application",


### PR DESCRIPTION
## Summary
- Update `shell.home.subtitle` to: surveys, AI chatbots, web, and native os-app (with evaluation reporting)
- Replaces outdated “browsers / agents” wording so the home line matches the supported task types

## Test plan
- [ ] Open Playground home and confirm the hero subtitle reads the new copy
- [ ] Spot-check that no other i18n keys changed in this PR


Made with [Cursor](https://cursor.com)