### PR TITLE
feat(playground): honor portions on 1M Pull

### DIFF
--- a/application/playground/backend/service/persona_1m_pool.py
+++ b/application/playground/backend/service/persona_1m_pool.py
@@ -489,9 +489,13 @@ def _stratified_sample_production(
     sources: list[str] | None,
     dimension_filters: dict[str, list[str]] | None,
     allocation: str | None = None,
+    portions: dict[str, dict[str, float]] | None = None,
 ) -> list[dict[str, Any]]:
     """Fast stratified sample with sequential early-exit when the target is known."""
-    from backend.service.persona_sampling_alloc import sample_proportional_from_buckets
+    from backend.service.persona_sampling_alloc import (
+        sample_by_portions_from_buckets,
+        sample_proportional_from_buckets,
+    )
 
     bare = [str(field).removeprefix("dimensions.").strip() for field in stratify_fields]
     bare = [field for field in bare if field]
@@ -566,6 +570,27 @@ def _stratified_sample_production(
             break
 
     if allocation_norm == "proportional":
+        if portions:
+            if len(bare) != 1:
+                raise ValueError(
+                    "portions currently supports a single stratify field "
+                    f"(got {', '.join(bare)})"
+                )
+            field = bare[0]
+            weights = portions.get(field) if isinstance(portions, dict) else None
+            if not isinstance(weights, dict) or not weights:
+                raise ValueError(
+                    f"portions has no target weights for stratify field {field!r}"
+                )
+            value_buckets = {
+                key[0]: rows for key, rows in buckets.items() if len(key) == 1
+            }
+            return sample_by_portions_from_buckets(
+                value_buckets,
+                weights=weights,
+                sample_size=sample_size,
+                seed=seed,
+            )
         return sample_proportional_from_buckets(
             buckets, sample_size=sample_size, seed=seed
         )
@@ -585,6 +610,7 @@ def sample_production_1m(
     stratify_fields: list[str] | None = None,
     sample_size_per_value_group: int | None = None,
     allocation: str | None = None,
+    portions: dict[str, dict[str, float]] | None = None,
 ) -> dict[str, Any]:
     if sample_size < 1:
         raise ValueError("sample_size must be >= 1")
@@ -605,7 +631,18 @@ def sample_production_1m(
         and sample_size_per_value_group >= 1
     ):
         allocation_norm = "perCell"
-    if (
+    if portions:
+        if allocation_norm and allocation_norm != "proportional":
+            raise ValueError(
+                'portions mix weights are only valid with allocation "proportional"'
+            )
+        allocation_norm = "proportional"
+        if not any(str(field).strip() for field in (stratify_fields or [])):
+            raise ValueError(
+                "portions mix weights require a stratify field "
+                "(pass sampling.fields, or omit portions for a random draw)"
+            )
+    elif (
         stratify_fields
         and not allocation_norm
         and not (
@@ -664,6 +701,7 @@ def sample_production_1m(
                 sources=sources,
                 dimension_filters=dimension_filters,
                 allocation=allocation_norm or None,
+                portions=portions,
             )
         elif has_filters:
             chosen = _random_sample_filtered(

--- a/application/playground/backend/service/persona_pool_service.py
+++ b/application/playground/backend/service/persona_pool_service.py
@@ -2146,11 +2146,6 @@ class PersonaPoolService:
 
         # Production 1M: sample + materialize a YAML cohort. Never synthesize.
         if is_production_1m_root(persona_pool):
-            if portions:
-                raise ValueError(
-                    "portions target is not yet supported for matraix-persona-1m; "
-                    "sample from a dev/generated pool to hit a declared mix"
-                )
             result = sample_production_1m(
                 repo_root=self.repo_root,
                 sample_size=sample_size,
@@ -2160,6 +2155,7 @@ class PersonaPoolService:
                 stratify_fields=stratify_fields,
                 sample_size_per_value_group=sample_size_per_value_group,
                 allocation=allocation_norm,
+                portions=portions,
             )
             return self._shape_sample_response(
                 result,

--- a/application/playground/backend/tests/test_persona_1m_pool.py
+++ b/application/playground/backend/tests/test_persona_1m_pool.py
@@ -286,3 +286,59 @@ def test_preview_production_1m_pages_are_stable(tmp_path, monkeypatch):
     )
     assert [card["personaId"] for card in again["personas"]] == ids0
 
+
+def _tiny_1m_repo(tmp_path, monkeypatch, *, rows: int = 200) -> Path:
+    release = _write_tiny_release(tmp_path, rows=rows)
+    monkeypatch.setenv(pool_mod.ENV_1M_DIR, str(release))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "persona/schema").mkdir(parents=True)
+    (repo / "persona/schema/dimension_categories.json").write_text(
+        json.dumps({"schemaVersion": "1.0", "personaSources": [], "devProfile": {"groups": []}}),
+        encoding="utf-8",
+    )
+    return repo
+
+
+def test_sample_production_1m_honors_declared_portions(tmp_path, monkeypatch):
+    repo = _tiny_1m_repo(tmp_path, monkeypatch, rows=200)
+    result = pool_mod.sample_production_1m(
+        repo_root=repo,
+        sample_size=10,
+        seed=7,
+        stratify_fields=["age_bracket"],
+        allocation="proportional",
+        portions={"age_bracket": {"18-24": 0.7, "25-34": 0.3}},
+    )
+    ages = [card["dimensions"]["age_bracket"] for card in result["personas"]]
+    assert ages.count("18-24") == 7
+    assert ages.count("25-34") == 3
+    assert set(ages) == {"18-24", "25-34"}
+
+
+def test_sample_production_1m_portions_require_stratify_field(tmp_path, monkeypatch):
+    repo = _tiny_1m_repo(tmp_path, monkeypatch, rows=40)
+    with pytest.raises(ValueError, match="require a stratify field"):
+        pool_mod.sample_production_1m(
+            repo_root=repo,
+            sample_size=10,
+            seed=7,
+            portions={"age_bracket": {"18-24": 0.7, "25-34": 0.3}},
+        )
+
+
+def test_persona_pool_service_samples_1m_portions(tmp_path, monkeypatch):
+    repo = _tiny_1m_repo(tmp_path, monkeypatch, rows=200)
+    service = PersonaPoolService(repo_root=repo)
+    sampled = service.sample_pool(
+        persona_pool=pool_mod.PRODUCTION_1M_POOL,
+        sample_size=10,
+        seed=7,
+        stratify_fields=["age_bracket"],
+        allocation="proportional",
+        portions={"age_bracket": {"18-24": 0.7, "25-34": 0.3}},
+    )
+    ages = [card["dimensions"]["age_bracket"] for card in sampled["personas"]]
+    assert ages.count("18-24") == 7
+    assert ages.count("25-34") == 3
+


### PR DESCRIPTION
## Summary
- Dataset Pull on the 1M pool now honors the operator `portions` mix instead of rejecting it.
- Sampling already had the proportional allocation math; this wires it through `PersonaPoolService` so Pull matches the declared strategy.

## Test plan
- [ ] `PYTHONPATH=".:environment/runtime:packages/playground/src:application/playground" uv run python -m pytest application/playground/backend/tests/test_persona_1m_pool.py -q`
- [ ] In Playground, Pull from 1M with a portions mix and confirm cell counts follow the mix.


Made with [Cursor](https://cursor.com)