### PR TITLE
feat(playground): dimension label pack infrastructure

### DIFF
--- a/application/playground/backend/api/app.py
+++ b/application/playground/backend/api/app.py
@@ -990,6 +990,23 @@ def create_app(catalog_path: Optional[str] = None) -> FastAPI:
         except (ValueError, FileNotFoundError, OSError) as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
 
+    @app.get(
+        "/api/persona-pool/dimension-labels",
+        response_model=schemas.PersonaDimensionLabelsResponse,
+        tags=["persona-pool"],
+    )
+    def get_persona_dimension_labels(
+        locale: str = Query(min_length=1),
+        services: AppState = Depends(get_services),
+    ) -> Dict[str, Any]:
+        """Translated dimension labels/values for display (English fallback)."""
+        try:
+            return services.persona_pool.get_dimension_labels(locale)
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+        except OSError as exc:
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+
     @app.post(
         "/api/persona-pool/match-attributes",
         response_model=schemas.PersonaMatchAttributesResponse,

--- a/application/playground/backend/api/schemas.py
+++ b/application/playground/backend/api/schemas.py
@@ -839,7 +839,9 @@ class PersonaDimensionLabelsResponse(BaseModel):
     """Display-label overlay for persona dimensions in one UI locale.
 
     ``dimensions`` maps canonical English dimension ids to translated
-    ``label`` / ``values`` entries; anything missing falls back to English.
+    ``label`` / ``values`` entries; ``taxonomy`` maps Layer-1 / Layer-2
+    group ids (Background, Demographics, …) to display titles. Anything
+    missing falls back to English.
     """
 
     model_config = ConfigDict(extra="allow")
@@ -848,6 +850,7 @@ class PersonaDimensionLabelsResponse(BaseModel):
     available: bool = False
     reviewStatus: Optional[str] = None
     dimensions: Dict[str, Any] = Field(default_factory=dict)
+    taxonomy: Dict[str, str] = Field(default_factory=dict)
 
 
 class PersonaMatchAttributesRequest(BaseModel):

--- a/application/playground/backend/api/schemas.py
+++ b/application/playground/backend/api/schemas.py
@@ -835,6 +835,21 @@ class PersonaPoolCatalogResponse(BaseModel):
     dimensionCategories: Dict[str, Any] = Field(default_factory=dict)
 
 
+class PersonaDimensionLabelsResponse(BaseModel):
+    """Display-label overlay for persona dimensions in one UI locale.
+
+    ``dimensions`` maps canonical English dimension ids to translated
+    ``label`` / ``values`` entries; anything missing falls back to English.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    locale: str
+    available: bool = False
+    reviewStatus: Optional[str] = None
+    dimensions: Dict[str, Any] = Field(default_factory=dict)
+
+
 class PersonaMatchAttributesRequest(BaseModel):
     """Free-text / NL prompt → catalog attribute suggestions (Treiver)."""
 

--- a/application/playground/backend/service/persona_pool_service.py
+++ b/application/playground/backend/service/persona_pool_service.py
@@ -56,6 +56,8 @@ _RESERVED_DATASET_SLUGS = frozenset(
     }
 )
 DIMENSION_CATEGORIES_PATH = "persona/schema/dimension_categories.json"
+DIMENSION_LABELS_DIR = "persona/schema/labels"
+_LABEL_LOCALE_RE = re.compile(r"^[A-Za-z0-9-]{1,32}$")
 # Soft guard for stratify cell cartesian products from dimensionFilters.
 MAX_FILTER_STRATA = 2048
 # UI keeps a full personaId list only at or below this size; larger cohorts are ref-based.
@@ -367,6 +369,33 @@ class PersonaPoolService:
             **summary,
             "dimensionCategoriesPath": "persona/schema/dimensions.json",
             "dimensionCategories": categories,
+        }
+
+    def get_dimension_labels(self, locale: str) -> dict[str, Any]:
+        """Display-label overlay for one locale (English fallback when absent).
+
+        Packs live in ``persona/schema/labels/dimensions.labels.<locale>.json``
+        and only carry translated labels/values keyed by canonical English
+        ids — they never replace the catalog served by :meth:`get_catalog`.
+        """
+        token = (locale or "").strip()
+        if not _LABEL_LOCALE_RE.match(token):
+            raise ValueError(f"invalid locale token: {locale!r}")
+        path = self.repo_root / DIMENSION_LABELS_DIR / f"dimensions.labels.{token}.json"
+        if not path.is_file():
+            return {
+                "locale": token,
+                "available": False,
+                "reviewStatus": None,
+                "dimensions": {},
+            }
+        payload = self._read_json(path)
+        dimensions = payload.get("dimensions")
+        return {
+            "locale": token,
+            "available": True,
+            "reviewStatus": payload.get("reviewStatus"),
+            "dimensions": dimensions if isinstance(dimensions, dict) else {},
         }
 
     def _is_persona_dataset_dir(self, path: Path) -> bool:

--- a/application/playground/backend/service/persona_pool_service.py
+++ b/application/playground/backend/service/persona_pool_service.py
@@ -388,14 +388,17 @@ class PersonaPoolService:
                 "available": False,
                 "reviewStatus": None,
                 "dimensions": {},
+                "taxonomy": {},
             }
         payload = self._read_json(path)
         dimensions = payload.get("dimensions")
+        taxonomy = payload.get("taxonomy")
         return {
             "locale": token,
             "available": True,
             "reviewStatus": payload.get("reviewStatus"),
             "dimensions": dimensions if isinstance(dimensions, dict) else {},
+            "taxonomy": taxonomy if isinstance(taxonomy, dict) else {},
         }
 
     def _is_persona_dataset_dir(self, path: Path) -> bool:

--- a/application/playground/backend/tests/test_persona_pool_service.py
+++ b/application/playground/backend/tests/test_persona_pool_service.py
@@ -829,3 +829,50 @@ def test_generate_synthetic_pool_from_task_strategy(tmp_path, monkeypatch):
     result = service.generate_synthetic_pool(task_path="application/tasks/demo-task")
     assert result["pool"] == "persona/datasets/generated-persona-dev-strategy-demo-task"
     assert result["count"] == 2
+
+
+def test_get_dimension_labels_missing_pack_reports_unavailable(tmp_path):
+    service = PersonaPoolService(repo_root=tmp_path)
+    result = service.get_dimension_labels("ko")
+    assert result == {
+        "locale": "ko",
+        "available": False,
+        "reviewStatus": None,
+        "dimensions": {},
+    }
+
+
+def test_get_dimension_labels_reads_committed_pack(tmp_path):
+    labels_dir = tmp_path / "persona" / "schema" / "labels"
+    labels_dir.mkdir(parents=True)
+    (labels_dir / "dimensions.labels.zh-Hans.json").write_text(
+        json.dumps(
+            {
+                "formatVersion": "1.0",
+                "locale": "zh-Hans",
+                "reviewStatus": "machine-assisted",
+                "dimensions": {
+                    "primary_language": {
+                        "label": "主要语言",
+                        "values": {"Mandarin": "普通话"},
+                    }
+                },
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    service = PersonaPoolService(repo_root=tmp_path)
+    result = service.get_dimension_labels("zh-Hans")
+    assert result["available"] is True
+    assert result["reviewStatus"] == "machine-assisted"
+    entry = result["dimensions"]["primary_language"]
+    assert entry["label"] == "主要语言"
+    assert entry["values"]["Mandarin"] == "普通话"
+
+
+def test_get_dimension_labels_rejects_unsafe_locale_tokens(tmp_path):
+    service = PersonaPoolService(repo_root=tmp_path)
+    for bad in ("", "../secrets", "zh Hans", "a/b", "x" * 33):
+        with pytest.raises(ValueError):
+            service.get_dimension_labels(bad)

--- a/application/playground/backend/tests/test_persona_pool_service.py
+++ b/application/playground/backend/tests/test_persona_pool_service.py
@@ -839,6 +839,7 @@ def test_get_dimension_labels_missing_pack_reports_unavailable(tmp_path):
         "available": False,
         "reviewStatus": None,
         "dimensions": {},
+        "taxonomy": {},
     }
 
 

--- a/application/playground/frontend/src/components/cockpit/PersonaGroupBuilder.tsx
+++ b/application/playground/frontend/src/components/cockpit/PersonaGroupBuilder.tsx
@@ -6,6 +6,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { useI18n } from "@/i18n/I18nProvider";
 import { api, ApiError } from "@/lib/api";
+import { useDimensionLabels } from "@/lib/dimensionLabels";
 import type { PersonaCohortDetail, PersonaPoolCatalog } from "@/lib/types";
 import { FOCUS_RING } from "./cockpitShared";
 
@@ -47,6 +48,7 @@ export function PersonaGroupBuilder({
   onCohortChange,
 }: PersonaGroupBuilderProps) {
   const { rich, t } = useI18n();
+  const labels = useDimensionLabels();
   const queryClient = useQueryClient();
   const [expandedGroup, setExpandedGroup] = useState<string | null>(null);
   const [previewError, setPreviewError] = useState<string | null>(null);
@@ -320,7 +322,12 @@ export function PersonaGroupBuilder({
                           key={dim.id}
                           className="flex flex-col gap-1 text-[13px] text-text-variant"
                         >
-                          <span className="font-mono text-[12px] text-text-dim">{dim.id}</span>
+                          <span
+                            className="font-mono text-[12px] text-text-dim"
+                            title={dim.id}
+                          >
+                            {labels.dimLabel(dim.id, dim.id)}
+                          </span>
                           <select
                             value={filters.dimensionFilters[dim.id] ?? ""}
                             onChange={(e) => setDimensionFilter(dim.id, e.target.value)}
@@ -329,7 +336,7 @@ export function PersonaGroupBuilder({
                             <option value="">{t("personaGroups.any")}</option>
                             {dim.values.map((value) => (
                               <option key={value} value={value}>
-                                {value}
+                                {labels.valueLabel(dim.id, value)}
                               </option>
                             ))}
                           </select>

--- a/application/playground/frontend/src/components/cockpit/setup/BenchPersonaCard.tsx
+++ b/application/playground/frontend/src/components/cockpit/setup/BenchPersonaCard.tsx
@@ -1,6 +1,7 @@
 import { FOCUS_RING, Sym } from "../cockpitShared";
 import { useI18n } from "@/i18n/I18nProvider";
 import type { MessageKey } from "@/i18n/types";
+import { useDimensionLabels } from "@/lib/dimensionLabels";
 import { personaDisplayId, personaPrimaryName } from "@/lib/personaDisplay";
 import type { PersonaPoolPersonaCard } from "@/lib/types";
 import { PersonaAvatar } from "./PersonaAvatar";
@@ -36,6 +37,7 @@ export function BenchPersonaCard({
   hits = [],
 }: BenchPersonaCardProps) {
   const { t } = useI18n();
+  const labels = useDimensionLabels();
   const dims = Object.entries(persona.dimensions ?? {}).slice(0, 4);
   const displayName = personaPrimaryName(
     persona.name,
@@ -131,19 +133,22 @@ export function BenchPersonaCard({
 
       {visibleHits.length > 0 ? (
         <div className="mt-3 flex flex-wrap gap-1.5">
-          {visibleHits.map((hit) => (
-            <span
-              key={`${hit.dimensionId}:${hit.value}`}
-              title={`${hit.label}: ${hit.value}`}
-              className="inline-flex max-w-full items-center gap-1 rounded-full border border-primary/25 bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary"
-            >
-              <span className="opacity-70">
-                {t("cockpitSetup.persona.match")}
+          {visibleHits.map((hit) => {
+            const hitValue = labels.valueLabel(hit.dimensionId, hit.value);
+            return (
+              <span
+                key={`${hit.dimensionId}:${hit.value}`}
+                title={`${labels.dimLabel(hit.dimensionId, hit.label)}: ${hitValue}`}
+                className="inline-flex max-w-full items-center gap-1 rounded-full border border-primary/25 bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary"
+              >
+                <span className="opacity-70">
+                  {t("cockpitSetup.persona.match")}
+                </span>
+                <span className="opacity-40">·</span>
+                <span className="truncate">{hitValue}</span>
               </span>
-              <span className="opacity-40">·</span>
-              <span className="truncate">{hit.value}</span>
-            </span>
-          ))}
+            );
+          })}
           {hits.length > visibleHits.length ? (
             <span className="self-center text-[11px] text-text-dim">
               +{hits.length - visibleHits.length}
@@ -161,9 +166,12 @@ export function BenchPersonaCard({
         >
           <dl className="space-y-2">
             {dims.map(([key, value], index) => {
-              const label = key in DIM_LABEL_KEYS
-                ? t(DIM_LABEL_KEYS[key])
-                : key.replace(/_/g, " ");
+              const fallback =
+                key in DIM_LABEL_KEYS
+                  ? t(DIM_LABEL_KEYS[key])
+                  : key.replace(/_/g, " ");
+              const label = labels.dimLabel(key, fallback);
+              const displayValue = labels.valueLabel(key, value);
               return (
                 <div
                   key={key}
@@ -181,9 +189,9 @@ export function BenchPersonaCard({
                   </dt>
                   <dd
                     className="min-w-0 truncate text-[13px] leading-snug text-text-main"
-                    title={value}
+                    title={displayValue}
                   >
-                    {value}
+                    {displayValue}
                   </dd>
                 </div>
               );

--- a/application/playground/frontend/src/components/cockpit/setup/BenchPersonaDetailPanel.tsx
+++ b/application/playground/frontend/src/components/cockpit/setup/BenchPersonaDetailPanel.tsx
@@ -4,6 +4,10 @@ import { useQuery } from "@tanstack/react-query";
 import { useI18n } from "@/i18n/I18nProvider";
 import type { MessageKey } from "@/i18n/types";
 import { api, ApiError } from "@/lib/api";
+import {
+  type DimensionLabelLookup,
+  useDimensionLabels,
+} from "@/lib/dimensionLabels";
 import { personaDisplayId, personaPrimaryName } from "@/lib/personaDisplay";
 import {
   PERSONA_BENCH_POOL,
@@ -67,9 +71,11 @@ function spotlightDotClass(
 function TaxonomyTree({
   groups,
   t,
+  labels,
 }: {
   groups: PersonaDimensionGroup[];
   t: ReturnType<typeof useI18n>["t"];
+  labels: DimensionLabelLookup;
 }) {
   const [openGroups, setOpenGroups] = useState<Record<string, boolean>>(() => {
     const initial: Record<string, boolean> = {};
@@ -119,7 +125,7 @@ function TaxonomyTree({
             >
               <span className="min-w-0">
                 <span className="block font-display text-[14px] font-semibold text-text-main">
-                  {group.label}
+                  {labels.taxonomyLabel(group.id, group.label)}
                 </span>
                 <span className="mt-1 block text-[12px] text-text-dim">
                   {t("cockpitSetup.persona.attributesAndSubgroups", {
@@ -153,7 +159,7 @@ function TaxonomyTree({
                         className={`flex w-full items-center justify-between gap-3 px-3.5 py-2.5 text-left ${FOCUS_RING}`}
                       >
                         <span className="text-[13px] font-medium text-text-main">
-                          {subgroup.label}
+                          {labels.taxonomyLabel(subgroup.id, subgroup.label)}
                         </span>
                         <span className="flex items-center gap-1.5 text-[12px] text-text-dim">
                           {subgroup.count}
@@ -165,25 +171,35 @@ function TaxonomyTree({
                       </button>
                       {subOpen ? (
                         <ul className="divide-y divide-outline/10 border-t border-outline/15 px-3.5 py-1">
-                          {subgroup.items.map((item) => (
+                          {subgroup.items.map((item) => {
+                            const dimLabel = labels.dimLabel(
+                              item.id,
+                              item.label,
+                            );
+                            const valueLabel = labels.valueLabel(
+                              item.id,
+                              item.value,
+                            );
+                            return (
                             <li
                               key={item.id}
                               className="grid grid-cols-[minmax(0,1fr)_minmax(0,1.15fr)] gap-3 py-2.5"
                             >
                               <span
                                 className="truncate text-[12px] leading-snug text-text-dim"
-                                title={item.label}
+                                title={dimLabel}
                               >
-                                {item.label}
+                                {dimLabel}
                               </span>
                               <span
                                 className="truncate text-right text-[13px] leading-snug text-text-main"
-                                title={item.value}
+                                title={valueLabel}
                               >
-                                {item.value}
+                                {valueLabel}
                               </span>
                             </li>
-                          ))}
+                            );
+                          })}
                         </ul>
                       ) : null}
                     </div>
@@ -209,6 +225,7 @@ export function BenchPersonaDetailPanel({
   className = "",
 }: BenchPersonaDetailPanelProps) {
   const { t } = useI18n();
+  const labels = useDimensionLabels();
   const personaId = persona?.personaId ?? null;
   const activePool = pool?.trim() || PERSONA_BENCH_POOL;
   const detailQuery = useQuery({
@@ -237,23 +254,29 @@ export function BenchPersonaDetailPanel({
             count: entries.length,
             items: entries.map(([id, value]) => ({
               id,
-              label: id.replace(/_/g, " "),
-              value,
+              label: labels.dimLabel(id, id.replace(/_/g, " ")),
+              value: labels.valueLabel(id, value),
             })),
           },
         ],
       },
     ];
-  }, [detailQuery.data?.dimensionGroups, dims, t]);
+  }, [detailQuery.data?.dimensionGroups, dims, t, labels]);
 
   const spotlight = useMemo(
     () =>
-      SPOTLIGHT_KEYS.map((key) => ({
-        key,
-        label: t(SPOTLIGHT_LABEL_KEYS[key]),
-        value: dims[key],
-      })).filter((item) => item.value),
-    [dims, t],
+      SPOTLIGHT_KEYS.map((key) => {
+        const raw = dims[key];
+        if (!raw) return null;
+        return {
+          key,
+          label: labels.dimLabel(key, t(SPOTLIGHT_LABEL_KEYS[key])),
+          value: labels.valueLabel(key, raw),
+        };
+      }).filter((item): item is { key: (typeof SPOTLIGHT_KEYS)[number]; label: string; value: string } =>
+        Boolean(item),
+      ),
+    [dims, t, labels],
   );
 
   if (!persona) return null;
@@ -401,7 +424,7 @@ export function BenchPersonaDetailPanel({
             </p>
           ) : null}
           {!detailQuery.isPending ? (
-            <TaxonomyTree groups={groups} t={t} />
+            <TaxonomyTree groups={groups} t={t} labels={labels} />
           ) : null}
         </div>
 

--- a/application/playground/frontend/src/components/cockpit/setup/PersonaFilterModal.tsx
+++ b/application/playground/frontend/src/components/cockpit/setup/PersonaFilterModal.tsx
@@ -4,6 +4,10 @@ import { useQuery } from "@tanstack/react-query";
 
 import { useI18n } from "@/i18n/I18nProvider";
 import { api } from "@/lib/api";
+import {
+  useDimensionLabels,
+  type DimensionLabelLookup,
+} from "@/lib/dimensionLabels";
 import type {
   PersonaMatchedAttribute,
   PersonaPoolCatalog,
@@ -67,23 +71,40 @@ function matchesQuery(text: string, query: string): boolean {
   return text.toLowerCase().includes(query);
 }
 
+/** English label/id/values plus, when a label pack is active, their translations. */
 function dimensionMatchesQuery(
   dim: PersonaPoolDimensionOption,
   query: string,
+  labels: DimensionLabelLookup,
 ): boolean {
   if (!query) return true;
   if (matchesQuery(`${dimLabel(dim)} ${dim.id}`, query)) return true;
-  return (dim.values ?? []).some((value) => matchesQuery(value, query));
+  if (labels.active && matchesQuery(labels.dimLabel(dim.id, ""), query)) {
+    return true;
+  }
+  return (dim.values ?? []).some(
+    (value) =>
+      matchesQuery(value, query) ||
+      (labels.active && matchesQuery(labels.valueLabel(dim.id, value), query)),
+  );
 }
 
 function filterDimensionValues(
   dim: PersonaPoolDimensionOption,
   query: string,
+  labels: DimensionLabelLookup,
 ): string[] {
   const values = dim.values ?? [];
   if (!query) return values;
   if (matchesQuery(`${dimLabel(dim)} ${dim.id}`, query)) return values;
-  return values.filter((value) => matchesQuery(value, query));
+  if (labels.active && matchesQuery(labels.dimLabel(dim.id, ""), query)) {
+    return values;
+  }
+  return values.filter(
+    (value) =>
+      matchesQuery(value, query) ||
+      (labels.active && matchesQuery(labels.valueLabel(dim.id, value), query)),
+  );
 }
 
 function useDebounced<T>(value: T, delay: number): T {
@@ -106,6 +127,7 @@ export function PersonaFilterModal({
   onConfirm,
 }: PersonaFilterModalProps) {
   const { t } = useI18n();
+  const labels = useDimensionLabels();
   const [draft, setDraft] = useState(filters);
   const [expandedGroup, setExpandedGroup] = useState<string | null>(null);
   const [expandedSubgroup, setExpandedSubgroup] = useState<string | null>(null);
@@ -164,7 +186,7 @@ export function PersonaFilterModal({
         const matchedSubs: PersonaPoolDimensionSubgroup[] = [];
         for (const sub of subgroups) {
           const dims = (sub.dimensions ?? []).filter((dim) =>
-            dimensionMatchesQuery(dim, normalizedQuery),
+            dimensionMatchesQuery(dim, normalizedQuery, labels),
           );
           if (dims.length === 0) continue;
           matchedSubs.push({
@@ -183,7 +205,7 @@ export function PersonaFilterModal({
         continue;
       }
       const dims = (group.dimensions ?? []).filter((dim) =>
-        dimensionMatchesQuery(dim, normalizedQuery),
+        dimensionMatchesQuery(dim, normalizedQuery, labels),
       );
       if (dims.length === 0) continue;
       next.push({
@@ -193,7 +215,7 @@ export function PersonaFilterModal({
       });
     }
     return next;
-  }, [groups, normalizedQuery]);
+  }, [groups, labels, normalizedQuery]);
 
   const selectedChips = useMemo(() => {
     const chips: Array<{
@@ -211,13 +233,13 @@ export function PersonaFilterModal({
       });
     }
     for (const [dimId, values] of Object.entries(draft.dimensionFilters)) {
-      const label = findDimensionLabel(catalog, dimId);
+      const label = labels.dimLabel(dimId, findDimensionLabel(catalog, dimId));
       for (const value of values) {
         chips.push({ key: `${dimId}:${value}`, dimId, label, value });
       }
     }
     return chips;
-  }, [catalog, draft, t]);
+  }, [catalog, draft, labels, t]);
 
   if (!open) return null;
 
@@ -275,7 +297,7 @@ export function PersonaFilterModal({
   };
 
   const renderDimension = (dim: PersonaPoolDimensionOption) => {
-    const visibleValues = filterDimensionValues(dim, normalizedQuery);
+    const visibleValues = filterDimensionValues(dim, normalizedQuery, labels);
     const dimOpen =
       expandedDim === dim.id ||
       (Boolean(normalizedQuery) && visibleValues.length > 0);
@@ -294,7 +316,7 @@ export function PersonaFilterModal({
           className={`flex w-full items-center justify-between gap-2 px-2.5 py-2 text-left text-[13px] ${FOCUS_RING}`}
         >
           <span className={selected.length ? "text-primary" : "text-text-main"}>
-            {dimLabel(dim)}
+            {labels.dimLabel(dim.id, dimLabel(dim))}
             {selected.length > 0 ? ` · ${selected.length}` : ""}
           </span>
           <div className="flex items-center gap-2">
@@ -336,7 +358,7 @@ export function PersonaFilterModal({
                       : "glass-tile glass-tile--hover text-text-variant"
                   }`}
                 >
-                  {value}
+                  {labels.valueLabel(dim.id, value)}
                 </button>
               );
             })}
@@ -465,9 +487,9 @@ export function PersonaFilterModal({
               <div className="flex flex-wrap gap-1.5">
                 {suggestions.map((attr) => {
                   const active = isSuggestionSelected(draft, attr);
-                  const label = (attr.label || attr.dimensionId).replace(
-                    /_/g,
-                    " ",
+                  const label = labels.dimLabel(
+                    attr.dimensionId,
+                    (attr.label || attr.dimensionId).replace(/_/g, " "),
                   );
                   return (
                     <button
@@ -493,7 +515,7 @@ export function PersonaFilterModal({
                     >
                       <span className="text-text-dim">{label}</span>
                       <span className="mx-1 text-text-dim">·</span>
-                      {attr.value}
+                      {labels.valueLabel(attr.dimensionId, attr.value)}
                     </button>
                   );
                 })}
@@ -603,7 +625,9 @@ export function PersonaFilterModal({
                       className="glass-tile glass-tile--active inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-[12px] text-primary"
                     >
                       <span className="text-text-dim">{chip.label}:</span>{" "}
-                      {chip.value}
+                      {chip.dimId === "source"
+                        ? chip.value
+                        : labels.valueLabel(chip.dimId, chip.value)}
                       <Sym name="close" size={12} />
                     </button>
                   ))}
@@ -625,7 +649,10 @@ export function PersonaFilterModal({
                 {fields.length > 0 ? (
                   <div className="flex flex-wrap gap-1.5">
                     {fields.map((field) => {
-                      const label = findDimensionLabel(catalog, field);
+                      const label = labels.dimLabel(
+                        field,
+                        findDimensionLabel(catalog, field),
+                      );
                       return (
                         <button
                           key={field}

--- a/application/playground/frontend/src/components/cockpit/setup/PersonaSamplingRail.tsx
+++ b/application/playground/frontend/src/components/cockpit/setup/PersonaSamplingRail.tsx
@@ -30,6 +30,7 @@ import {
   type PersonaPoolSampleError,
 } from "@/lib/personaPoolCopy";
 import { syntheticDisplayName } from "@/lib/personaDisplay";
+import { useDimensionLabels } from "@/lib/dimensionLabels";
 import { FOCUS_RING, Sym, humanizeToken } from "../cockpitShared";
 import { CockpitSelect, type CockpitSelectOption } from "./CockpitSelect";
 import { CockpitToggle } from "./CockpitToggle";
@@ -185,6 +186,7 @@ function PersonaFilterChips({
   showStratify: boolean;
 }) {
   const { t } = useI18n();
+  const labels = useDimensionLabels();
   const filterCount = activeFilterCount(filters);
   if (filterCount === 0 && !(showStratify && fields.length > 0)) return null;
   return (
@@ -203,9 +205,11 @@ function PersonaFilterChips({
           <span
             key={dim}
             className="rounded-full bg-primary/10 px-2 py-0.5 text-[11px] text-primary"
-            title={values.join(", ")}
+            title={values
+              .map((value) => labels.valueLabel(dim, value))
+              .join(", ")}
           >
-            {humanizeToken(dim)}
+            {labels.dimLabel(dim, humanizeToken(dim))}
             <span className="text-primary/70"> · {values.length}</span>
           </span>
         ))}
@@ -215,7 +219,8 @@ function PersonaFilterChips({
               key={`st:${field}`}
               className="rounded-full border border-secondary/35 bg-secondary/10 px-2 py-0.5 text-[11px] text-secondary"
             >
-              {t("personaSetup.filters.stratify")} · {humanizeToken(field)}
+              {t("personaSetup.filters.stratify")} ·{" "}
+              {labels.dimLabel(field, humanizeToken(field))}
             </span>
           ))
         : null}
@@ -412,6 +417,7 @@ function TaskStrategySummary({
   onExpandedChange: (expanded: boolean) => void;
 }) {
   const { t } = useI18n();
+  const labels = useDimensionLabels();
   const sampling = readStrategySampling(strategy);
   const dimEntries = Object.entries(strategy.dimensionFilters ?? {}).filter(
     ([, values]) => Array.isArray(values) && values.length > 0,
@@ -448,7 +454,9 @@ function TaskStrategySummary({
                 : t("personaSetup.strategy.noFilters")}
               {stratify.length > 0
                 ? ` · ${t("personaSetup.strategy.stratifyFields", {
-                    fields: stratify.map(humanizeToken).join(" × "),
+                    fields: stratify
+                      .map((field) => labels.dimLabel(field, humanizeToken(field)))
+                      .join(" × "),
                   })}`
                 : ""}
             </p>
@@ -493,8 +501,8 @@ function TaskStrategySummary({
                 {dimEntries.map(([dim, values]) => (
                   <StrategyFilterValueChip
                     key={dim}
-                    label={humanizeToken(dim)}
-                    values={values}
+                    label={labels.dimLabel(dim, humanizeToken(dim))}
+                    values={values.map((value) => labels.valueLabel(dim, value))}
                     open={openFilterKey === dim}
                     onToggle={() =>
                       setOpenFilterKey((key) => (key === dim ? null : dim))
@@ -536,7 +544,7 @@ function TaskStrategySummary({
                     <div className="flex flex-wrap gap-1">
                       {stratify.map((field) => (
                         <span key={field} className={STRATEGY_STRATIFY_CHIP}>
-                          {humanizeToken(field)}
+                          {labels.dimLabel(field, humanizeToken(field))}
                         </span>
                       ))}
                     </div>

--- a/application/playground/frontend/src/lib/__tests__/dimensionLabels.test.ts
+++ b/application/playground/frontend/src/lib/__tests__/dimensionLabels.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { createDimensionLabelLookup } from "../dimensionLabels";
+import type { PersonaDimensionLabels } from "../types";
+
+const PACK: PersonaDimensionLabels = {
+  locale: "zh-Hans",
+  available: true,
+  reviewStatus: "machine-assisted",
+  dimensions: {
+    primary_language: {
+      label: "主要语言",
+      values: { Mandarin: "普通话", Swahili: "斯瓦希里语" },
+    },
+    age_bracket: {
+      // Values-only entry: label falls back to English.
+      values: { "25-34": "25–34岁" },
+    },
+  },
+  taxonomy: {
+    background: "背景",
+    demographics: "人口统计",
+  },
+};
+
+describe("createDimensionLabelLookup", () => {
+  it("is an inert English passthrough without a pack", () => {
+    for (const lookup of [
+      createDimensionLabelLookup(null),
+      createDimensionLabelLookup(undefined),
+      createDimensionLabelLookup({
+        locale: "ko",
+        available: false,
+        dimensions: {},
+      }),
+    ]) {
+      expect(lookup.active).toBe(false);
+      expect(lookup.dimLabel("primary_language", "Primary language")).toBe(
+        "Primary language",
+      );
+      expect(lookup.valueLabel("primary_language", "Mandarin")).toBe(
+        "Mandarin",
+      );
+      expect(lookup.taxonomyLabel("background", "Background")).toBe(
+        "Background",
+      );
+    }
+  });
+
+  it("returns translated labels and values when the pack has them", () => {
+    const lookup = createDimensionLabelLookup(PACK);
+    expect(lookup.active).toBe(true);
+    expect(lookup.dimLabel("primary_language", "Primary language")).toBe(
+      "主要语言",
+    );
+    expect(lookup.valueLabel("primary_language", "Mandarin")).toBe("普通话");
+    expect(lookup.valueLabel("age_bracket", "25-34")).toBe("25–34岁");
+    expect(lookup.taxonomyLabel("background", "Background")).toBe("背景");
+    expect(lookup.taxonomyLabel("demographics", "Demographics")).toBe(
+      "人口统计",
+    );
+  });
+
+  it("falls back to English for anything untranslated", () => {
+    const lookup = createDimensionLabelLookup(PACK);
+    // Untranslated value on a translated dimension.
+    expect(lookup.valueLabel("primary_language", "Hindi")).toBe("Hindi");
+    // Dimension absent from the pack entirely.
+    expect(lookup.dimLabel("region", "Region")).toBe("Region");
+    expect(lookup.valueLabel("region", "East Asia")).toBe("East Asia");
+    // Entry without a label keeps the English label.
+    expect(lookup.dimLabel("age_bracket", "Age bracket")).toBe("Age bracket");
+    expect(lookup.taxonomyLabel("career", "Career")).toBe("Career");
+  });
+
+  it("ignores packs whose dimensions object is empty", () => {
+    const lookup = createDimensionLabelLookup({
+      locale: "ja",
+      available: true,
+      dimensions: {},
+    });
+    expect(lookup.active).toBe(false);
+    expect(lookup.dimLabel("primary_language", "Primary language")).toBe(
+      "Primary language",
+    );
+  });
+});

--- a/application/playground/frontend/src/lib/api.ts
+++ b/application/playground/frontend/src/lib/api.ts
@@ -10,6 +10,7 @@ import type {
   HarborJobStatusResponse,
   HarborTrialEventsResponse,
   PersonaDatasetListResponse,
+  PersonaDimensionLabels,
   PersonaMatchAttributesResponse,
   PersonaPoolCatalog,
   PersonaPoolCardsResponse,
@@ -250,6 +251,10 @@ export const api = {
       method: "POST",
       body: JSON.stringify({ prompt, useLlm }),
     }),
+  getPersonaDimensionLabels: (locale: string) =>
+    request<PersonaDimensionLabels>(
+      `/api/persona-pool/dimension-labels?${new URLSearchParams({ locale }).toString()}`,
+    ),
   getPersonaPoolCards: async (input?: {
     pool?: string;
     limit?: number;

--- a/application/playground/frontend/src/lib/dimensionLabels.ts
+++ b/application/playground/frontend/src/lib/dimensionLabels.ts
@@ -1,0 +1,62 @@
+/**
+ * Display-label overlay for persona dimensions.
+ *
+ * Canonical dimension ids and enum values stay English everywhere data is
+ * stored, filtered, stratified, or scored. This module only swaps what the
+ * operator sees: when the UI locale has a committed label pack
+ * (persona/schema/labels/dimensions.labels.<locale>.json), lookups return the
+ * translated strings; anything untranslated falls back to English.
+ */
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { useI18n } from "@/i18n/I18nProvider";
+import { SOURCE_LOCALE } from "@/i18n/source";
+import { api } from "./api";
+import type { PersonaDimensionLabels } from "./types";
+
+export interface DimensionLabelLookup {
+  /** True when a non-English pack is loaded and non-empty. */
+  active: boolean;
+  /** Translated dimension label, or the given English fallback. */
+  dimLabel: (dimId: string, fallback: string) => string;
+  /** Translated enum value, or the raw English value. */
+  valueLabel: (dimId: string, value: string) => string;
+  /** Translated taxonomy group/subgroup title, or the English fallback. */
+  taxonomyLabel: (nodeId: string, fallback: string) => string;
+}
+
+export function createDimensionLabelLookup(
+  pack: PersonaDimensionLabels | null | undefined,
+): DimensionLabelLookup {
+  const dimensions = pack?.available ? pack.dimensions : undefined;
+  const taxonomy = pack?.available ? pack.taxonomy : undefined;
+  const active = Boolean(
+    (dimensions && Object.keys(dimensions).length > 0) ||
+      (taxonomy && Object.keys(taxonomy).length > 0),
+  );
+  return {
+    active,
+    dimLabel: (dimId, fallback) => dimensions?.[dimId]?.label || fallback,
+    valueLabel: (dimId, value) => dimensions?.[dimId]?.values?.[value] || value,
+    taxonomyLabel: (nodeId, fallback) => taxonomy?.[nodeId] || fallback,
+  };
+}
+
+/** Label overlay for the active UI locale; inert English passthrough otherwise. */
+export function useDimensionLabels(): DimensionLabelLookup {
+  const { locale } = useI18n();
+  const enabled = locale !== SOURCE_LOCALE;
+  const query = useQuery({
+    queryKey: ["persona-dimension-labels", locale],
+    queryFn: () => api.getPersonaDimensionLabels(locale),
+    enabled,
+    staleTime: Infinity,
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+  return useMemo(
+    () => createDimensionLabelLookup(enabled ? query.data : null),
+    [enabled, query.data],
+  );
+}

--- a/application/playground/frontend/src/lib/types.ts
+++ b/application/playground/frontend/src/lib/types.ts
@@ -974,6 +974,20 @@ export interface PersonaMatchAttributesResponse {
   usedLlm: boolean;
 }
 
+/** Translated display strings for one dimension (missing keys fall back to English). */
+export interface PersonaDimensionLabelEntry {
+  label?: string;
+  values?: Record<string, string>;
+}
+
+/** Display-label overlay for persona dimensions in one UI locale. */
+export interface PersonaDimensionLabels {
+  locale: string;
+  available: boolean;
+  reviewStatus?: string | null;
+  dimensions: Record<string, PersonaDimensionLabelEntry>;
+}
+
 export interface PersonaDatasetOption {
   pool: string;
   label: string;

--- a/application/playground/frontend/src/lib/types.ts
+++ b/application/playground/frontend/src/lib/types.ts
@@ -986,6 +986,8 @@ export interface PersonaDimensionLabels {
   available: boolean;
   reviewStatus?: string | null;
   dimensions: Record<string, PersonaDimensionLabelEntry>;
+  /** Layer-1 / Layer-2 filter accordion titles (Background, Demographics, …). */
+  taxonomy?: Record<string, string>;
 }
 
 export interface PersonaDatasetOption {

--- a/persona/schema/labels/README.md
+++ b/persona/schema/labels/README.md
@@ -1,0 +1,56 @@
+# Persona dimension label packs
+
+Locale-specific **display overlays** for `persona/schema/dimensions.json`.
+There is exactly one canonical dimension catalog — always English ids and
+values. A label pack only changes what operators *see* in the Playground
+(filter / stratify / cohort surfaces). Storage, sampling, filters, scoring, and
+the Treiver keep using English codes; missing translations fall back to the
+English strings at render time.
+
+```
+dimensions.json                      dimensions.labels.zh-Hans.json / zh-Hant.json
+---------------                      ------------------------------
+id: primary_language                 primary_language -> 主要语言
+values: [Mandarin, English, ...]     Mandarin -> 普通话
+```
+
+## Layout
+
+```
+persona/schema/labels/
+  build_labels.py                    # deterministic generator + validator
+  dimensions.labels.<locale>.json    # generated packs (committed)
+  sources/<locale>/
+    meta.json                        # {"reviewStatus": "reviewed" | "machine-assisted"}
+    dimensions.json                  # per-dimension {label, values} — no cross-dim sharing
+    taxonomy.json                    # optional Layer-1/2 accordion titles (Background, …)
+```
+
+Each dimension owns its own translations. A shared English token such as
+`None` is **not** copied across dimensions; translate it on `primary_language`
+and on a skill dimension separately if both need a localized display string.
+
+## Workflow
+
+```bash
+# regenerate one pack from its sources
+python persona/schema/labels/build_labels.py --locale ko
+
+# CI-style staleness check for every committed pack
+python persona/schema/labels/build_labels.py --all --check
+```
+
+Rules (enforced by the generator and `tests/unit/matraix/test_dimension_label_packs.py`):
+
+- every dimension id / value key in a pack must exist in `dimensions.json`;
+- packs record the `sha256` of `dimensions.json` (`sourceHash`) — a schema
+  change makes packs stale until regenerated;
+- regeneration from unchanged sources is byte-identical;
+- `reviewStatus` must be honest: `reviewed` only when a fluent speaker checked
+  the pack, otherwise `machine-assisted`;
+- untranslated entries are simply omitted — never pad with English copies or
+  invented enum values.
+
+Serving: the Playground backend exposes packs via
+`GET /api/persona-pool/dimension-labels?locale=<code>`; the frontend overlays
+them through `useDimensionLabels()` keyed off the active UI locale.

--- a/persona/schema/labels/build_labels.py
+++ b/persona/schema/labels/build_labels.py
@@ -1,0 +1,361 @@
+"""Build display-label packs for persona dimensions.
+
+A label pack is a locale-specific overlay on ``persona/schema/dimensions.json``:
+it translates dimension labels and enum values FOR DISPLAY ONLY. Canonical ids
+and values stay English everywhere data is stored, filtered, stratified, or
+scored. Missing translations fall back to the English strings at render time.
+
+Sources are **per dimension** — one dimension never inherits another
+dimension's value translations. ``None`` on a language field and ``None`` on a
+skill field are independent rows.
+
+Compact translation sources live under ``sources/<locale>/``:
+
+- ``meta.json``         — ``{"reviewStatus": "machine-assisted" | "reviewed"}``
+- ``dimensions.json``   — ``{"<dimension_id>": {"label": "...", "values":
+  {"<English value>": "<translation>"}}}``. Omit any key to fall back to English.
+- ``taxonomy.json``     — optional ``{"<group_or_subgroup_id>": "<label>"}`` for
+  Layer-1 / Layer-2 filter accordion titles (Background, Demographics, …).
+
+The generator copies these into ``dimensions.labels.<locale>.json`` in schema
+order and validates against ``dimensions.json``. Regenerating from unchanged
+sources is byte-identical, which CI enforces via ``--check``.
+
+Usage:
+    python persona/schema/labels/build_labels.py --locale ko
+    python persona/schema/labels/build_labels.py --all --check
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+FORMAT_VERSION = "1.0"
+GENERATOR = "persona/schema/labels/build_labels.py"
+SOURCE_CATALOG = "persona/schema/dimensions.json"
+PACK_NOTE = (
+    "Display overlay only. Dimension ids and value keys stay English; "
+    "never use translated strings for storage, filters, or scoring."
+)
+REVIEW_STATUSES = ("reviewed", "machine-assisted")
+
+# Layer-1 / Layer-2 taxonomy node ids from
+# ``application/playground/backend/service/persona_taxonomy.py`` (plus Other).
+TAXONOMY_NODE_IDS: frozenset[str] = frozenset(
+    {
+        "background",
+        "demographics",
+        "language",
+        "education",
+        "career",
+        "psychology",
+        "personality",
+        "worldview",
+        "decision_making",
+        "capability",
+        "domains",
+        "skills",
+        "behavior",
+        "personal_behavior",
+        "interaction_state",
+        "work_practices",
+        "technology_use",
+        "lifestyle",
+        "interests",
+        "culture",
+        "health",
+        "other",
+        "uncategorized",
+    }
+)
+
+LABELS_DIR = Path(__file__).resolve().parent
+REPO_ROOT = LABELS_DIR.parents[2]
+DEFAULT_SCHEMA_PATH = REPO_ROOT / SOURCE_CATALOG
+
+
+def file_sha256(path: Path) -> str:
+    return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def load_dimensions(schema_path: Path) -> tuple[dict[str, list[str]], str | None]:
+    """Return ``{dimension_id: [values...]}`` in schema order plus schemaVersion."""
+    payload = json.loads(schema_path.read_text(encoding="utf-8"))
+    dimensions: dict[str, list[str]] = {}
+    for row in payload.get("dimensions") or []:
+        if not isinstance(row, dict):
+            continue
+        dim_id = str(row.get("id") or "").strip()
+        if not dim_id:
+            continue
+        values = [str(v) for v in (row.get("values") or []) if str(v).strip()]
+        dimensions[dim_id] = values
+    return dimensions, payload.get("schemaVersion")
+
+
+def _read_optional_json(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def load_sources(sources_dir: Path) -> dict[str, Any]:
+    meta = _read_optional_json(sources_dir / "meta.json")
+    return {
+        "reviewStatus": str(meta.get("reviewStatus") or "machine-assisted"),
+        "dimensions": _read_optional_json(sources_dir / "dimensions.json"),
+        "taxonomy": _read_optional_json(sources_dir / "taxonomy.json"),
+    }
+
+
+def validate_sources(
+    dimensions: dict[str, list[str]], sources: dict[str, Any]
+) -> list[str]:
+    errors: list[str] = []
+
+    if sources["reviewStatus"] not in REVIEW_STATUSES:
+        errors.append(
+            f"meta.json reviewStatus must be one of {REVIEW_STATUSES}, "
+            f"got {sources['reviewStatus']!r}"
+        )
+
+    entries = sources["dimensions"]
+    if entries and not isinstance(entries, dict):
+        return errors + ["dimensions.json must contain an object keyed by dimension id"]
+
+    for dim_id, entry in entries.items():
+        if dim_id not in dimensions:
+            errors.append(f"dimensions.json: unknown dimension id {dim_id!r}")
+            continue
+        if not isinstance(entry, dict):
+            errors.append(f"dimensions.json: {dim_id!r} must map to an object")
+            continue
+        label = entry.get("label")
+        if label is not None and (not isinstance(label, str) or not label.strip()):
+            errors.append(f"dimensions.json: empty label for {dim_id!r}")
+        values = entry.get("values")
+        if values is None:
+            continue
+        if not isinstance(values, dict):
+            errors.append(f"dimensions.json: {dim_id!r}.values must be an object")
+            continue
+        allowed = set(dimensions[dim_id])
+        for value, translation in values.items():
+            if value not in allowed:
+                errors.append(f"dimensions.json: {dim_id!r} has no value {value!r}")
+            if not isinstance(translation, str) or not translation.strip():
+                errors.append(f"dimensions.json: empty translation for {dim_id}.{value}")
+
+    taxonomy = sources.get("taxonomy") or {}
+    if taxonomy and not isinstance(taxonomy, dict):
+        errors.append("taxonomy.json must contain an object keyed by taxonomy node id")
+    elif isinstance(taxonomy, dict):
+        for node_id, translation in taxonomy.items():
+            if node_id not in TAXONOMY_NODE_IDS:
+                errors.append(f"taxonomy.json: unknown node id {node_id!r}")
+                continue
+            if not isinstance(translation, str) or not translation.strip():
+                errors.append(f"taxonomy.json: empty label for {node_id!r}")
+
+    return errors
+
+
+def expand(
+    dimensions: dict[str, list[str]],
+    sources: dict[str, Any],
+    *,
+    locale: str,
+    schema_version: str | None,
+    source_hash: str,
+) -> dict[str, Any]:
+    """Copy per-dimension sources into a pack (schema order, deterministic).
+
+    Translations never leak across dimension ids. A value string that appears
+    on two dimensions must be translated on each dimension separately.
+    """
+    authored = sources["dimensions"]
+    packed: dict[str, Any] = {}
+    for dim_id, values in dimensions.items():
+        raw = authored.get(dim_id)
+        if not isinstance(raw, dict):
+            continue
+        entry: dict[str, Any] = {}
+        label = raw.get("label")
+        if isinstance(label, str) and label.strip() and label != dim_id:
+            entry["label"] = label
+        authored_values = raw.get("values") if isinstance(raw.get("values"), dict) else {}
+        translated_values: dict[str, str] = {}
+        for value in values:
+            translation = authored_values.get(value)
+            if (
+                isinstance(translation, str)
+                and translation.strip()
+                and translation != value
+            ):
+                translated_values[value] = translation
+        if translated_values:
+            entry["values"] = translated_values
+        if entry:
+            packed[dim_id] = entry
+
+    authored_taxonomy = sources.get("taxonomy") if isinstance(sources.get("taxonomy"), dict) else {}
+    taxonomy: dict[str, str] = {}
+    for node_id in sorted(TAXONOMY_NODE_IDS):
+        translation = authored_taxonomy.get(node_id)
+        if (
+            isinstance(translation, str)
+            and translation.strip()
+            and translation != node_id
+        ):
+            taxonomy[node_id] = translation
+
+    return {
+        "formatVersion": FORMAT_VERSION,
+        "locale": locale,
+        "reviewStatus": sources["reviewStatus"],
+        "generator": GENERATOR,
+        "sourceCatalog": SOURCE_CATALOG,
+        "sourceSchemaVersion": schema_version,
+        "sourceHash": source_hash,
+        "note": PACK_NOTE,
+        "dimensions": packed,
+        "taxonomy": taxonomy,
+    }
+
+
+def validate_pack(
+    dimensions: dict[str, list[str]],
+    pack: dict[str, Any],
+    *,
+    source_hash: str,
+) -> list[str]:
+    errors: list[str] = []
+    if pack.get("formatVersion") != FORMAT_VERSION:
+        errors.append(f"unsupported formatVersion {pack.get('formatVersion')!r}")
+    if pack.get("reviewStatus") not in REVIEW_STATUSES:
+        errors.append(f"invalid reviewStatus {pack.get('reviewStatus')!r}")
+    if pack.get("sourceHash") != source_hash:
+        errors.append(
+            "sourceHash does not match the current dimensions.json — regenerate "
+            "the pack against the updated schema"
+        )
+    packed = pack.get("dimensions")
+    if not isinstance(packed, dict):
+        return errors + ["pack is missing the dimensions object"]
+    for dim_id, entry in packed.items():
+        if dim_id not in dimensions:
+            errors.append(f"pack: unknown dimension id {dim_id!r}")
+            continue
+        if not isinstance(entry, dict):
+            errors.append(f"pack: {dim_id!r} must map to an object")
+            continue
+        allowed = set(dimensions[dim_id])
+        for value in entry.get("values") or {}:
+            if value not in allowed:
+                errors.append(f"pack: {dim_id!r} has no value {value!r}")
+    taxonomy = pack.get("taxonomy")
+    if taxonomy is None:
+        taxonomy = {}
+    if not isinstance(taxonomy, dict):
+        errors.append("pack taxonomy must be an object")
+    else:
+        for node_id, translation in taxonomy.items():
+            if node_id not in TAXONOMY_NODE_IDS:
+                errors.append(f"pack: unknown taxonomy node id {node_id!r}")
+            if not isinstance(translation, str) or not translation.strip():
+                errors.append(f"pack: empty taxonomy label for {node_id!r}")
+    return errors
+
+
+def serialize(pack: dict[str, Any]) -> str:
+    return json.dumps(pack, ensure_ascii=False, indent=2) + "\n"
+
+
+def build_locale(
+    locale: str,
+    *,
+    labels_dir: Path = LABELS_DIR,
+    schema_path: Path = DEFAULT_SCHEMA_PATH,
+) -> tuple[Path, str]:
+    """Return (pack path, serialized pack) for one locale, validating sources."""
+    sources_dir = labels_dir / "sources" / locale
+    if not sources_dir.is_dir():
+        raise FileNotFoundError(f"no translation sources at {sources_dir}")
+    dimensions, schema_version = load_dimensions(schema_path)
+    sources = load_sources(sources_dir)
+    errors = validate_sources(dimensions, sources)
+    if errors:
+        raise ValueError(
+            f"invalid sources for {locale!r}:\n" + "\n".join(f"- {e}" for e in errors)
+        )
+    source_hash = file_sha256(schema_path)
+    pack = expand(
+        dimensions,
+        sources,
+        locale=locale,
+        schema_version=schema_version,
+        source_hash=source_hash,
+    )
+    return labels_dir / f"dimensions.labels.{locale}.json", serialize(pack)
+
+
+def discover_locales(labels_dir: Path = LABELS_DIR) -> list[str]:
+    sources_root = labels_dir / "sources"
+    if not sources_root.is_dir():
+        return []
+    return sorted(p.name for p in sources_root.iterdir() if p.is_dir())
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--locale", help="build one locale (e.g. ko, ja, pt-BR, es)")
+    parser.add_argument(
+        "--all", action="store_true", help="build every locale under sources/"
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="verify committed packs are byte-identical to regenerated output",
+    )
+    parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA_PATH)
+    parser.add_argument("--labels-dir", type=Path, default=LABELS_DIR)
+    args = parser.parse_args(argv)
+
+    locales = (
+        discover_locales(args.labels_dir)
+        if args.all
+        else ([args.locale] if args.locale else [])
+    )
+    if not locales:
+        parser.error("pass --locale <code> or --all")
+
+    failures = 0
+    for locale in locales:
+        pack_path, text = build_locale(
+            locale, labels_dir=args.labels_dir, schema_path=args.schema
+        )
+        if args.check:
+            current = (
+                pack_path.read_text(encoding="utf-8") if pack_path.is_file() else None
+            )
+            if current != text:
+                print(f"STALE {pack_path} — rerun the generator", file=sys.stderr)
+                failures += 1
+            else:
+                print(f"OK {pack_path}")
+        else:
+            pack_path.write_text(text, encoding="utf-8")
+            print(f"WROTE {pack_path}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/matraix/test_dimension_label_packs.py
+++ b/tests/unit/matraix/test_dimension_label_packs.py
@@ -1,0 +1,168 @@
+"""Dimension label packs: per-dimension sources and schema alignment."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+LABELS_DIR = REPO_ROOT / "persona" / "schema" / "labels"
+SCHEMA_PATH = REPO_ROOT / "persona" / "schema" / "dimensions.json"
+
+_spec = importlib.util.spec_from_file_location(
+    "build_labels", LABELS_DIR / "build_labels.py"
+)
+build_labels = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(build_labels)
+
+
+def _write_sources(
+    sources_dir: Path,
+    *,
+    dimensions: dict | None = None,
+    taxonomy: dict | None = None,
+    review_status: str = "machine-assisted",
+) -> None:
+    sources_dir.mkdir(parents=True)
+    (sources_dir / "meta.json").write_text(
+        json.dumps({"reviewStatus": review_status}), encoding="utf-8"
+    )
+    if dimensions is not None:
+        (sources_dir / "dimensions.json").write_text(
+            json.dumps(dimensions, ensure_ascii=False), encoding="utf-8"
+        )
+    if taxonomy is not None:
+        (sources_dir / "taxonomy.json").write_text(
+            json.dumps(taxonomy, ensure_ascii=False), encoding="utf-8"
+        )
+
+
+def test_expand_keeps_translations_on_their_own_dimension(tmp_path: Path) -> None:
+    _write_sources(
+        tmp_path / "sources" / "xx",
+        dimensions={
+            "primary_language": {
+                "label": "主要语言",
+                "values": {
+                    "Mandarin": "普通话",
+                    "English": "English",
+                    "Swahili": "斯瓦希里语",
+                },
+            }
+        },
+    )
+    pack_path, text = build_labels.build_locale(
+        "xx", labels_dir=tmp_path, schema_path=SCHEMA_PATH
+    )
+    assert pack_path == tmp_path / "dimensions.labels.xx.json"
+    pack = json.loads(text)
+
+    entry = pack["dimensions"]["primary_language"]
+    assert entry["label"] == "主要语言"
+    assert entry["values"]["Mandarin"] == "普通话"
+    assert entry["values"]["Swahili"] == "斯瓦希里语"
+    assert "English" not in entry["values"]
+    assert "Hindi" not in entry["values"]
+    # A shared English token on another dimension is not filled in.
+    assert "english_proficiency" not in pack["dimensions"]
+
+    assert pack["locale"] == "xx"
+    assert pack["reviewStatus"] == "machine-assisted"
+    assert pack["sourceHash"] == build_labels.file_sha256(SCHEMA_PATH)
+
+
+def test_same_english_value_can_differ_per_dimension(tmp_path: Path) -> None:
+    catalog, _ = build_labels.load_dimensions(SCHEMA_PATH)
+    none_dims = [dim_id for dim_id, values in catalog.items() if "None" in values]
+    assert len(none_dims) >= 2
+    first, second = none_dims[0], none_dims[1]
+    _write_sources(
+        tmp_path / "sources" / "xx",
+        dimensions={
+            first: {"values": {"None": "不会"}},
+            second: {"values": {"None": "无"}},
+        },
+    )
+    _, text = build_labels.build_locale(
+        "xx", labels_dir=tmp_path, schema_path=SCHEMA_PATH
+    )
+    pack = json.loads(text)
+    assert pack["dimensions"][first]["values"]["None"] == "不会"
+    assert pack["dimensions"][second]["values"]["None"] == "无"
+
+
+def test_sources_reject_unknown_ids_and_values(tmp_path: Path) -> None:
+    _write_sources(
+        tmp_path / "sources" / "xx",
+        dimensions={
+            "not_a_dimension": {"label": "x"},
+            "primary_language": {"values": {"Klingon": "x"}},
+        },
+    )
+    with pytest.raises(ValueError) as excinfo:
+        build_labels.build_locale("xx", labels_dir=tmp_path, schema_path=SCHEMA_PATH)
+    message = str(excinfo.value)
+    assert "unknown dimension id 'not_a_dimension'" in message
+    assert "has no value 'Klingon'" in message
+
+
+def test_expansion_is_deterministic(tmp_path: Path) -> None:
+    _write_sources(
+        tmp_path / "sources" / "xx",
+        dimensions={"age_bracket": {"label": "年龄段", "values": {"18-24": "18–24 岁"}}},
+    )
+    _, first = build_labels.build_locale(
+        "xx", labels_dir=tmp_path, schema_path=SCHEMA_PATH
+    )
+    _, second = build_labels.build_locale(
+        "xx", labels_dir=tmp_path, schema_path=SCHEMA_PATH
+    )
+    assert first == second
+
+
+def test_taxonomy_labels_are_packed(tmp_path: Path) -> None:
+    _write_sources(
+        tmp_path / "sources" / "xx",
+        dimensions={"age_bracket": {"label": "年龄段"}},
+        taxonomy={"background": "背景", "demographics": "人口统计"},
+    )
+    _, text = build_labels.build_locale(
+        "xx", labels_dir=tmp_path, schema_path=SCHEMA_PATH
+    )
+    pack = json.loads(text)
+    assert pack["taxonomy"]["background"] == "背景"
+    assert pack["taxonomy"]["demographics"] == "人口统计"
+    assert "career" not in pack["taxonomy"]
+
+
+def test_taxonomy_rejects_unknown_ids(tmp_path: Path) -> None:
+    _write_sources(
+        tmp_path / "sources" / "xx",
+        taxonomy={"not_a_node": "x"},
+    )
+    with pytest.raises(ValueError) as excinfo:
+        build_labels.build_locale("xx", labels_dir=tmp_path, schema_path=SCHEMA_PATH)
+    assert "unknown node id 'not_a_node'" in str(excinfo.value)
+
+
+def test_committed_packs_are_valid_and_fresh() -> None:
+    """Every committed pack matches the schema and its own sources exactly."""
+    dimensions, _ = build_labels.load_dimensions(SCHEMA_PATH)
+    source_hash = build_labels.file_sha256(SCHEMA_PATH)
+    for pack_path in sorted(LABELS_DIR.glob("dimensions.labels.*.json")):
+        pack = json.loads(pack_path.read_text(encoding="utf-8"))
+        errors = build_labels.validate_pack(dimensions, pack, source_hash=source_hash)
+        assert not errors, f"{pack_path.name}: {errors}"
+
+        locale = pack["locale"]
+        regenerated_path, regenerated = build_labels.build_locale(
+            locale, labels_dir=LABELS_DIR, schema_path=SCHEMA_PATH
+        )
+        assert regenerated_path == pack_path
+        assert regenerated == pack_path.read_text(encoding="utf-8"), (
+            f"{pack_path.name} is stale — rerun "
+            f"python persona/schema/labels/build_labels.py --locale {locale}"
+        )


### PR DESCRIPTION
## Summary
- Adds deterministic dimension **label pack** infrastructure (`persona/schema/labels/build_labels.py`, sources layout, `--check`).
- Backend: `GET /api/persona-pool/dimension-labels?locale=…` (display overlay only).
- Frontend: `useDimensionLabels()` wired into filter / stratify / cohort / persona card & detail.
- Canonical English dimension ids/values remain the storage & sampling contract.

No locale message packs and no attribute-search changes in this PR. Label **content** packs (`zh-Hans` / `zh-Hant` / …) follow in a stacked PR.

## Test plan
- [ ] `pytest tests/unit/matraix/test_dimension_label_packs.py`
- [ ] Playground backend tests for `get_dimension_labels`
- [ ] With a temporary pack file present, switch UI locale and confirm filter/card values localize; without a pack, English fallback

Refs #66

Made with [Cursor](https://cursor.com)