### PR TITLE
ci: add i18n auto-label for locale and label-pack paths

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -36,3 +36,10 @@
       - any-glob-to-any-file:
           - docs/migration/**
           - migration/matraix/**
+
+"i18n":
+  - changed-files:
+      - any-glob-to-any-file:
+          - application/playground/frontend/src/i18n/**
+          - persona/schema/labels/**
+          - docs/i18n/**


### PR DESCRIPTION
## Summary
- Adds GitHub label **`i18n`** usage via `.github/labeler.yml` for:
  - `application/playground/frontend/src/i18n/**`
  - `persona/schema/labels/**`
  - `docs/i18n/**`
- Supports the open localization-fix call on #66.

## Test plan
- [ ] Open a tiny PR touching only an i18n path and confirm `i18n` is applied

Refs #66

Made with [Cursor](https://cursor.com)