### PR TITLE
feat(playground): add Gemini, xAI, DeepSeek, and Z.ai persona providers

### DIFF
--- a/application/playground/.env.local.example
+++ b/application/playground/.env.local.example
@@ -28,6 +28,30 @@ ANTHROPIC_API_KEY=sk-ant-your-key-here
 # MATRIX_PERSONA_MODEL=openai/gpt-4o-mini
 # MATRIX_PERSONA_MODEL=dashscope/qwen3.6-plus-2026-04-02
 # MATRIX_PERSONA_MODEL=dashscope/deepseek-v4-pro
+# MATRIX_PERSONA_MODEL=gemini/gemini-2.5-flash
+# MATRIX_PERSONA_MODEL=xai/grok-4.5
+# MATRIX_PERSONA_MODEL=deepseek/deepseek-v4-pro
+# MATRIX_PERSONA_MODEL=zai/glm-4.7
+
+# --- Gemini official API (optional) ------------------------------------------
+# Required when selecting gemini/* persona models.
+# GEMINI_API_KEY=your-gemini-key-here
+# GEMINI_API_BASE=https://generativelanguage.googleapis.com/v1beta/openai/
+
+# --- xAI official API (optional) ---------------------------------------------
+# Required when selecting xai/* persona models.
+# XAI_API_KEY=your-xai-key-here
+# XAI_API_BASE=https://api.x.ai/v1
+
+# --- DeepSeek official API (optional) ----------------------------------------
+# Required when selecting deepseek/* persona models (not dashscope/deepseek-*).
+# DEEPSEEK_API_KEY=sk-your-deepseek-key-here
+# DEEPSEEK_API_BASE=https://api.deepseek.com
+
+# --- Z.ai official GLM API (optional) ----------------------------------------
+# Required when selecting zai/* persona models (not openrouter/z-ai/*).
+# ZAI_API_KEY=your-z-ai-key-here
+# ZAI_API_BASE=https://api.z.ai/api/paas/v4
 
 # --- CLI harness subscription auth (optional) --------------------------------
 # Default for persona-claude-code / persona-codex / persona-gemini-cli is API

--- a/application/playground/backend/api/app.py
+++ b/application/playground/backend/api/app.py
@@ -284,7 +284,7 @@ def preflight_checks() -> List[Dict[str, Any]]:
     **Required** (block platform ready)
 
     * Model credentials — at least one of OpenAI / Anthropic / DashScope
-      / OpenRouter
+      / OpenRouter / Gemini / xAI / DeepSeek / Z.ai
       (every survey / chat / web / os-app run needs a persona or agent model).
     * Survey forms / Web tasks — surfaces are always available in-process.
 
@@ -310,6 +310,10 @@ def preflight_checks() -> List[Dict[str, Any]]:
     )
     dashscope_key = bool(os.environ.get("DASHSCOPE_API_KEY"))
     openrouter_key = bool(os.environ.get("OPENROUTER_API_KEY"))
+    gemini_key = bool(os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY"))
+    xai_key = bool(os.environ.get("XAI_API_KEY"))
+    deepseek_key = bool(os.environ.get("DEEPSEEK_API_KEY"))
+    zai_key = bool(os.environ.get("ZAI_API_KEY"))
     configured = [
         label
         for label, present in (
@@ -317,6 +321,10 @@ def preflight_checks() -> List[Dict[str, Any]]:
             ("Anthropic", anthropic_key),
             ("DashScope", dashscope_key),
             ("OpenRouter", openrouter_key),
+            ("Gemini", gemini_key),
+            ("xAI", xai_key),
+            ("DeepSeek", deepseek_key),
+            ("Z.ai", zai_key),
         )
         if present
     ]
@@ -328,8 +336,9 @@ def preflight_checks() -> List[Dict[str, Any]]:
             "detail": (
                 "Configured: {}.".format(", ".join(configured))
                 if configured
-                else "Not configured. Set OpenAI, Anthropic, DashScope, or "
-                "OpenRouter credentials to run application tasks."
+                else "Not configured. Set OpenAI, Anthropic, DashScope, "
+                "OpenRouter, Gemini, xAI, DeepSeek, or Z.ai credentials "
+                "to run application tasks."
             ),
         }
     )
@@ -383,6 +392,58 @@ def preflight_checks() -> List[Dict[str, Any]]:
                 "Configured."
                 if openrouter_key
                 else "Not configured. Needed only for OpenRouter persona models."
+            ),
+        }
+    )
+    checks.append(
+        {
+            "group": "Core",
+            "name": "Gemini credentials",
+            "ok": gemini_key,
+            "optional": True,
+            "detail": (
+                "Configured. Used by Gemini persona models."
+                if gemini_key
+                else "Not configured. Needed only for Gemini persona models."
+            ),
+        }
+    )
+    checks.append(
+        {
+            "group": "Core",
+            "name": "xAI credentials",
+            "ok": xai_key,
+            "optional": True,
+            "detail": (
+                "Configured. Used by Grok persona models."
+                if xai_key
+                else "Not configured. Needed only for Grok persona models."
+            ),
+        }
+    )
+    checks.append(
+        {
+            "group": "Core",
+            "name": "DeepSeek credentials",
+            "ok": deepseek_key,
+            "optional": True,
+            "detail": (
+                "Configured. Used by official DeepSeek persona models."
+                if deepseek_key
+                else "Not configured. Needed only for official DeepSeek persona models."
+            ),
+        }
+    )
+    checks.append(
+        {
+            "group": "Core",
+            "name": "Z.ai credentials",
+            "ok": zai_key,
+            "optional": True,
+            "detail": (
+                "Configured. Used by official GLM persona models."
+                if zai_key
+                else "Not configured. Needed only for official GLM persona models."
             ),
         }
     )

--- a/application/playground/backend/service/config.py
+++ b/application/playground/backend/service/config.py
@@ -28,8 +28,8 @@ REMOTE_RUNNER_API_URL_ENV = "REMOTE_RUNNER_API_URL"
 DEFAULT_PERSONA_MODEL = "anthropic/claude-haiku-4-5"
 
 # Persona-model IDs use LiteLLM provider prefixes (``anthropic/``, ``openai/``,
