### PR TITLE
feat: add OrcaRouter as a named persona-model provider

### DIFF
--- a/application/playground/backend/api/app.py
+++ b/application/playground/backend/api/app.py
@@ -310,6 +310,7 @@ def preflight_checks() -> List[Dict[str, Any]]:
     )
     dashscope_key = bool(os.environ.get("DASHSCOPE_API_KEY"))
     openrouter_key = bool(os.environ.get("OPENROUTER_API_KEY"))
+    orcarouter_key = bool(os.environ.get("ORCAROUTER_API_KEY"))
     gemini_key = bool(os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY"))
     xai_key = bool(os.environ.get("XAI_API_KEY"))
     deepseek_key = bool(os.environ.get("DEEPSEEK_API_KEY"))
@@ -321,6 +322,7 @@ def preflight_checks() -> List[Dict[str, Any]]:
             ("Anthropic", anthropic_key),
             ("DashScope", dashscope_key),
             ("OpenRouter", openrouter_key),
+            ("OrcaRouter", orcarouter_key),
             ("Gemini", gemini_key),
             ("xAI", xai_key),
             ("DeepSeek", deepseek_key),
@@ -337,8 +339,8 @@ def preflight_checks() -> List[Dict[str, Any]]:
                 "Configured: {}.".format(", ".join(configured))
                 if configured
                 else "Not configured. Set OpenAI, Anthropic, DashScope, "
-                "OpenRouter, Gemini, xAI, DeepSeek, or Z.ai credentials "
-                "to run application tasks."
+                "OpenRouter, OrcaRouter, Gemini, xAI, DeepSeek, or Z.ai "
+                "credentials to run application tasks."
             ),
         }
     )
@@ -392,6 +394,19 @@ def preflight_checks() -> List[Dict[str, Any]]:
                 "Configured."
                 if openrouter_key
                 else "Not configured. Needed only for OpenRouter persona models."
+            ),
+        }
+    )
+    checks.append(
+        {
+            "group": "Core",
+            "name": "OrcaRouter",
+            "ok": orcarouter_key,
+            "optional": True,
+            "detail": (
+                "Configured."
+                if orcarouter_key
+                else "Not configured. Needed only for OrcaRouter persona models."
             ),
         }
     )

--- a/application/playground/backend/service/config.py
+++ b/application/playground/backend/service/config.py
@@ -28,7 +28,8 @@ REMOTE_RUNNER_API_URL_ENV = "REMOTE_RUNNER_API_URL"
 DEFAULT_PERSONA_MODEL = "anthropic/claude-haiku-4-5"
 
 # Persona-model IDs use LiteLLM provider prefixes (``anthropic/``, ``openai/``,
