### PR TITLE
docs: reorder README language bar by traffic demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
   </p>
   <p>
     <strong>English</strong> |
-    <a href="docs/i18n/README.ko.md">한국어</a> |
     <a href="docs/i18n/README.zh-CN.md">简体中文</a> |
     <a href="docs/i18n/README.zh-TW.md">繁體中文</a> |
+    <a href="docs/i18n/README.ko.md">한국어</a> |
     <a href="docs/i18n/README.ja.md">日本語</a> |
-    <a href="docs/i18n/README.pt-BR.md">Português</a> |
-    <a href="docs/i18n/README.es.md">Español</a>
+    <a href="docs/i18n/README.es.md">Español</a> |
+    <a href="docs/i18n/README.pt-BR.md">Português</a>
   </p>
   <p>
     <a href="https://matraix.ai/"><img alt="Website" src="https://img.shields.io/badge/Website-matraix.ai-4f7cff?style=for-the-badge"></a>

--- a/docs/i18n/README.es.md
+++ b/docs/i18n/README.es.md
@@ -7,12 +7,12 @@
   </p>
   <p>
     <a href="../../README.md">English</a> |
-    <a href="README.ko.md">한국어</a> |
     <a href="README.zh-CN.md">简体中文</a> |
     <a href="README.zh-TW.md">繁體中文</a> |
+    <a href="README.ko.md">한국어</a> |
     <a href="README.ja.md">日本語</a> |
-    <a href="README.pt-BR.md">Português</a> |
-    <strong>Español</strong>
+    <strong>Español</strong> |
+    <a href="README.pt-BR.md">Português</a>
   </p>
   <p>
     <a href="https://matraix.ai/"><img alt="Website" src="https://img.shields.io/badge/Website-matraix.ai-4f7cff?style=for-the-badge"></a>

--- a/docs/i18n/README.ja.md
+++ b/docs/i18n/README.ja.md
@@ -7,12 +7,12 @@
   </p>
   <p>
     <a href="../../README.md">English</a> |
-    <a href="README.ko.md">한국어</a> |
     <a href="README.zh-CN.md">简体中文</a> |
     <a href="README.zh-TW.md">繁體中文</a> |
+    <a href="README.ko.md">한국어</a> |
     <strong>日本語</strong> |
-    <a href="README.pt-BR.md">Português</a> |
-    <a href="README.es.md">Español</a>
+    <a href="README.es.md">Español</a> |
+    <a href="README.pt-BR.md">Português</a>
   </p>
   <p>
     <a href="https://matraix.ai/"><img alt="Website" src="https://img.shields.io/badge/Website-matraix.ai-4f7cff?style=for-the-badge"></a>

--- a/docs/i18n/README.ko.md
+++ b/docs/i18n/README.ko.md
@@ -7,12 +7,12 @@
   </p>
   <p>
     <a href="../../README.md">English</a> |
-    <strong>한국어</strong> |
     <a href="README.zh-CN.md">简体中文</a> |
     <a href="README.zh-TW.md">繁體中文</a> |
+    <strong>한국어</strong> |
     <a href="README.ja.md">日本語</a> |
-    <a href="README.pt-BR.md">Português</a> |
-    <a href="README.es.md">Español</a>
+    <a href="README.es.md">Español</a> |
+    <a href="README.pt-BR.md">Português</a>
   </p>
   <p>
     <a href="https://matraix.ai/"><img alt="Website" src="https://img.shields.io/badge/Website-matraix.ai-4f7cff?style=for-the-badge"></a>

--- a/docs/i18n/README.pt-BR.md
+++ b/docs/i18n/README.pt-BR.md
@@ -7,12 +7,12 @@
   </p>
   <p>
     <a href="../../README.md">English</a> |
-    <a href="README.ko.md">한국어</a> |
     <a href="README.zh-CN.md">简体中文</a> |
     <a href="README.zh-TW.md">繁體中文</a> |
+    <a href="README.ko.md">한국어</a> |
     <a href="README.ja.md">日本語</a> |
-    <strong>Português</strong> |
-    <a href="README.es.md">Español</a>
+    <a href="README.es.md">Español</a> |
+    <strong>Português</strong>
   </p>
   <p>
     <a href="https://matraix.ai/"><img alt="Website" src="https://img.shields.io/badge/Website-matraix.ai-4f7cff?style=for-the-badge"></a>

--- a/docs/i18n/README.zh-CN.md
+++ b/docs/i18n/README.zh-CN.md
@@ -6,12 +6,12 @@
   </p>
   <p>
     <a href="../../README.md">English</a> |
-    <a href="README.ko.md">한국어</a> |
     <strong>简体中文</strong> |
     <a href="README.zh-TW.md">繁體中文</a> |
+    <a href="README.ko.md">한국어</a> |
     <a href="README.ja.md">日本語</a> |
-    <a href="README.pt-BR.md">Português</a> |
-    <a href="README.es.md">Español</a>
+    <a href="README.es.md">Español</a> |
+    <a href="README.pt-BR.md">Português</a>
   </p>
   <p>
     <a href="https://matraix.ai/"><img alt="Website" src="https://img.shields.io/badge/Website-matraix.ai-4f7cff?style=for-the-badge"></a>

--- a/docs/i18n/README.zh-TW.md
+++ b/docs/i18n/README.zh-TW.md
@@ -6,12 +6,12 @@
   </p>
   <p>
     <a href="../../README.md">English</a> |
-    <a href="README.ko.md">한국어</a> |
     <a href="README.zh-CN.md">简体中文</a> |
     <strong>繁體中文</strong> |
+    <a href="README.ko.md">한국어</a> |
     <a href="README.ja.md">日本語</a> |
-    <a href="README.pt-BR.md">Português</a> |
-    <a href="README.es.md">Español</a>
+    <a href="README.es.md">Español</a> |
+    <a href="README.pt-BR.md">Português</a>
   </p>
   <p>
     <a href="https://matraix.ai/"><img alt="Website" src="https://img.shields.io/badge/Website-matraix.ai-4f7cff?style=for-the-badge"></a>


### PR DESCRIPTION
## Summary
- Reorders the language switcher on the root README and all `docs/i18n/README.*.md` mirrors to: **English → 简体中文 → 繁體中文 → 한국어 → 日本語 → Español → Português**.
- Driven by GitHub Traffic popular paths: only `docs/i18n/README.zh-CN.md` appears among top paths (~872 views / 546 uniques); other locale READMEs do not. The previous Korean-second order came from an unverified “audience signal” in #40, not geo data.

## Test plan
- [ ] Spot-check language bar links on root README and each `docs/i18n/README.*.md`
- [ ] Confirm current locale is `<strong>` and others link correctly


Made with [Cursor](https://cursor.com)