-# ``dashscope/``, ``openrouter/``). OpenAI-compatible providers use their own
-# credentials and endpoints.
+# ``gemini/``, ``xai/``, ``deepseek/``, ``zai/``, ``dashscope/``, ``openrouter/``).
+# OpenAI-compatible providers use their own credentials and endpoints.
 PERSONA_MODEL_KNOB_META: Dict[str, Dict[str, str]] = {
     "anthropic/claude-haiku-4-5": {
         "label": "Claude Haiku 4.5",
@@ -58,6 +58,42 @@ PERSONA_MODEL_KNOB_META: Dict[str, Dict[str, str]] = {
     "openai/gpt-5.5": {
         "label": "GPT-5.5",
         "description": "OpenAI computer-use CUA (default OpenAI desktop CUA model).",
+    },
+    "gemini/gemini-2.5-flash": {
+        "label": "Gemini 2.5 Flash",
+        "description": "Google persona simulation with lower cost.",
+    },
+    "gemini/gemini-2.5-pro": {
+        "label": "Gemini 2.5 Pro",
+        "description": "Google persona simulation with stronger reasoning.",
+    },
+    "gemini/gemini-2.5-computer-use-preview-10-2025": {
+        "label": "Gemini 2.5 Computer Use",
+        "description": "Google computer-use CUA (macOS/Linux desktop).",
+    },
+    "xai/grok-4.5": {
+        "label": "Grok 4.5",
+        "description": "xAI flagship persona simulation.",
+    },
+    "xai/grok-3-mini": {
+        "label": "Grok 3 Mini",
+        "description": "xAI lower-cost persona simulation.",
+    },
+    "deepseek/deepseek-v4-pro": {
+        "label": "DeepSeek V4 Pro",
+        "description": "DeepSeek official API flagship.",
+    },
+    "deepseek/deepseek-chat": {
+        "label": "DeepSeek Chat",
+        "description": "DeepSeek official API chat alias.",
+    },
+    "zai/glm-5": {
+        "label": "GLM 5",
+        "description": "Z.ai official GLM flagship.",
+    },
+    "zai/glm-4.7": {
+        "label": "GLM 4.7",
+        "description": "Z.ai official GLM 4.7.",
     },
     "dashscope/qwen3.6-plus-2026-04-02": {
         "label": "Qwen 3.6 Plus · Apr 2026",

--- a/application/playground/backend/tests/test_api.py
+++ b/application/playground/backend/tests/test_api.py
@@ -33,6 +33,10 @@ def test_preflight_shape(client):
         "Anthropic credentials",
         "DashScope (Qwen / DeepSeek)",
         "OpenRouter",
+        "Gemini credentials",
+        "xAI credentials",
+        "DeepSeek credentials",
+        "Z.ai credentials",
         "OpenBB (finance)",
         "Meal planning",
         "Acme support API",
@@ -63,6 +67,10 @@ def test_preflight_required_vs_optional_contract(client):
         "Anthropic credentials",
         "DashScope (Qwen / DeepSeek)",
         "OpenRouter",
+        "Gemini credentials",
+        "xAI credentials",
+        "DeepSeek credentials",
+        "Z.ai credentials",
         "OpenBB (finance)",
         "Meal planning",
         "Acme support API",
@@ -82,6 +90,11 @@ def test_preflight_does_not_leak_env_var_names(client):
         "CLAUDE_API_KEY",
         "DASHSCOPE_API_KEY",
         "OPENROUTER_API_KEY",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "XAI_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "ZAI_API_KEY",
         "USE_COMPUTER_API_KEY",
         "INTERECAGENT_ROOT",
         "INTERECAGENT_CATALOG_PATH",
@@ -98,6 +111,11 @@ def test_preflight_model_credentials_any_provider(client, monkeypatch):
     monkeypatch.delenv("CLAUDE_API_KEY", raising=False)
     monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    monkeypatch.delenv("ZAI_API_KEY", raising=False)
     body = client.get("/api/preflight").json()
     model = next(c for c in body["checks"] if c["name"] == "Model credentials")
     assert model["ok"] is False
@@ -136,6 +154,59 @@ def test_preflight_openrouter_check_optional(client, monkeypatch):
     body = client.get("/api/preflight").json()
     openrouter = next(c for c in body["checks"] if c["name"] == "OpenRouter")
     assert openrouter["ok"] is True
+
+
+def test_preflight_gemini_check_optional(client, monkeypatch):
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    body = client.get("/api/preflight").json()
+    gemini = next(c for c in body["checks"] if c["name"] == "Gemini credentials")
+    assert gemini["ok"] is False
+    assert gemini.get("optional") is True
+
+    monkeypatch.setenv("GEMINI_API_KEY", "sk-test")
+    body = client.get("/api/preflight").json()
+    gemini = next(c for c in body["checks"] if c["name"] == "Gemini credentials")
+    assert gemini["ok"] is True
+
+
+def test_preflight_xai_check_optional(client, monkeypatch):
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    body = client.get("/api/preflight").json()
+    xai = next(c for c in body["checks"] if c["name"] == "xAI credentials")
+    assert xai["ok"] is False
+    assert xai.get("optional") is True
+
+    monkeypatch.setenv("XAI_API_KEY", "sk-test")
+    body = client.get("/api/preflight").json()
+    xai = next(c for c in body["checks"] if c["name"] == "xAI credentials")
+    assert xai["ok"] is True
+
+
+def test_preflight_deepseek_check_optional(client, monkeypatch):
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    body = client.get("/api/preflight").json()
+    deepseek = next(c for c in body["checks"] if c["name"] == "DeepSeek credentials")
+    assert deepseek["ok"] is False
+    assert deepseek.get("optional") is True
+
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-test")
+    body = client.get("/api/preflight").json()
+    deepseek = next(c for c in body["checks"] if c["name"] == "DeepSeek credentials")
+    assert deepseek["ok"] is True
+
+
+def test_preflight_zai_check_optional(client, monkeypatch):
+    monkeypatch.delenv("ZAI_API_KEY", raising=False)
+    body = client.get("/api/preflight").json()
+    zai = next(c for c in body["checks"] if c["name"] == "Z.ai credentials")
+    assert zai["ok"] is False
+    assert zai.get("optional") is True
+
+    monkeypatch.setenv("ZAI_API_KEY", "sk-test")
+    body = client.get("/api/preflight").json()
+    zai = next(c for c in body["checks"] if c["name"] == "Z.ai credentials")
+    assert zai["ok"] is True
 
 
 def test_preflight_anthropic_check_optional(client, monkeypatch):

--- a/application/playground/backend/tests/test_config.py
+++ b/application/playground/backend/tests/test_config.py
@@ -71,6 +71,15 @@ def test_options_knob_values_match_allowed(config_manager):
     assert "openrouter/anthropic/claude-haiku-4.5" in PERSONA_MODEL_OPTIONS
     assert "openai/gpt-5.4" in PERSONA_MODEL_OPTIONS
     assert "openai/gpt-5.5" in PERSONA_MODEL_OPTIONS
+    assert "gemini/gemini-2.5-flash" in PERSONA_MODEL_OPTIONS
+    assert "gemini/gemini-2.5-pro" in PERSONA_MODEL_OPTIONS
+    assert "gemini/gemini-2.5-computer-use-preview-10-2025" in PERSONA_MODEL_OPTIONS
+    assert "xai/grok-4.5" in PERSONA_MODEL_OPTIONS
+    assert "xai/grok-3-mini" in PERSONA_MODEL_OPTIONS
+    assert "deepseek/deepseek-v4-pro" in PERSONA_MODEL_OPTIONS
+    assert "deepseek/deepseek-chat" in PERSONA_MODEL_OPTIONS
+    assert "zai/glm-5" in PERSONA_MODEL_OPTIONS
+    assert "zai/glm-4.7" in PERSONA_MODEL_OPTIONS
 
 
 def test_preflight_recognizes_openrouter_credentials(client, monkeypatch):
@@ -79,6 +88,11 @@ def test_preflight_recognizes_openrouter_credentials(client, monkeypatch):
     monkeypatch.delenv("CLAUDE_API_KEY", raising=False)
     monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    monkeypatch.delenv("ZAI_API_KEY", raising=False)
 
     body = client.get("/api/preflight").json()
     model = next(c for c in body["checks"] if c["name"] == "Model credentials")

--- a/application/playground/frontend/src/components/cockpit/setup/useSetupPersonaSampling.ts
+++ b/application/playground/frontend/src/components/cockpit/setup/useSetupPersonaSampling.ts
@@ -7,6 +7,7 @@ import { useUrlState } from "@/lib/useUrlState";
 import type { HarborCockpitTaskKind } from "@/lib/harborCockpitMappers";
 import type { ConfigOptionsResponse, PlaygroundPersona, TaskPersonaStrategy } from "@/lib/types";
 import { PERSONA_BENCH_POOL } from "@/lib/types";
+import { personaModelProviderLabel } from "@/lib/personaAgentCatalog";
 
 import {
   defaultPersonaSetup,
@@ -42,17 +43,6 @@ function applyPersonaHandoffToSetup(
     useTaskDefaultStrategy: false,
     taskDefaultStrategyDismissed: true,
   };
-}
-
-const PERSONA_MODEL_PROVIDER_LABELS: Record<string, string> = {
-  anthropic: "Anthropic",
-  dashscope: "DashScope",
-  openai: "OpenAI",
-  openrouter: "OpenRouter",
-};
-
-function personaModelProviderLabel(modelId: string): string | undefined {
-  return PERSONA_MODEL_PROVIDER_LABELS[modelId.split("/", 1)[0]];
 }
 
 export function useSetupPersonaSampling(
@@ -425,13 +415,12 @@ export function useSetupPersonaSampling(
     samplingMode !== "single" || selectedCount > 1 || selectedPersonaIds.length > 1;
 
   const personaModelKnob = options?.knobs.find((k) => k.key === "personaModel");
-  // Provider meta only in the open menu (closed trigger stays label-only).
-  // Omit summary — long descriptions clutter the compact Persona rail.
+  // Grouped by provider in the open menu. Omit summary — descriptions clutter the rail.
   const personaModelOptions =
     personaModelKnob?.options.map((o) => ({
       value: o.value,
       label: o.label,
-      meta: personaModelProviderLabel(o.value),
+      group: personaModelProviderLabel(o.value),
     })) ?? [{ value: personaModel, label: personaModel }];
 
   const togglePersona = useCallback(

--- a/application/playground/frontend/src/lib/personaAgentCatalog.ts
+++ b/application/playground/frontend/src/lib/personaAgentCatalog.ts
@@ -335,12 +335,25 @@ const OPENAI_CUA_MODELS = new Set(["openai/gpt-5.4", "openai/gpt-5.5"]);
 
 function isCuaCapablePersonaModel(modelId: string, platform: string): boolean {
   if (modelId.startsWith("anthropic/")) return true;
+  const isGeminiChat =
+    modelId.startsWith("gemini/") && !modelId.includes("computer-use");
+  const isGeminiCu =
+    modelId.startsWith("gemini/") && modelId.includes("computer-use");
   if (platform === "ios") {
-    // IOSAgent is litellm-backed and accepts any vision-capable chat model.
-    return modelId.startsWith("openai/") || modelId.startsWith("gemini/");
+    // IOSAgent is litellm-backed and accepts vision-capable chat models.
+    if (isGeminiCu) return false;
+    return (
+      modelId.startsWith("openai/") ||
+      isGeminiChat ||
+      modelId.startsWith("dashscope/") ||
+      modelId.startsWith("openrouter/") ||
+      modelId.startsWith("xai/") ||
+      modelId.startsWith("deepseek/") ||
+      modelId.startsWith("zai/")
+    );
   }
-  // macOS / Linux desktop: native CUA providers only.
-  return OPENAI_CUA_MODELS.has(modelId) || modelId.startsWith("gemini/");
+  // macOS desktop: native CUA providers only (Anthropic / OpenAI CU / Gemini CU).
+  return OPENAI_CUA_MODELS.has(modelId) || isGeminiCu;
 }
 
 /** Platform-aware agent model list for the Persona rail. */
@@ -352,7 +365,11 @@ export function cuaPersonaModelSelectOptions(
   if (normalized === "macos" || normalized === "ios") {
     return options.filter((opt) => isCuaCapablePersonaModel(opt.value, normalized));
   }
-  return options;
+  // Linux desktop: generic JSON harness for most models. Native Gemini CUA
+  // only accepts computer-use models — other gemini/* raise at provider resolve.
+  return options.filter(
+    (opt) => !opt.value.startsWith("gemini/") || opt.value.includes("computer-use"),
+  );
 }
 
 /** Short pipeline subtitle for the Persona node (mirrors the Persona model selector). */
@@ -365,4 +382,21 @@ export function personaModelPipelineLabel(
   if (match) return match.label;
   const slash = modelId.lastIndexOf("/");
   return slash >= 0 ? modelId.slice(slash + 1) : modelId;
+}
+
+const PERSONA_MODEL_PROVIDER_LABELS: Record<string, string> = {
+  anthropic: "Anthropic",
+  dashscope: "DashScope",
+  gemini: "Google",
+  google: "Google",
+  openai: "OpenAI",
+  openrouter: "OpenRouter",
+  xai: "xAI",
+  deepseek: "DeepSeek",
+  zai: "Z.ai",
+};
+
+/** Provider section for the persona-model picker (`anthropic/claude-…` → Anthropic). */
+export function personaModelProviderLabel(modelId: string): string {
+  return PERSONA_MODEL_PROVIDER_LABELS[modelId.split("/", 1)[0]] ?? "Other";
 }

--- a/environment/agents/matraix/agents/installed/browser_use.py
+++ b/environment/agents/matraix/agents/installed/browser_use.py
@@ -150,10 +150,19 @@ class BrowserUseHarborAgent(BaseInstalledAgent):
                 "OPENAI_API_KEY",
                 "LLM_API_KEY",
                 "DASHSCOPE_API_KEY",
+                "GEMINI_API_KEY",
+                "GOOGLE_API_KEY",
+                "OPENROUTER_API_KEY",
+                "XAI_API_KEY",
+                "DEEPSEEK_API_KEY",
+                "ZAI_API_KEY",
             )
         ):
             raise ValueError(
-                "Set ANTHROPIC_API_KEY, OPENAI_API_KEY, DASHSCOPE_API_KEY, or LLM_API_KEY for browser-use"
+                "Set ANTHROPIC_API_KEY, OPENAI_API_KEY, DASHSCOPE_API_KEY, "
+                "GEMINI_API_KEY, OPENROUTER_API_KEY, XAI_API_KEY, "
+                "DEEPSEEK_API_KEY, ZAI_API_KEY, or LLM_API_KEY "
+                "for browser-use"
             )
 
         llm_api_key = self._get_env("LLM_API_KEY")
@@ -162,11 +171,28 @@ class BrowserUseHarborAgent(BaseInstalledAgent):
             and "ANTHROPIC_API_KEY" not in env
             and "OPENAI_API_KEY" not in env
             and "DASHSCOPE_API_KEY" not in env
+            and "GEMINI_API_KEY" not in env
+            and "OPENROUTER_API_KEY" not in env
+            and "XAI_API_KEY" not in env
+            and "DEEPSEEK_API_KEY" not in env
+            and "ZAI_API_KEY" not in env
         ):
             if self.model_name.startswith("anthropic/"):
                 env["ANTHROPIC_API_KEY"] = llm_api_key
             elif self.model_name.startswith("dashscope/"):
                 env["DASHSCOPE_API_KEY"] = llm_api_key
+            elif self.model_name.startswith("gemini/") or self.model_name.startswith(
+                "google/"
+            ):
+                env["GEMINI_API_KEY"] = llm_api_key
+            elif self.model_name.startswith("openrouter/"):
+                env["OPENROUTER_API_KEY"] = llm_api_key
+            elif self.model_name.startswith("xai/"):
+                env["XAI_API_KEY"] = llm_api_key
+            elif self.model_name.startswith("deepseek/"):
+                env["DEEPSEEK_API_KEY"] = llm_api_key
+            elif self.model_name.startswith("zai/"):
+                env["ZAI_API_KEY"] = llm_api_key
             else:
                 env["OPENAI_API_KEY"] = llm_api_key
 

--- a/environment/agents/matraix/agents/installed/browser_use_runner.py
+++ b/environment/agents/matraix/agents/installed/browser_use_runner.py
@@ -38,6 +38,19 @@ def _create_llm(model: str):
 
     from browser_use import ChatOpenAI
 
+    if provider in ("gemini", "google"):
+        api_key = (
+            os.environ.get("GEMINI_API_KEY")
+            or os.environ.get("GOOGLE_API_KEY")
+            or os.environ.get("LLM_API_KEY")
+            or ""
+        ).strip()
+        base_url = (
+            os.environ.get("GEMINI_API_BASE")
+            or "https://generativelanguage.googleapis.com/v1beta/openai/"
+        ).strip()
+        return ChatOpenAI(model=bare, api_key=api_key, base_url=base_url)
+
     if provider == "dashscope":
         api_key = (
             os.environ.get("DASHSCOPE_API_KEY")
@@ -49,6 +62,42 @@ def _create_llm(model: str):
             os.environ.get("DASHSCOPE_API_BASE")
             or os.environ.get("LLM_BASE_URL")
             or "https://dashscope.aliyuncs.com/compatible-mode/v1"
+        ).strip()
+        return ChatOpenAI(model=bare, api_key=api_key, base_url=base_url)
+
+    if provider == "openrouter":
+        api_key = (
+            os.environ.get("OPENROUTER_API_KEY") or os.environ.get("LLM_API_KEY") or ""
+        ).strip()
+        base_url = (
+            os.environ.get("OPENROUTER_API_BASE")
+            or os.environ.get("OPENROUTER_BASE_URL")
+            or "https://openrouter.ai/api/v1"
+        ).strip()
+        return ChatOpenAI(model=bare, api_key=api_key, base_url=base_url)
+
+    if provider == "xai":
+        api_key = (
+            os.environ.get("XAI_API_KEY") or os.environ.get("LLM_API_KEY") or ""
+        ).strip()
+        base_url = (os.environ.get("XAI_API_BASE") or "https://api.x.ai/v1").strip()
+        return ChatOpenAI(model=bare, api_key=api_key, base_url=base_url)
+
+    if provider == "deepseek":
+        api_key = (
+            os.environ.get("DEEPSEEK_API_KEY") or os.environ.get("LLM_API_KEY") or ""
+        ).strip()
+        base_url = (
+            os.environ.get("DEEPSEEK_API_BASE") or "https://api.deepseek.com"
+        ).strip()
+        return ChatOpenAI(model=bare, api_key=api_key, base_url=base_url)
+
+    if provider == "zai":
+        api_key = (
+            os.environ.get("ZAI_API_KEY") or os.environ.get("LLM_API_KEY") or ""
+        ).strip()
+        base_url = (
+            os.environ.get("ZAI_API_BASE") or "https://api.z.ai/api/paas/v4"
         ).strip()
         return ChatOpenAI(model=bare, api_key=api_key, base_url=base_url)
 

--- a/environment/agents/matraix/agents/installed/cocoa.py
+++ b/environment/agents/matraix/agents/installed/cocoa.py
@@ -137,6 +137,18 @@ class CocoaHarborAgent(BaseInstalledAgent):
             "ANTHROPIC_API_KEY",
             "OPENAI_API_KEY",
             "DASHSCOPE_API_KEY",
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "GEMINI_API_BASE",
+            "OPENROUTER_API_KEY",
+            "OPENROUTER_API_BASE",
+            "OPENROUTER_BASE_URL",
+            "XAI_API_KEY",
+            "XAI_API_BASE",
+            "DEEPSEEK_API_KEY",
+            "DEEPSEEK_API_BASE",
+            "ZAI_API_KEY",
+            "ZAI_API_BASE",
             "LLM_API_KEY",
             "LLM_BASE_URL",
             "DASHSCOPE_API_BASE",
@@ -157,13 +169,49 @@ class CocoaHarborAgent(BaseInstalledAgent):
                 and self._get_env("DASHSCOPE_API_KEY")
             ):
                 env["LLM_API_KEY"] = self._get_env("DASHSCOPE_API_KEY")  # type: ignore[assignment]
+        elif (
+            self.model_name.startswith("gemini/") or self.model_name.startswith("google/")
+        ) and "LLM_API_KEY" not in env:
+            gemini_key = self._get_env("GEMINI_API_KEY") or self._get_env("GOOGLE_API_KEY")
+            if gemini_key:
+                env["LLM_API_KEY"] = gemini_key
+        elif self.model_name.startswith("openrouter/") and "LLM_API_KEY" not in env:
+            openrouter_key = self._get_env("OPENROUTER_API_KEY")
+            if openrouter_key:
+                env["LLM_API_KEY"] = openrouter_key
+        elif self.model_name.startswith("xai/") and "LLM_API_KEY" not in env:
+            xai_key = self._get_env("XAI_API_KEY")
+            if xai_key:
+                env["LLM_API_KEY"] = xai_key
+        elif self.model_name.startswith("deepseek/") and "LLM_API_KEY" not in env:
+            deepseek_key = self._get_env("DEEPSEEK_API_KEY")
+            if deepseek_key:
+                env["LLM_API_KEY"] = deepseek_key
+        elif self.model_name.startswith("zai/") and "LLM_API_KEY" not in env:
+            zai_key = self._get_env("ZAI_API_KEY")
+            if zai_key:
+                env["LLM_API_KEY"] = zai_key
 
         if not any(
             self._get_env(k)
-            for k in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "LLM_API_KEY", "DASHSCOPE_API_KEY")
+            for k in (
+                "ANTHROPIC_API_KEY",
+                "OPENAI_API_KEY",
+                "LLM_API_KEY",
+                "DASHSCOPE_API_KEY",
+                "GEMINI_API_KEY",
+                "GOOGLE_API_KEY",
+                "OPENROUTER_API_KEY",
+                "XAI_API_KEY",
+                "DEEPSEEK_API_KEY",
+                "ZAI_API_KEY",
+            )
         ):
             raise ValueError(
-                "Set ANTHROPIC_API_KEY, OPENAI_API_KEY, or LLM_API_KEY for cocoa"
+                "Set ANTHROPIC_API_KEY, OPENAI_API_KEY, DASHSCOPE_API_KEY, "
+                "GEMINI_API_KEY, OPENROUTER_API_KEY, XAI_API_KEY, "
+                "DEEPSEEK_API_KEY, ZAI_API_KEY, or LLM_API_KEY "
+                "for cocoa"
             )
 
         env["AGENT_LOGS_DIR"] = "/logs/agent"

--- a/environment/agents/matraix/agents/installed/cocoa_runner.py
+++ b/environment/agents/matraix/agents/installed/cocoa_runner.py
@@ -110,14 +110,84 @@ def _api_key(model: str) -> str:
         value = os.environ.get("DASHSCOPE_API_KEY", "").strip()
         if value:
             return value
-    for name in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "LLM_API_KEY", "DASHSCOPE_API_KEY"):
+    if model.startswith("gemini/") or model.startswith("google/"):
+        value = (
+            os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY") or ""
+        ).strip()
+        if value:
+            return value
+    if model.startswith("openrouter/"):
+        value = os.environ.get("OPENROUTER_API_KEY", "").strip()
+        if value:
+            return value
+    if model.startswith("xai/"):
+        value = os.environ.get("XAI_API_KEY", "").strip()
+        if value:
+            return value
+    if model.startswith("deepseek/"):
+        value = os.environ.get("DEEPSEEK_API_KEY", "").strip()
+        if value:
+            return value
+    if model.startswith("zai/"):
+        value = os.environ.get("ZAI_API_KEY", "").strip()
+        if value:
+            return value
+    for name in (
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "LLM_API_KEY",
+        "DASHSCOPE_API_KEY",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "OPENROUTER_API_KEY",
+        "XAI_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "ZAI_API_KEY",
+    ):
         value = os.environ.get(name, "").strip()
         if value:
             return value
     raise RuntimeError(
-        "Set DASHSCOPE_API_KEY (for dashscope/*), or ANTHROPIC_API_KEY, OPENAI_API_KEY, "
-        "or LLM_API_KEY for persona-cocoa"
+        "Set DASHSCOPE_API_KEY (for dashscope/*), GEMINI_API_KEY (for gemini/*), "
+        "OPENROUTER_API_KEY (for openrouter/*), XAI_API_KEY (for xai/*), "
+        "DEEPSEEK_API_KEY (for deepseek/*), ZAI_API_KEY (for zai/*), "
+        "or ANTHROPIC_API_KEY, OPENAI_API_KEY, or LLM_API_KEY for persona-cocoa"
     )
+
+
+def _llm_base_url(model: str) -> str:
+    if model.startswith("dashscope/"):
+        return (
+            os.environ.get("LLM_BASE_URL")
+            or os.environ.get("DASHSCOPE_API_BASE")
+            or "https://dashscope.aliyuncs.com/compatible-mode/v1"
+        )
+    if model.startswith("openrouter/"):
+        return (
+            os.environ.get("LLM_BASE_URL")
+            or os.environ.get("OPENROUTER_API_BASE")
+            or os.environ.get("OPENROUTER_BASE_URL")
+            or "https://openrouter.ai/api/v1"
+        )
+    if model.startswith("xai/"):
+        return (
+            os.environ.get("LLM_BASE_URL")
+            or os.environ.get("XAI_API_BASE")
+            or "https://api.x.ai/v1"
+        )
+    if model.startswith("deepseek/"):
+        return (
+            os.environ.get("LLM_BASE_URL")
+            or os.environ.get("DEEPSEEK_API_BASE")
+            or "https://api.deepseek.com"
+        )
+    if model.startswith("zai/"):
+        return (
+            os.environ.get("LLM_BASE_URL")
+            or os.environ.get("ZAI_API_BASE")
+            or "https://api.z.ai/api/paas/v4"
+        )
+    return os.environ.get("LLM_BASE_URL") or ""
 
 
 def _skip_docker() -> bool:
@@ -591,13 +661,7 @@ def main() -> int:
             "args": {
                 "model": bare_model,
                 "api_key": _api_key(args.model),
-                "base_url": os.environ.get("LLM_BASE_URL")
-                or os.environ.get("DASHSCOPE_API_BASE")
-                or (
-                    "https://dashscope.aliyuncs.com/compatible-mode/v1"
-                    if args.model.startswith("dashscope/")
-                    else ""
-                ),
+                "base_url": _llm_base_url(args.model),
             },
         },
         "sandbox": {

--- a/environment/runtime/harbor/agents/installed/openhands_sdk.py
+++ b/environment/runtime/harbor/agents/installed/openhands_sdk.py
@@ -224,6 +224,18 @@ class OpenHandsSDK(BaseInstalledAgent):
             llm_api_key = self._get_env("LLM_API_KEY")
         if llm_api_key is None and self.model_name and self.model_name.startswith("dashscope/"):
             llm_api_key = self._get_env("DASHSCOPE_API_KEY")
+        if llm_api_key is None and self.model_name and (
+            self.model_name.startswith("gemini/") or self.model_name.startswith("google/")
+        ):
+            llm_api_key = self._get_env("GEMINI_API_KEY") or self._get_env("GOOGLE_API_KEY")
+        if llm_api_key is None and self.model_name and self.model_name.startswith("openrouter/"):
+            llm_api_key = self._get_env("OPENROUTER_API_KEY")
+        if llm_api_key is None and self.model_name and self.model_name.startswith("xai/"):
+            llm_api_key = self._get_env("XAI_API_KEY")
+        if llm_api_key is None and self.model_name and self.model_name.startswith("deepseek/"):
+            llm_api_key = self._get_env("DEEPSEEK_API_KEY")
+        if llm_api_key is None and self.model_name and self.model_name.startswith("zai/"):
+            llm_api_key = self._get_env("ZAI_API_KEY")
         if llm_api_key is None:
             raise ValueError("LLM_API_KEY environment variable must be set")
         env["LLM_API_KEY"] = llm_api_key

--- a/packages/playground/src/playground/model_client.py
+++ b/packages/playground/src/playground/model_client.py
@@ -19,7 +19,11 @@ from playground.openai_client import (
 )
 
 DASHSCOPE_DEFAULT_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+GEMINI_DEFAULT_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
 OPENROUTER_DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
+XAI_DEFAULT_BASE_URL = "https://api.x.ai/v1"
+DEEPSEEK_DEFAULT_BASE_URL = "https://api.deepseek.com"
+ZAI_DEFAULT_BASE_URL = "https://api.z.ai/api/paas/v4"
 
 
 def dashscope_model_id(model: str) -> str:
@@ -44,6 +48,98 @@ def dashscope_openai_client_kwargs(model: str) -> Dict[str, str]:
     ).strip()
     return {
         "model": dashscope_model_id(model),
+        "api_key": api_key,
+        "base_url": base_url,
+    }
+
+
+def gemini_model_id(model: str) -> str:
+    """Return the bare Gemini model id from a Harbor persona model string."""
+    value = (model or "").strip()
+    if value.startswith("gemini/") or value.startswith("google/"):
+        return value.split("/", 1)[1]
+    return value
+
+
+def gemini_openai_client_kwargs(model: str) -> Dict[str, str]:
+    """OpenAI SDK kwargs for Google AI Studio's OpenAI-compatible chat API."""
+    api_key = (
+        os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY") or ""
+    ).strip()
+    if not api_key:
+        raise RuntimeError(
+            "GEMINI_API_KEY or GOOGLE_API_KEY is required for persona model {!r}".format(
+                model
+            )
+        )
+    base_url = (os.environ.get("GEMINI_API_BASE") or GEMINI_DEFAULT_BASE_URL).strip()
+    return {
+        "model": gemini_model_id(model),
+        "api_key": api_key,
+        "base_url": base_url,
+    }
+
+
+def xai_model_id(model: str) -> str:
+    """Return the bare xAI model id from a Harbor persona model string."""
+    value = (model or "").strip()
+    if value.startswith("xai/"):
+        return value.split("/", 1)[1]
+    return value
+
+
+def xai_openai_client_kwargs(model: str) -> Dict[str, str]:
+    """OpenAI SDK kwargs for xAI's OpenAI-compatible chat API."""
+    api_key = (os.environ.get("XAI_API_KEY") or "").strip()
+    if not api_key:
+        raise RuntimeError("XAI_API_KEY is required for persona model {!r}".format(model))
+    base_url = (os.environ.get("XAI_API_BASE") or XAI_DEFAULT_BASE_URL).strip()
+    return {
+        "model": xai_model_id(model),
+        "api_key": api_key,
+        "base_url": base_url,
+    }
+
+
+def deepseek_model_id(model: str) -> str:
+    """Return the bare DeepSeek model id from a Harbor persona model string."""
+    value = (model or "").strip()
+    if value.startswith("deepseek/"):
+        return value.split("/", 1)[1]
+    return value
+
+
+def deepseek_openai_client_kwargs(model: str) -> Dict[str, str]:
+    """OpenAI SDK kwargs for DeepSeek's official OpenAI-compatible chat API."""
+    api_key = (os.environ.get("DEEPSEEK_API_KEY") or "").strip()
+    if not api_key:
+        raise RuntimeError(
+            "DEEPSEEK_API_KEY is required for persona model {!r}".format(model)
+        )
+    base_url = (os.environ.get("DEEPSEEK_API_BASE") or DEEPSEEK_DEFAULT_BASE_URL).strip()
+    return {
+        "model": deepseek_model_id(model),
+        "api_key": api_key,
+        "base_url": base_url,
+    }
+
+
+def zai_model_id(model: str) -> str:
+    """Return the bare Z.ai GLM model id from a Harbor persona model string."""
+    value = (model or "").strip()
+    if value.startswith("zai/"):
+        return value.split("/", 1)[1]
+    return value
+
+
+def zai_openai_client_kwargs(model: str) -> Dict[str, str]:
+    """OpenAI SDK kwargs for Z.ai's official OpenAI-compatible chat API."""
+    api_key = (os.environ.get("ZAI_API_KEY") or "").strip()
+    if not api_key:
+        raise RuntimeError("ZAI_API_KEY is required for persona model {!r}".format(model))
+    base_url = (os.environ.get("ZAI_API_BASE") or ZAI_DEFAULT_BASE_URL).strip()
+    return {
+        "model": zai_model_id(model),
         "api_key": api_key,
         "base_url": base_url,
     }