-# ``gemini/``, ``xai/``, ``deepseek/``, ``zai/``, ``dashscope/``, ``openrouter/``).
+# ``gemini/``, ``xai/``, ``deepseek/``, ``zai/``, ``dashscope/``, ``openrouter/``,
+# ``orcarouter/``).
 # OpenAI-compatible providers use their own credentials and endpoints.
 PERSONA_MODEL_KNOB_META: Dict[str, Dict[str, str]] = {
     "anthropic/claude-haiku-4-5": {
@@ -162,6 +163,14 @@ PERSONA_MODEL_KNOB_META: Dict[str, Dict[str, str]] = {
     "openrouter/anthropic/claude-haiku-4.5": {
         "label": "Claude Haiku 4.5",
         "description": "Anthropic Claude Haiku 4.5 served through OpenRouter.",
+    },
+    "orcarouter/auto": {
+        "label": "OrcaRouter auto",
+        "description": "Adaptive routing across many models via OrcaRouter.",
+    },
+    "orcarouter/anthropic/claude-haiku-4.5": {
+        "label": "Claude Haiku 4.5",
+        "description": "Anthropic Claude Haiku 4.5 served through OrcaRouter.",
     },
 }
 

--- a/application/playground/backend/tests/test_api.py
+++ b/application/playground/backend/tests/test_api.py
@@ -33,6 +33,7 @@ def test_preflight_shape(client):
         "Anthropic credentials",
         "DashScope (Qwen / DeepSeek)",
         "OpenRouter",
+        "OrcaRouter",
         "Gemini credentials",
         "xAI credentials",
         "DeepSeek credentials",
@@ -67,6 +68,7 @@ def test_preflight_required_vs_optional_contract(client):
         "Anthropic credentials",
         "DashScope (Qwen / DeepSeek)",
         "OpenRouter",
+        "OrcaRouter",
         "Gemini credentials",
         "xAI credentials",
         "DeepSeek credentials",
@@ -90,6 +92,7 @@ def test_preflight_does_not_leak_env_var_names(client):
         "CLAUDE_API_KEY",
         "DASHSCOPE_API_KEY",
         "OPENROUTER_API_KEY",
+        "ORCAROUTER_API_KEY",
         "GEMINI_API_KEY",
         "GOOGLE_API_KEY",
         "XAI_API_KEY",
@@ -111,6 +114,7 @@ def test_preflight_model_credentials_any_provider(client, monkeypatch):
     monkeypatch.delenv("CLAUDE_API_KEY", raising=False)
     monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("ORCAROUTER_API_KEY", raising=False)
     monkeypatch.delenv("GEMINI_API_KEY", raising=False)
     monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
     monkeypatch.delenv("XAI_API_KEY", raising=False)

--- a/application/playground/backend/tests/test_config.py
+++ b/application/playground/backend/tests/test_config.py
@@ -69,6 +69,8 @@ def test_options_knob_values_match_allowed(config_manager):
     assert "dashscope/deepseek-v4-pro" in PERSONA_MODEL_OPTIONS
     assert "openrouter/z-ai/glm-4.7" in PERSONA_MODEL_OPTIONS
     assert "openrouter/anthropic/claude-haiku-4.5" in PERSONA_MODEL_OPTIONS
+    assert "orcarouter/auto" in PERSONA_MODEL_OPTIONS
+    assert "orcarouter/anthropic/claude-haiku-4.5" in PERSONA_MODEL_OPTIONS
     assert "openai/gpt-5.4" in PERSONA_MODEL_OPTIONS
     assert "openai/gpt-5.5" in PERSONA_MODEL_OPTIONS
     assert "gemini/gemini-2.5-flash" in PERSONA_MODEL_OPTIONS
@@ -88,6 +90,7 @@ def test_preflight_recognizes_openrouter_credentials(client, monkeypatch):
     monkeypatch.delenv("CLAUDE_API_KEY", raising=False)
     monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("ORCAROUTER_API_KEY", raising=False)
     monkeypatch.delenv("GEMINI_API_KEY", raising=False)
     monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
     monkeypatch.delenv("XAI_API_KEY", raising=False)
@@ -106,6 +109,33 @@ def test_preflight_recognizes_openrouter_credentials(client, monkeypatch):
     assert "OpenRouter" in model["detail"]
     assert openrouter["ok"] is True
     assert openrouter.get("optional") is True
+
+
+def test_preflight_recognizes_orcarouter_credentials(client, monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("CLAUDE_API_KEY", raising=False)
+    monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("ORCAROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    monkeypatch.delenv("ZAI_API_KEY", raising=False)
+
+    body = client.get("/api/preflight").json()
+    model = next(c for c in body["checks"] if c["name"] == "Model credentials")
+    assert model["ok"] is False
+
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-test")
+    body = client.get("/api/preflight").json()
+    model = next(c for c in body["checks"] if c["name"] == "Model credentials")
+    orcarouter = next(c for c in body["checks"] if c["name"] == "OrcaRouter")
+    assert model["ok"] is True
+    assert "OrcaRouter" in model["detail"]
+    assert orcarouter["ok"] is True
+    assert orcarouter.get("optional") is True
 
 
 def test_options_rebuilds_agent_flag(config_manager):

--- a/application/playground/frontend/src/lib/personaAgentCatalog.ts
+++ b/application/playground/frontend/src/lib/personaAgentCatalog.ts
@@ -347,6 +347,7 @@ function isCuaCapablePersonaModel(modelId: string, platform: string): boolean {
       isGeminiChat ||
       modelId.startsWith("dashscope/") ||
       modelId.startsWith("openrouter/") ||
+      modelId.startsWith("orcarouter/") ||
       modelId.startsWith("xai/") ||
       modelId.startsWith("deepseek/") ||
       modelId.startsWith("zai/")
@@ -391,6 +392,7 @@ const PERSONA_MODEL_PROVIDER_LABELS: Record<string, string> = {
   google: "Google",
   openai: "OpenAI",
   openrouter: "OpenRouter",
+  orcarouter: "OrcaRouter",
   xai: "xAI",
   deepseek: "DeepSeek",
   zai: "Z.ai",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,6 +121,7 @@ The **persona LLM** is separate from the chat sidecar backend (e.g., `MATRIX_CHA
 - **Google Gemini:** `google/gemini-2.5-pro` (with `persona-gemini-cli`)
 - **DashScope (Alibaba):** `dashscope/qwen3.7-max`, `dashscope/deepseek-v4-pro`, etc.
 - **OpenRouter:** `openrouter/z-ai/glm-4.7`, `openrouter/anthropic/claude-haiku-4.5`, etc.
+- **OrcaRouter:** `orcarouter/auto`, `orcarouter/anthropic/claude-haiku-4.5`, etc.
 
 #### OpenRouter
 
@@ -139,6 +140,24 @@ diverts the `anthropic/` prefix through that proxy, because a non-empty
 `OPENAI_BASE_URL` switches Anthropic models onto the proxy's OpenAI-compatible
 endpoint. Addressing OpenRouter explicitly keeps the two independent, so one
 process can send some models to OpenRouter and others direct to Anthropic.
+
+#### OrcaRouter
+
+OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents.
+Like OpenRouter it exposes a provider/model namespace across many models, and it
+also combines adaptive routing, automatic failover, zero-markup inference,
+observability, guardrails, and agent-tool governance behind the same endpoint.
+OrcaRouter model ids follow the same `provider/model` shape as OpenRouter
+(`orcarouter/anthropic/claude-haiku-4.5`); the special `orcarouter/auto` id uses
+OrcaRouter's adaptive router to pick a live upstream model per request. Only the
+leading `orcarouter/` is stripped.
+
+Set `ORCAROUTER_API_KEY`. The endpoint defaults to `https://api.orcarouter.ai/v1`
+and can be overridden with `ORCAROUTER_API_BASE`.
+
+The `orcarouter/` prefix also deliberately ignores `OPENAI_BASE_URL`, so one
+process can route some models through OrcaRouter and others direct to their
+native providers.
 
 ### API keys and environment variables
 
@@ -178,6 +197,7 @@ export OPENAI_API_KEY="sk-..."
 export GEMINI_API_KEY="..."
 export DASHSCOPE_API_KEY="..."
 export OPENROUTER_API_KEY="..."
+export ORCAROUTER_API_KEY="sk-orca-..."
 
 # If using persona-openhands-sdk, map to LLM_API_KEY
 export LLM_API_KEY="${ANTHROPIC_API_KEY}"

--- a/docs/environment/agents.md
+++ b/docs/environment/agents.md
@@ -64,7 +64,9 @@ auto survey/chat and Docker web/CUA agents. OpenRouter models include
 `openrouter/z-ai/glm-4.7` and `openrouter/anthropic/claude-haiku-4.5`. Set
 `OPENROUTER_API_KEY` (and optional `OPENROUTER_API_BASE`) for `openrouter/*`.
 `OPENROUTER_BASE_URL` remains a compatibility alias when
-`OPENROUTER_API_BASE` is unset.
+`OPENROUTER_API_BASE` is unset. OrcaRouter models include `orcarouter/auto`
+(adaptive routing) and `orcarouter/anthropic/claude-haiku-4.5`. Set
+`ORCAROUTER_API_KEY` (and optional `ORCAROUTER_API_BASE`) for `orcarouter/*`.
 CLI harness agents
 (`persona-claude-code`, `persona-gemini-cli`, `persona-codex`) stay
 vendor-locked. Other LiteLLM-compatible ids may work if the matching API key is
@@ -135,6 +137,7 @@ export ANTHROPIC_API_KEY=sk-...
 export GEMINI_API_KEY=...
 export OPENAI_API_KEY=sk-...
 export OPENROUTER_API_KEY=...
+export ORCAROUTER_API_KEY=sk-orca-...
 
 # persona-openhands-sdk (pick one to match -m)
 export LLM_API_KEY="$ANTHROPIC_API_KEY"

--- a/packages/playground/src/playground/model_client.py
+++ b/packages/playground/src/playground/model_client.py
@@ -21,6 +21,7 @@ from playground.openai_client import (
 DASHSCOPE_DEFAULT_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
 GEMINI_DEFAULT_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
 OPENROUTER_DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
+ORCAROUTER_DEFAULT_BASE_URL = "https://api.orcarouter.ai/v1"
 XAI_DEFAULT_BASE_URL = "https://api.x.ai/v1"
 DEEPSEEK_DEFAULT_BASE_URL = "https://api.deepseek.com"
 ZAI_DEFAULT_BASE_URL = "https://api.z.ai/api/paas/v4"
@@ -167,6 +168,31 @@ def openrouter_openai_client_kwargs(model: str) -> Dict[str, str]:
     ).strip()
     return {
         "model": openrouter_model_id(model),
+        "api_key": api_key,
+        "base_url": base_url,
+    }
+
+
+def orcarouter_model_id(model: str) -> str:
+    """Return the bare OrcaRouter model id from a Harbor persona model string."""
+    value = (model or "").strip()
+    if value.startswith("orcarouter/"):
+        return value.split("/", 1)[1]
+    return value
+
+
+def orcarouter_openai_client_kwargs(model: str) -> Dict[str, str]:
+    """OpenAI SDK kwargs for OrcaRouter's OpenAI-compatible chat endpoint."""
+    api_key = (os.environ.get("ORCAROUTER_API_KEY") or "").strip()
+    if not api_key:
+        raise RuntimeError(
+            "ORCAROUTER_API_KEY is required for persona model {!r}".format(model)
+        )
+    base_url = (
+        os.environ.get("ORCAROUTER_API_BASE") or ORCAROUTER_DEFAULT_BASE_URL
+    ).strip()
+    return {
+        "model": orcarouter_model_id(model),
         "api_key": api_key,
         "base_url": base_url,
     }
@@ -332,6 +358,16 @@ def build_json_client(model: str, *, temperature: float = 0.7) -> Any:
             temperature=temperature,
             timeout_seconds=timeout_seconds,
             provider="openrouter",
+        )
+    if value.startswith("orcarouter/"):
+        kwargs = orcarouter_openai_client_kwargs(value)
+        return OpenAIChatClient(
+            model=kwargs["model"],
+            api_key=kwargs["api_key"],
+            base_url=kwargs["base_url"],
+            temperature=temperature,
+            timeout_seconds=timeout_seconds,
+            provider="orcarouter",
         )
     if value.startswith("xai/"):
         kwargs = xai_openai_client_kwargs(value)

--- a/packages/playground/src/playground/tests/test_model_client_orcarouter.py
+++ b/packages/playground/src/playground/tests/test_model_client_orcarouter.py
@@ -1,0 +1,147 @@
+import pytest
+
+from playground import model_client
+from playground.openai_client import OpenAIChatClient
+from playground.user_sim.tool_client import OpenAIToolStepClient, build_tool_step_client
+
+
+class _FakeOpenAI:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.chat = object()
+
+
+def test_orcarouter_model_id_preserves_provider_model_path():
+    assert (
+        model_client.orcarouter_model_id("orcarouter/z-ai/glm-4.7")
+        == "z-ai/glm-4.7"
+    )
+
+
+def test_orcarouter_model_id_preserves_anthropic_model_path():
+    assert (
+        model_client.orcarouter_model_id(
+            "orcarouter/anthropic/claude-haiku-4.5"
+        )
+        == "anthropic/claude-haiku-4.5"
+    )
+
+
+def test_orcarouter_model_id_keeps_auto_router_alias():
+    assert model_client.orcarouter_model_id("orcarouter/auto") == "auto"
+
+
+def test_orcarouter_openai_client_kwargs_requires_api_key(monkeypatch):
+    monkeypatch.delenv("ORCAROUTER_API_KEY", raising=False)
+
+    with pytest.raises(RuntimeError, match="ORCAROUTER_API_KEY"):
+        model_client.orcarouter_openai_client_kwargs(
+            "orcarouter/z-ai/glm-4.7"
+        )
+
+
+def test_orcarouter_api_base_overrides_default(monkeypatch):
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-test")
+    monkeypatch.setenv("ORCAROUTER_API_BASE", "https://orcarouter.test/v1")
+
+    kwargs = model_client.orcarouter_openai_client_kwargs(
+        "orcarouter/z-ai/glm-4.7"
+    )
+    assert kwargs == {
+        "model": "z-ai/glm-4.7",
+        "api_key": "sk-orca-test",
+        "base_url": "https://orcarouter.test/v1",
+    }
+
+
+def test_build_json_client_routes_orcarouter_to_openai_compatible(monkeypatch):
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-test")
+    monkeypatch.delenv("ORCAROUTER_API_BASE", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    created: list[dict[str, str]] = []
+
+    def fake_openai(**kwargs):
+        created.append(kwargs)
+        return _FakeOpenAI(**kwargs)
+
+    monkeypatch.setattr("openai.OpenAI", fake_openai)
+
+    client = model_client.build_json_client("orcarouter/z-ai/glm-4.7")
+    assert isinstance(client, OpenAIChatClient)
+    assert client.model == "z-ai/glm-4.7"
+    assert created == [
+        {
+            "api_key": "sk-orca-test",
+            "base_url": model_client.ORCAROUTER_DEFAULT_BASE_URL,
+        }
+    ]
+
+
+def test_build_json_client_routes_orcarouter_auto(monkeypatch):
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-test")
+    monkeypatch.delenv("ORCAROUTER_API_BASE", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    created: list[dict[str, str]] = []
+
+    def fake_openai(**kwargs):
+        created.append(kwargs)
+        return _FakeOpenAI(**kwargs)
+
+    monkeypatch.setattr("openai.OpenAI", fake_openai)
+
+    client = model_client.build_json_client("orcarouter/auto")
+    assert isinstance(client, OpenAIChatClient)
+    assert client.model == "auto"
+    assert created == [
+        {
+            "api_key": "sk-orca-test",
+            "base_url": model_client.ORCAROUTER_DEFAULT_BASE_URL,
+        }
+    ]
+
+
+def test_build_tool_step_client_routes_orcarouter_to_openai_compatible(monkeypatch):
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-test")
+    monkeypatch.delenv("ORCAROUTER_API_BASE", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("CLAUDE_API_KEY", raising=False)
+    created: list[dict[str, str]] = []
+
+    def fake_openai(**kwargs):
+        created.append(kwargs)
+        return _FakeOpenAI(**kwargs)
+
+    monkeypatch.setattr("openai.OpenAI", fake_openai)
+
+    client = build_tool_step_client("orcarouter/z-ai/glm-4.7")
+    assert isinstance(client, OpenAIToolStepClient)
+    assert client.model == "z-ai/glm-4.7"
+    assert created == [
+        {
+            "api_key": "sk-orca-test",
+            "base_url": model_client.ORCAROUTER_DEFAULT_BASE_URL,
+        }
+    ]
+
+
+def test_openai_base_url_does_not_change_orcarouter_routing(monkeypatch):
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-test")
+    monkeypatch.delenv("ORCAROUTER_API_BASE", raising=False)
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://openai-proxy.test/v1")
+    created: list[dict[str, str]] = []
+
+    def fake_openai(**kwargs):
+        created.append(kwargs)
+        return _FakeOpenAI(**kwargs)
+
+    monkeypatch.setattr("openai.OpenAI", fake_openai)
+
+    client = model_client.build_json_client("orcarouter/z-ai/glm-4.7")
+    assert isinstance(client, OpenAIChatClient)
+    assert client.model == "z-ai/glm-4.7"
+    assert created == [
+        {
+            "api_key": "sk-orca-test",
+            "base_url": model_client.ORCAROUTER_DEFAULT_BASE_URL,
+        }
+    ]

--- a/packages/playground/src/playground/user_sim/tool_client.py
+++ b/packages/playground/src/playground/user_sim/tool_client.py
@@ -217,6 +217,7 @@ def build_tool_step_client(
         dashscope_openai_client_kwargs,
         deepseek_openai_client_kwargs,
         gemini_openai_client_kwargs,
+        orcarouter_openai_client_kwargs,
         openrouter_openai_client_kwargs,
         xai_openai_client_kwargs,
         zai_openai_client_kwargs,
@@ -271,6 +272,16 @@ def build_tool_step_client(
             temperature=temperature,
             capabilities=capabilities,
             provider="openrouter",
+        )
+    if value.startswith("orcarouter/"):
+        kwargs = orcarouter_openai_client_kwargs(value)
+        return OpenAIToolStepClient(
+            kwargs["model"],
+            api_key=kwargs["api_key"],
+            base_url=kwargs["base_url"],
+            temperature=temperature,
+            capabilities=capabilities,
+            provider="orcarouter",
         )
     if value.startswith("xai/"):
         kwargs = xai_openai_client_kwargs(value)

--- a/src/matraix/provider_credentials.py
+++ b/src/matraix/provider_credentials.py
@@ -37,6 +37,8 @@ def resolve_provider_credential(model_name: str) -> ProviderCredential:
         return ProviderCredential("Gemini", "GEMINI_API_KEY", value)
     if lowered.startswith("openrouter/"):
         return ProviderCredential("OpenRouter", "OPENROUTER_API_KEY", value)
+    if lowered.startswith("orcarouter/"):
+        return ProviderCredential("OrcaRouter", "ORCAROUTER_API_KEY", value)
     if lowered.startswith("xai/"):
         return ProviderCredential("xAI", "XAI_API_KEY", value)
     if lowered.startswith("deepseek/"):

--- a/tests/unit/matraix/test_provider_credentials.py
+++ b/tests/unit/matraix/test_provider_credentials.py
@@ -55,6 +55,26 @@ def test_resolve_deepseek_and_zai(monkeypatch) -> None:
     assert resolve_provider_credential("zai/glm-5").present is True
 
 
+def test_resolve_openrouter_and_orcarouter(monkeypatch) -> None:
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("ORCAROUTER_API_KEY", raising=False)
+    openrouter = resolve_provider_credential("openrouter/z-ai/glm-4.7")
+    assert openrouter.provider == "OpenRouter"
+    assert openrouter.env_var == "OPENROUTER_API_KEY"
+    assert openrouter.present is False
+    orcarouter = resolve_provider_credential("orcarouter/auto")
+    assert orcarouter.provider == "OrcaRouter"
+    assert orcarouter.env_var == "ORCAROUTER_API_KEY"
+    assert orcarouter.present is False
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-test")
+    assert resolve_provider_credential("openrouter/anthropic/claude-haiku-4.5").present is True
+    assert (
+        resolve_provider_credential("orcarouter/anthropic/claude-haiku-4.5").present
+        is True
+    )
+
+
 def test_resolve_anthropic_default_and_bare_model() -> None:
     assert resolve_provider_credential("anthropic/claude-sonnet-4-6").env_var == (
         "ANTHROPIC_API_KEY"


### PR DESCRIPTION
## Module

- [ ] `persona/`
- [x] `application/`
- [ ] `environment/`
- [x] `packages/`
- [ ] `apps/`
- [ ] docs or migration metadata only

## Summary

Add **OrcaRouter** as a first-class persona-model provider, fully parallel to the
existing **OpenRouter** wiring. MatrAIx is persona-driven infrastructure for
evaluating AI systems with heterogeneous simulated users, and its Playground
already resolves provider-prefixed model ids through a named-provider registry.
Until now OrcaRouter could only be used by pointing an anonymous custom base URL
at it; this PR makes `orcarouter/*` a recognized provider so Playground users get
the full OrcaRouter stack (adaptive routing, failover, zero-markup inference,
observability, guardrails, agent-tool governance) without treating it as a
generic passthrough.

Every OrcaRouter code path mirrors the corresponding OpenRouter one file-for-file:

| OpenRouter wiring (existing) | OrcaRouter wiring (this PR) |
|---|---|
| `packages/playground/src/playground/model_client.py` — `OPENROUTER_DEFAULT_BASE_URL`, `openrouter_model_id`, `openrouter_openai_client_kwargs`, `build_json_client` branch | same file — `ORCAROUTER_DEFAULT_BASE_URL` (`https://api.orcarouter.ai/v1`), `orcarouter_model_id`, `orcarouter_openai_client_kwargs`, `build_json_client` branch |
| `packages/playground/src/playground/user_sim/tool_client.py` — `build_tool_step_client` openrouter branch | same file — `build_tool_step_client` orcarouter branch |
| `application/playground/backend/service/config.py` — `PERSONA_MODEL_KNOB_META` `openrouter/…` entries | same file — `orcarouter/auto` (adaptive router) and `orcarouter/anthropic/claude-haiku-4.5` entries |
| `application/playground/backend/api/app.py` — preflight `OpenRouter` optional check | same file — preflight `OrcaRouter` optional check |
| `src/matraix/provider_credentials.py` — `openrouter/` → `OPENROUTER_API_KEY` | same file — `orcarouter/` → `ORCAROUTER_API_KEY` |
| `application/playground/frontend/src/lib/personaAgentCatalog.ts` — `openrouter` provider label + iOS CUA set | same file — `orcarouter` provider label + iOS CUA set |
| `docs/configuration.md`, `docs/environment/agents.md` — OpenRouter section | same files — OrcaRouter section |
| `packages/playground/src/playground/tests/test_model_client_openrouter.py` | `packages/playground/src/playground/tests/test_model_client_orcarouter.py` |

Like the existing `openrouter/` prefix, `orcarouter/` strips only the leading
prefix, resolves `ORCAROUTER_API_KEY`, defaults to `https://api.orcarouter.ai/v1`
(overridable with `ORCAROUTER_API_BASE`), and deliberately ignores
`OPENAI_BASE_URL` so one process can route some models through OrcaRouter and
others direct to their native providers. The special `orcarouter/auto` model id
lets OrcaRouter pick a live upstream model per request via its adaptive router.

### Why OrcaRouter

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built
for both models and agents. Like OpenRouter, it exposes a provider/model
namespace across many models — but it also combines adaptive routing, automatic
failover, zero-markup inference, observability, guardrails, and agent-tool
governance behind the same endpoint. Adding orcarouter as a first-class provider
means this project's users can use that stack directly, without treating
OrcaRouter as an anonymous custom base URL.

It also runs gateway-level, zero-trust security for AI agents on the same
endpoint — screening every prompt/response and governing every tool call on a
default-deny basis, with no application code changes.

## Validation

Commands run (all green):

```bash
# Playground model-client + provider-credential unit tests
uv run pytest packages/playground/src/playground/tests/test_model_client_orcarouter.py \
  packages/playground/src/playground/tests/test_model_client_openrouter.py \
  packages/playground/src/playground/tests/test_model_client.py \
  tests/unit/matraix/test_provider_credentials.py          # 45 passed

# Playground backend preflight + options tests
uv run pytest application/playground/backend/tests/test_config.py \
  application/playground/backend/tests/test_api.py         # 29 passed

# Broader regression sweep
uv run pytest tests/unit/ packages/playground/src/playground/tests/... \
  application/playground/backend/tests/...                 # 795 passed, 2 skipped

# Frontend typecheck
npm run typecheck                                         # clean

# Ruff on all changed Python files
uv run ruff check ...                                     # All checks passed
```

Live L3 check — a real completion through the new `orcarouter/` code path
(`build_json_client("orcarouter/deepseek/deepseek-v4-flash-free")` →
`orcarouter_openai_client_kwargs` → `https://api.orcarouter.ai/v1`) returned
`{'ok': 'ORCA-OK'}` with usage attributed to `provider='orcarouter'`. The
`orcarouter/auto` id was also exercised and correctly resolved the endpoint
(returned a model-capacity 404 from OrcaRouter, confirming the API was reached).

## Data Policy

- [x] No large generated outputs or raw dumps were added.
- [x] Any fixtures are small and necessary for tests or docs.

---

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