@@ -217,6 +313,16 @@ def build_json_client(model: str, *, temperature: float = 0.7) -> Any:
             timeout_seconds=timeout_seconds,
             provider="dashscope",
         )
+    if value.startswith("gemini/") or value.startswith("google/"):
+        kwargs = gemini_openai_client_kwargs(value)
+        return OpenAIChatClient(
+            model=kwargs["model"],
+            api_key=kwargs["api_key"],
+            base_url=kwargs["base_url"],
+            temperature=temperature,
+            timeout_seconds=timeout_seconds,
+            provider="gemini",
+        )
     if value.startswith("openrouter/"):
         kwargs = openrouter_openai_client_kwargs(value)
         return OpenAIChatClient(
@@ -226,6 +332,36 @@ def build_json_client(model: str, *, temperature: float = 0.7) -> Any:
             temperature=temperature,
             timeout_seconds=timeout_seconds,
             provider="openrouter",
+        )
+    if value.startswith("xai/"):
+        kwargs = xai_openai_client_kwargs(value)
+        return OpenAIChatClient(
+            model=kwargs["model"],
+            api_key=kwargs["api_key"],
+            base_url=kwargs["base_url"],
+            temperature=temperature,
+            timeout_seconds=timeout_seconds,
+            provider="xai",
+        )
+    if value.startswith("deepseek/"):
+        kwargs = deepseek_openai_client_kwargs(value)
+        return OpenAIChatClient(
+            model=kwargs["model"],
+            api_key=kwargs["api_key"],
+            base_url=kwargs["base_url"],
+            temperature=temperature,
+            timeout_seconds=timeout_seconds,
+            provider="deepseek",
+        )
+    if value.startswith("zai/"):
+        kwargs = zai_openai_client_kwargs(value)
+        return OpenAIChatClient(
+            model=kwargs["model"],
+            api_key=kwargs["api_key"],
+            base_url=kwargs["base_url"],
+            temperature=temperature,
+            timeout_seconds=timeout_seconds,
+            provider="zai",
         )
     if value.startswith("openai/"):
         return OpenAIChatClient(

--- a/packages/playground/src/playground/tests/test_model_client.py
+++ b/packages/playground/src/playground/tests/test_model_client.py
@@ -2,8 +2,10 @@ import pytest
 
 from playground.model_client import (
     DASHSCOPE_DEFAULT_BASE_URL,
+    GEMINI_DEFAULT_BASE_URL,
     build_json_client,
     dashscope_openai_client_kwargs,
+    gemini_openai_client_kwargs,
 )
 from playground.openai_client import OpenAIChatClient
 from playground.user_sim.tool_client import OpenAIToolStepClient, build_tool_step_client
@@ -74,3 +76,272 @@ def test_build_json_client_requires_dashscope_key(monkeypatch):
     monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
     with pytest.raises(RuntimeError, match="DASHSCOPE_API_KEY"):
         build_json_client("dashscope/qwen-plus")
+
+
+def test_gemini_openai_client_kwargs_reads_env(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "sk-gemini-test")
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_BASE", raising=False)
+
+    kwargs = gemini_openai_client_kwargs("gemini/gemini-2.5-pro")
+    assert kwargs == {
+        "model": "gemini-2.5-pro",
+        "api_key": "sk-gemini-test",
+        "base_url": GEMINI_DEFAULT_BASE_URL,
+    }
+
+
+def test_build_json_client_routes_gemini_to_openai_compatible(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "sk-gemini-test")
+    monkeypatch.delenv("GEMINI_API_BASE", raising=False)
+    created: list[dict[str, str]] = []
+
+    def fake_openai(**kwargs):
+        created.append(kwargs)
+        return _FakeOpenAI(**kwargs)
+
+    monkeypatch.setattr("openai.OpenAI", fake_openai)
+
+    client = build_json_client("gemini/gemini-2.5-flash")
+    assert isinstance(client, OpenAIChatClient)
+    assert client.model == "gemini-2.5-flash"
+    assert created == [
+        {
+            "api_key": "sk-gemini-test",
+            "base_url": GEMINI_DEFAULT_BASE_URL,
+        }
+    ]
+
+
+def test_build_tool_step_client_routes_gemini(monkeypatch):
+    monkeypatch.setenv("GOOGLE_API_KEY", "sk-google-test")
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_BASE", raising=False)
+    created: list[dict[str, str]] = []
+
+    def fake_openai(**kwargs):
+        created.append(kwargs)
+        return _FakeOpenAI(**kwargs)
+
+    monkeypatch.setattr("openai.OpenAI", fake_openai)
+
+    client = build_tool_step_client("google/gemini-2.5-pro")
+    assert isinstance(client, OpenAIToolStepClient)
+    assert client.model == "gemini-2.5-pro"
+    assert created == [
+        {
+            "api_key": "sk-google-test",
+            "base_url": GEMINI_DEFAULT_BASE_URL,
+        }
+    ]
+
+
+def test_build_json_client_requires_gemini_key(monkeypatch):
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    with pytest.raises(RuntimeError, match="GEMINI_API_KEY"):
+        build_json_client("gemini/gemini-2.5-pro")
+
+
+def test_xai_openai_client_kwargs_reads_env(monkeypatch):
+    from playground.model_client import XAI_DEFAULT_BASE_URL, xai_openai_client_kwargs
+
+    monkeypatch.setenv("XAI_API_KEY", "sk-xai-test")
+    monkeypatch.delenv("XAI_API_BASE", raising=False)
+
+    kwargs = xai_openai_client_kwargs("xai/grok-4.5")
+    assert kwargs == {
+        "model": "grok-4.5",
+        "api_key": "sk-xai-test",
+        "base_url": XAI_DEFAULT_BASE_URL,
+    }
+
+
+def test_build_json_client_routes_xai_to_openai_compatible(monkeypatch):
+    from playground.model_client import XAI_DEFAULT_BASE_URL
+
+    monkeypatch.setenv("XAI_API_KEY", "sk-xai-test")
+    monkeypatch.delenv("XAI_API_BASE", raising=False)
+    created: list[dict[str, str]] = []
+
+    def fake_openai(**kwargs):
+        created.append(kwargs)
+        return _FakeOpenAI(**kwargs)
+
+    monkeypatch.setattr("openai.OpenAI", fake_openai)
+
+    client = build_json_client("xai/grok-3-mini")
+    assert isinstance(client, OpenAIChatClient)
+    assert client.model == "grok-3-mini"
+    assert created == [
+        {
+            "api_key": "sk-xai-test",
+            "base_url": XAI_DEFAULT_BASE_URL,
+        }
+    ]
+
+
+def test_build_tool_step_client_routes_xai(monkeypatch):
+    from playground.model_client import XAI_DEFAULT_BASE_URL
+
+    monkeypatch.setenv("XAI_API_KEY", "sk-xai-test")
+    monkeypatch.delenv("XAI_API_BASE", raising=False)
+    created: list[dict[str, str]] = []
+
+    def fake_openai(**kwargs):
+        created.append(kwargs)
+        return _FakeOpenAI(**kwargs)
+
+    monkeypatch.setattr("openai.OpenAI", fake_openai)
+
+    client = build_tool_step_client("xai/grok-4.5")
+    assert isinstance(client, OpenAIToolStepClient)
+    assert client.model == "grok-4.5"
+    assert created == [
+        {
+            "api_key": "sk-xai-test",
+            "base_url": XAI_DEFAULT_BASE_URL,
+        }
+    ]
+
+
+def test_build_json_client_requires_xai_key(monkeypatch):
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    with pytest.raises(RuntimeError, match="XAI_API_KEY"):
+        build_json_client("xai/grok-4.5")
+
+
+def test_deepseek_openai_client_kwargs_reads_env(monkeypatch):
+    from playground.model_client import DEEPSEEK_DEFAULT_BASE_URL, deepseek_openai_client_kwargs
+
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-deepseek-test")
+    monkeypatch.delenv("DEEPSEEK_API_BASE", raising=False)
+
+    kwargs = deepseek_openai_client_kwargs("deepseek/deepseek-v4-pro")
+    assert kwargs == {
+        "model": "deepseek-v4-pro",
+        "api_key": "sk-deepseek-test",
+        "base_url": DEEPSEEK_DEFAULT_BASE_URL,
+    }
+
+
+def test_build_json_client_routes_deepseek_to_openai_compatible(monkeypatch):
+    from playground.model_client import DEEPSEEK_DEFAULT_BASE_URL
+
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-deepseek-test")
+    monkeypatch.delenv("DEEPSEEK_API_BASE", raising=False)
+    created: list[dict[str, str]] = []
+
+    def fake_openai(**kwargs):
+        created.append(kwargs)
+        return _FakeOpenAI(**kwargs)
+
+    monkeypatch.setattr("openai.OpenAI", fake_openai)
+
+    client = build_json_client("deepseek/deepseek-chat")
+    assert isinstance(client, OpenAIChatClient)
+    assert client.model == "deepseek-chat"
+    assert created == [
+        {
+            "api_key": "sk-deepseek-test",
+            "base_url": DEEPSEEK_DEFAULT_BASE_URL,
+        }
+    ]
+
+
+def test_build_tool_step_client_routes_deepseek(monkeypatch):
+    from playground.model_client import DEEPSEEK_DEFAULT_BASE_URL
+
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-deepseek-test")
+    monkeypatch.delenv("DEEPSEEK_API_BASE", raising=False)
+    created: list[dict[str, str]] = []
+
+    def fake_openai(**kwargs):
+        created.append(kwargs)
+        return _FakeOpenAI(**kwargs)
+
+    monkeypatch.setattr("openai.OpenAI", fake_openai)
+
+    client = build_tool_step_client("deepseek/deepseek-v4-pro")
+    assert isinstance(client, OpenAIToolStepClient)
+    assert client.model == "deepseek-v4-pro"
+    assert created == [
+        {
+            "api_key": "sk-deepseek-test",
+            "base_url": DEEPSEEK_DEFAULT_BASE_URL,
+        }
+    ]
+
+
+def test_build_json_client_requires_deepseek_key(monkeypatch):
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    with pytest.raises(RuntimeError, match="DEEPSEEK_API_KEY"):
+        build_json_client("deepseek/deepseek-chat")
+
+
+def test_zai_openai_client_kwargs_reads_env(monkeypatch):
+    from playground.model_client import ZAI_DEFAULT_BASE_URL, zai_openai_client_kwargs
+
+    monkeypatch.setenv("ZAI_API_KEY", "sk-zai-test")
+    monkeypatch.delenv("ZAI_API_BASE", raising=False)
+
+    kwargs = zai_openai_client_kwargs("zai/glm-4.7")
+    assert kwargs == {
+        "model": "glm-4.7",
+        "api_key": "sk-zai-test",
+        "base_url": ZAI_DEFAULT_BASE_URL,
+    }
+
+
+def test_build_json_client_routes_zai_to_openai_compatible(monkeypatch):
+    from playground.model_client import ZAI_DEFAULT_BASE_URL
+
+    monkeypatch.setenv("ZAI_API_KEY", "sk-zai-test")
+    monkeypatch.delenv("ZAI_API_BASE", raising=False)
+    created: list[dict[str, str]] = []
+
+    def fake_openai(**kwargs):
+        created.append(kwargs)
+        return _FakeOpenAI(**kwargs)
+
+    monkeypatch.setattr("openai.OpenAI", fake_openai)
+
+    client = build_json_client("zai/glm-5")
+    assert isinstance(client, OpenAIChatClient)
+    assert client.model == "glm-5"
+    assert created == [
+        {
+            "api_key": "sk-zai-test",
+            "base_url": ZAI_DEFAULT_BASE_URL,
+        }
+    ]
+
+
+def test_build_tool_step_client_routes_zai(monkeypatch):
+    from playground.model_client import ZAI_DEFAULT_BASE_URL
+
+    monkeypatch.setenv("ZAI_API_KEY", "sk-zai-test")
+    monkeypatch.delenv("ZAI_API_BASE", raising=False)
+    created: list[dict[str, str]] = []
+
+    def fake_openai(**kwargs):
+        created.append(kwargs)
+        return _FakeOpenAI(**kwargs)
+
+    monkeypatch.setattr("openai.OpenAI", fake_openai)
+
+    client = build_tool_step_client("zai/glm-4.7")
+    assert isinstance(client, OpenAIToolStepClient)
+    assert client.model == "glm-4.7"
+    assert created == [
+        {
+            "api_key": "sk-zai-test",
+            "base_url": ZAI_DEFAULT_BASE_URL,
+        }
+    ]
+
+
+def test_build_json_client_requires_zai_key(monkeypatch):
+    monkeypatch.delenv("ZAI_API_KEY", raising=False)
+    with pytest.raises(RuntimeError, match="ZAI_API_KEY"):
+        build_json_client("zai/glm-5")

--- a/packages/playground/src/playground/user_sim/tool_client.py
+++ b/packages/playground/src/playground/user_sim/tool_client.py
@@ -215,7 +215,11 @@ def build_tool_step_client(
 ) -> ToolStepClient:
     from playground.model_client import (
         dashscope_openai_client_kwargs,
+        deepseek_openai_client_kwargs,
+        gemini_openai_client_kwargs,
         openrouter_openai_client_kwargs,
+        xai_openai_client_kwargs,
+        zai_openai_client_kwargs,
     )
 
     value = (model or "openai/gpt-4o-mini").strip()
@@ -248,6 +252,16 @@ def build_tool_step_client(
             capabilities=capabilities,
             provider="dashscope",
         )
+    if value.startswith("gemini/") or value.startswith("google/"):
+        kwargs = gemini_openai_client_kwargs(value)
+        return OpenAIToolStepClient(
+            kwargs["model"],
+            api_key=kwargs["api_key"],
+            base_url=kwargs["base_url"],
+            temperature=temperature,
+            capabilities=capabilities,
+            provider="gemini",
+        )
     if value.startswith("openrouter/"):
         kwargs = openrouter_openai_client_kwargs(value)
         return OpenAIToolStepClient(
@@ -257,6 +271,36 @@ def build_tool_step_client(
             temperature=temperature,
             capabilities=capabilities,
             provider="openrouter",
+        )
+    if value.startswith("xai/"):
+        kwargs = xai_openai_client_kwargs(value)
+        return OpenAIToolStepClient(
+            kwargs["model"],
+            api_key=kwargs["api_key"],
+            base_url=kwargs["base_url"],
+            temperature=temperature,
+            capabilities=capabilities,
+            provider="xai",
+        )
+    if value.startswith("deepseek/"):
+        kwargs = deepseek_openai_client_kwargs(value)
+        return OpenAIToolStepClient(
+            kwargs["model"],
+            api_key=kwargs["api_key"],
+            base_url=kwargs["base_url"],
+            temperature=temperature,
+            capabilities=capabilities,
+            provider="deepseek",
+        )
+    if value.startswith("zai/"):
+        kwargs = zai_openai_client_kwargs(value)
+        return OpenAIToolStepClient(
+            kwargs["model"],
+            api_key=kwargs["api_key"],
+            base_url=kwargs["base_url"],
+            temperature=temperature,
+            capabilities=capabilities,
+            provider="zai",
         )
     if value.startswith("openai/"):
         return OpenAIToolStepClient(

--- a/src/matraix/provider_credentials.py
+++ b/src/matraix/provider_credentials.py
@@ -33,8 +33,16 @@ def resolve_provider_credential(model_name: str) -> ProviderCredential:
         return ProviderCredential("OpenAI", "OPENAI_API_KEY", value)
     if lowered.startswith("dashscope/"):
         return ProviderCredential("DashScope", "DASHSCOPE_API_KEY", value)
+    if lowered.startswith("gemini/") or lowered.startswith("google/"):
+        return ProviderCredential("Gemini", "GEMINI_API_KEY", value)
     if lowered.startswith("openrouter/"):
         return ProviderCredential("OpenRouter", "OPENROUTER_API_KEY", value)
+    if lowered.startswith("xai/"):
+        return ProviderCredential("xAI", "XAI_API_KEY", value)
+    if lowered.startswith("deepseek/"):
+        return ProviderCredential("DeepSeek", "DEEPSEEK_API_KEY", value)
+    if lowered.startswith("zai/"):
+        return ProviderCredential("Z.ai", "ZAI_API_KEY", value)
     if lowered.startswith("anthropic/"):
         return ProviderCredential("Anthropic", "ANTHROPIC_API_KEY", value)
     if "/" not in value:

--- a/tests/unit/agents/test_web_live_trajectory_flush.py
+++ b/tests/unit/agents/test_web_live_trajectory_flush.py
@@ -212,3 +212,142 @@ def test_openhands_save_screenshot_b64(tmp_path):
     rel = oh._save_screenshot_b64(png, tmp_path / "images", 2)
     assert rel == "images/step_002.png"
     assert (tmp_path / "images" / "step_002.png").is_file()
+
+
+def test_cocoa_controller_type_and_gemini_api_key(monkeypatch):
+    assert cocoa._controller_type("gemini/gemini-2.5-pro") == "gemini"
+    monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.setenv("GEMINI_API_KEY", "sk-gemini-test")
+    assert cocoa._api_key("gemini/gemini-2.5-pro") == "sk-gemini-test"
+
+
+def test_cocoa_api_key_prefers_openrouter_and_xai(monkeypatch):
+    monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    monkeypatch.setenv("XAI_API_KEY", "sk-xai-test")
+    assert cocoa._api_key("openrouter/z-ai/glm-4.7") == "sk-or-test"
+    assert cocoa._api_key("xai/grok-4.5") == "sk-xai-test"
+    assert cocoa._llm_base_url("xai/grok-4.5") == "https://api.x.ai/v1"
+    assert cocoa._llm_base_url("openrouter/z-ai/glm-4.7") == "https://openrouter.ai/api/v1"
+
+
+def test_cocoa_api_key_prefers_deepseek_and_zai(monkeypatch):
+    monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-deepseek-test")
+    monkeypatch.setenv("ZAI_API_KEY", "sk-zai-test")
+    assert cocoa._api_key("deepseek/deepseek-v4-pro") == "sk-deepseek-test"
+    assert cocoa._api_key("zai/glm-4.7") == "sk-zai-test"
+    assert cocoa._llm_base_url("deepseek/deepseek-chat") == "https://api.deepseek.com"
+    assert cocoa._llm_base_url("zai/glm-5") == "https://api.z.ai/api/paas/v4"
+
+
+def test_browser_use_routes_gemini_to_openai_compatible(monkeypatch):
+    created: dict[str, str] = {}
+
+    class _ChatOpenAI:
+        def __init__(self, *, model, api_key, base_url):
+            created.update(model=model, api_key=api_key, base_url=base_url)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "browser_use",
+        types.SimpleNamespace(ChatOpenAI=_ChatOpenAI, ChatAnthropic=object),
+    )
+    monkeypatch.setenv("GEMINI_API_KEY", "sk-gemini-test")
+    monkeypatch.delenv("GEMINI_API_BASE", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+
+    llm = bu._create_llm("gemini/gemini-2.5-flash")
+    assert isinstance(llm, _ChatOpenAI)
+    assert created == {
+        "model": "gemini-2.5-flash",
+        "api_key": "sk-gemini-test",
+        "base_url": "https://generativelanguage.googleapis.com/v1beta/openai/",
+    }
+
+
+def test_browser_use_routes_xai_and_openrouter(monkeypatch):
+    created: dict[str, str] = {}
+
+    class _ChatOpenAI:
+        def __init__(self, *, model, api_key, base_url):
+            created.update(model=model, api_key=api_key, base_url=base_url)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "browser_use",
+        types.SimpleNamespace(ChatOpenAI=_ChatOpenAI, ChatAnthropic=object),
+    )
+    monkeypatch.setenv("XAI_API_KEY", "sk-xai-test")
+    monkeypatch.delenv("XAI_API_BASE", raising=False)
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+    monkeypatch.delenv("LLM_BASE_URL", raising=False)
+    bu._create_llm("xai/grok-4.5")
+    assert created == {
+        "model": "grok-4.5",
+        "api_key": "sk-xai-test",
+        "base_url": "https://api.x.ai/v1",
+    }
+
+    created.clear()
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    monkeypatch.delenv("OPENROUTER_API_BASE", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("LLM_BASE_URL", raising=False)
+    bu._create_llm("openrouter/z-ai/glm-4.7")
+    assert created == {
+        "model": "z-ai/glm-4.7",
+        "api_key": "sk-or-test",
+        "base_url": "https://openrouter.ai/api/v1",
+    }
+
+
+def test_browser_use_routes_deepseek_and_zai(monkeypatch):
+    created: dict[str, str] = {}
+
+    class _ChatOpenAI:
+        def __init__(self, *, model, api_key, base_url):
+            created.update(model=model, api_key=api_key, base_url=base_url)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "browser_use",
+        types.SimpleNamespace(ChatOpenAI=_ChatOpenAI, ChatAnthropic=object),
+    )
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-deepseek-test")
+    monkeypatch.delenv("DEEPSEEK_API_BASE", raising=False)
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+    monkeypatch.delenv("LLM_BASE_URL", raising=False)
+    bu._create_llm("deepseek/deepseek-v4-pro")
+    assert created == {
+        "model": "deepseek-v4-pro",
+        "api_key": "sk-deepseek-test",
+        "base_url": "https://api.deepseek.com",
+    }
+
+    created.clear()
+    monkeypatch.setenv("ZAI_API_KEY", "sk-zai-test")
+    monkeypatch.delenv("ZAI_API_BASE", raising=False)
+    bu._create_llm("zai/glm-4.7")
+    assert created == {
+        "model": "glm-4.7",
+        "api_key": "sk-zai-test",
+        "base_url": "https://api.z.ai/api/paas/v4",
+    }

--- a/tests/unit/matraix/test_provider_credentials.py
+++ b/tests/unit/matraix/test_provider_credentials.py
@@ -18,6 +18,43 @@ def test_resolve_openai_and_dashscope(monkeypatch) -> None:
     assert dash.present is True
 
 
+def test_resolve_gemini(monkeypatch) -> None:
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    cred = resolve_provider_credential("gemini/gemini-2.5-pro")
+    assert cred.provider == "Gemini"
+    assert cred.env_var == "GEMINI_API_KEY"
+    assert cred.present is False
+    monkeypatch.setenv("GEMINI_API_KEY", "sk-test")
+    assert resolve_provider_credential("google/gemini-2.5-flash").present is True
+
+
+def test_resolve_xai(monkeypatch) -> None:
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    cred = resolve_provider_credential("xai/grok-4.5")
+    assert cred.provider == "xAI"
+    assert cred.env_var == "XAI_API_KEY"
+    assert cred.present is False
+    monkeypatch.setenv("XAI_API_KEY", "sk-test")
+    assert resolve_provider_credential("xai/grok-3-mini").present is True
+
+
+def test_resolve_deepseek_and_zai(monkeypatch) -> None:
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    monkeypatch.delenv("ZAI_API_KEY", raising=False)
+    deepseek = resolve_provider_credential("deepseek/deepseek-v4-pro")
+    assert deepseek.provider == "DeepSeek"
+    assert deepseek.env_var == "DEEPSEEK_API_KEY"
+    assert deepseek.present is False
+    zai = resolve_provider_credential("zai/glm-4.7")
+    assert zai.provider == "Z.ai"
+    assert zai.env_var == "ZAI_API_KEY"
+    assert zai.present is False
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-test")
+    monkeypatch.setenv("ZAI_API_KEY", "sk-test")
+    assert resolve_provider_credential("deepseek/deepseek-chat").present is True
+    assert resolve_provider_credential("zai/glm-5").present is True
+
+
 def test_resolve_anthropic_default_and_bare_model() -> None:
     assert resolve_provider_credential("anthropic/claude-sonnet-4-6").env_var == (
         "ANTHROPIC_API_KEY"


### PR DESCRIPTION
## Summary
- Register `gemini/*`, `xai/*`, `deepseek/*`, and `zai/*` as first-class persona models (Survey/Chat + preflight), distinct from DashScope/OpenRouter aliases.
- Route those prefixes through OpenAI-compatible clients and extend Harbor env-key propagation for browser-use, cocoa, and OpenHands.
- Tighten CUA platform filtering (Gemini computer-use vs chat) and group the Persona model picker by provider.

## Test plan
- [ ] Unit: `test_config.py`, `test_provider_credentials.py`, `test_model_client.py`, `test_api.py` preflight, `test_web_live_trajectory_flush.py`
- [ ] Playground Persona rail: each new provider section appears; missing keys show on preflight
- [ ] Survey trial with `gemini/gemini-2.5-flash` and `xai/grok-3-mini` when keys are set
- [ ] Web browser-use with a `gemini/*` persona model: container receives `GEMINI_API_KEY`


Made with [Cursor](https://cursor.com)