### PR TITLE
fix(playground): keep Dataset and selected personas together

### DIFF
--- a/application/playground/frontend/scripts/cohort-ref-contract.test.mjs
+++ b/application/playground/frontend/scripts/cohort-ref-contract.test.mjs
@@ -44,6 +44,20 @@ test("launch helper omits personaIds when useEntirePool", () => {
   assert.match(launch, /personaIds:\s*input\.selectedPersonaIds/);
 });
 
+test("task hydrate keeps Dataset + ids together and does not paste leftover people onto strategy pool", () => {
+  const storage = read("src/components/cockpit/setup/cockpitPersonaSetupStorage.ts");
+  const hook = read("src/components/cockpit/setup/useSetupPersonaSampling.ts");
+  assert.match(storage, /export function resolveTaskHydrateSetup/);
+  assert.match(storage, /keepOperatorCohort/);
+  assert.match(storage, /hasDurableOperatorCohort/);
+  assert.match(hook, /resolveTaskHydrateSetup\(/);
+  assert.match(hook, /incomingCohortRef/);
+  assert.doesNotMatch(
+    hook,
+    /applied\.selectedPersonaIds = stored\.selectedPersonaIds/,
+  );
+});
+
 test("parallel trials are not hard-capped by task type", () => {
   assert.throws(() => read("src/components/cockpit/setup/cockpitParallelCaps.ts"), /ENOENT/);
   const bar = read("src/components/cockpit/setup/RunLaunchBar.tsx");

--- a/application/playground/frontend/src/components/cockpit/setup/PersonaSamplingRail.tsx
+++ b/application/playground/frontend/src/components/cockpit/setup/PersonaSamplingRail.tsx
@@ -1088,7 +1088,7 @@ export function PersonaSamplingRail({
       return selectedPersonaIds.map((personaId) => ({
         personaId,
         name: syntheticDisplayName(personaId),
-        source: "matraix-persona-dev-sample",
+        source: activePool.split("/").filter(Boolean).pop() || "matraix-persona-dev-sample",
         dimensions: {},
       }));
     }
@@ -1100,6 +1100,7 @@ export function PersonaSamplingRail({
     disabled,
     selectedPersonaIds,
     lockedCohortQuery.data?.personas,
+    activePool,
   ]);
 
   useEffect(() => {
@@ -1111,9 +1112,10 @@ export function PersonaSamplingRail({
     if (useTaskDefaultStrategy) setStrategySummaryOpen(true);
   }, [taskPath, useTaskDefaultStrategy]);
 
-  // Turning Task default off resets pool/selection in the parent — drop local preview too.
+  // Turning Task default on starts a fresh strategy pull — drop stale preview.
+  // Turning it off keeps Dataset + selection, so leave preview cards in place.
   useEffect(() => {
-    if (!useTaskDefaultStrategy) {
+    if (useTaskDefaultStrategy) {
       setPreviewCards([]);
       setPullError(null);
       setGenerateError(null);
@@ -1126,6 +1128,9 @@ export function PersonaSamplingRail({
         // Cohort-ref selection is not per-card editable.
         return;
       }
+      // Launch pool must match the Dataset those cards were loaded from.
+      const cardPool = panelMode === "single" ? sourcePool : activePool;
+      onPersonaPoolChange?.(cardPool);
       if (mode === "single") {
         onSelectedPersonaIdsChange(
           selectedPersonaIds.includes(personaId) ? [] : [personaId],
@@ -1140,10 +1145,14 @@ export function PersonaSamplingRail({
       onSelectedCountChange?.(next.length);
     },
     [
+      activePool,
       mode,
+      onPersonaPoolChange,
       onSelectedCountChange,
       onSelectedPersonaIdsChange,
+      panelMode,
       selectedPersonaIds,
+      sourcePool,
       useEntirePool,
     ],
   );

--- a/application/playground/frontend/src/components/cockpit/setup/cockpitPersonaSetupStorage.test.ts
+++ b/application/playground/frontend/src/components/cockpit/setup/cockpitPersonaSetupStorage.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PERSONA_BENCH_POOL,
+  PERSONA_PRODUCTION_1M_POOL,
+  type TaskPersonaStrategy,
+} from "@/lib/types";
+
+import {
+  defaultPersonaSetup,
+  hasDurableOperatorCohort,
+  keepOperatorCohort,
+  resolveTaskHydrateSetup,
+  samplingModeForOperatorCohort,
+  scrubTaskStrategyFillForCustomMode,
+} from "./cockpitPersonaSetupStorage";
+
+const MODEL = "anthropic/claude-haiku-4-5";
+const CLARA = "wiki-e690edb701e2";
+const FILL_POOL = "persona/datasets/generated-persona-dev-strategy-abc";
+
+const SURVEY_STRATEGY: TaskPersonaStrategy = {
+  sampling: {
+    mode: "stratified",
+    fields: ["economic_motivation"],
+    allocation: "proportional",
+    sampleSize: 20,
+  },
+  dimensionFilters: {
+    life_stage: ["Parent of young kids"],
+  },
+};
+
+function storedDraft(
+  overrides: Partial<ReturnType<typeof defaultPersonaSetup>> = {},
+) {
+  return {
+    ...defaultPersonaSetup(MODEL),
+    ...overrides,
+  };
+}
+
+describe("samplingModeForOperatorCohort", () => {
+  it("matches explicit launch ids instead of strategy stratified-N", () => {
+    expect(
+      samplingModeForOperatorCohort({
+        selectedPersonaIds: [CLARA],
+        selectedCount: 1,
+      }),
+    ).toBe("single");
+    expect(
+      samplingModeForOperatorCohort({
+        selectedPersonaIds: [CLARA, "wiki-other"],
+        selectedCount: 2,
+      }),
+    ).toBe("random");
+    expect(
+      samplingModeForOperatorCohort({
+        selectedPersonaIds: [],
+        selectedCount: 20,
+        useEntirePool: true,
+      }),
+    ).toBe("all");
+  });
+});
+
+describe("hasDurableOperatorCohort", () => {
+  it("rejects task-fill generate pools", () => {
+    expect(
+      hasDurableOperatorCohort({
+        personaPool: FILL_POOL,
+        selectedPersonaIds: [CLARA],
+        selectedCount: 1,
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts a 1M Dataset pick", () => {
+    expect(
+      hasDurableOperatorCohort({
+        personaPool: PERSONA_PRODUCTION_1M_POOL,
+        selectedPersonaIds: [CLARA],
+        selectedCount: 1,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("resolveTaskHydrateSetup", () => {
+  it("keeps Dataset + id together and turns Task default off when picking a survey after a 1M persona", () => {
+    const applied = resolveTaskHydrateSetup({
+      strategy: SURVEY_STRATEGY,
+      stored: storedDraft(),
+      hasTaskSpecificStore: false,
+      incoming: {
+        personaPool: PERSONA_PRODUCTION_1M_POOL,
+        selectedPersonaIds: [CLARA],
+        selectedCount: 1,
+        useEntirePool: false,
+      },
+      fallbackPersonaModel: MODEL,
+    });
+
+    expect(applied.personaPool).toBe(PERSONA_PRODUCTION_1M_POOL);
+    expect(applied.selectedPersonaIds).toEqual([CLARA]);
+    expect(applied.useTaskDefaultStrategy).toBe(false);
+    expect(applied.taskDefaultStrategyDismissed).toBe(true);
+    expect(applied.samplingMode).toBe("single");
+  });
+
+  it("applies persona_strategy.json on a fresh task with no operator pick", () => {
+    const applied = resolveTaskHydrateSetup({
+      strategy: SURVEY_STRATEGY,
+      stored: storedDraft({
+        personaPool: PERSONA_PRODUCTION_1M_POOL,
+        selectedPersonaIds: [CLARA],
+        selectedCount: 1,
+      }),
+      hasTaskSpecificStore: false,
+      incoming: {
+        personaPool: PERSONA_BENCH_POOL,
+        selectedPersonaIds: [],
+        selectedCount: 0,
+        useEntirePool: false,
+      },
+      fallbackPersonaModel: MODEL,
+    });
+
+    expect(applied.useTaskDefaultStrategy).toBe(true);
+    expect(applied.selectedPersonaIds).toEqual([]);
+    expect(applied.samplingMode).toBe("stratified");
+    expect(applied.sampleSize).toBe(20);
+    expect(applied.personaPool).toBe(PERSONA_BENCH_POOL);
+  });
+
+  it("does not paste leftover ids onto the strategy pool", () => {
+    const applied = resolveTaskHydrateSetup({
+      strategy: SURVEY_STRATEGY,
+      stored: storedDraft({
+        personaPool: PERSONA_BENCH_POOL,
+        selectedPersonaIds: [CLARA],
+        selectedCount: 1,
+      }),
+      hasTaskSpecificStore: false,
+      incoming: {
+        personaPool: PERSONA_BENCH_POOL,
+        selectedPersonaIds: [],
+        selectedCount: 0,
+        useEntirePool: false,
+      },
+      fallbackPersonaModel: MODEL,
+    });
+
+    expect(applied.selectedPersonaIds).toEqual([]);
+    expect(applied.personaPool).toBe(PERSONA_BENCH_POOL);
+    expect(applied.useTaskDefaultStrategy).toBe(true);
+  });
+
+  it("restores a dismissed custom 1M pick for the same task", () => {
+    const stored = storedDraft({
+      personaPool: PERSONA_PRODUCTION_1M_POOL,
+      selectedPersonaIds: [CLARA],
+      selectedCount: 1,
+      useTaskDefaultStrategy: false,
+      taskDefaultStrategyDismissed: true,
+      samplingMode: "single",
+    });
+    const applied = resolveTaskHydrateSetup({
+      strategy: SURVEY_STRATEGY,
+      stored,
+      hasTaskSpecificStore: true,
+      incoming: {
+        personaPool: PERSONA_BENCH_POOL,
+        selectedPersonaIds: [],
+        selectedCount: 0,
+        useEntirePool: false,
+      },
+      fallbackPersonaModel: MODEL,
+    });
+
+    expect(applied.personaPool).toBe(PERSONA_PRODUCTION_1M_POOL);
+    expect(applied.selectedPersonaIds).toEqual([CLARA]);
+    expect(applied.useTaskDefaultStrategy).toBe(false);
+  });
+
+  it("restores this task's fill pool with Task default on", () => {
+    const stored = storedDraft({
+      personaPool: FILL_POOL,
+      selectedPersonaIds: ["gen-1"],
+      selectedCount: 1,
+      useTaskDefaultStrategy: true,
+    });
+    const applied = resolveTaskHydrateSetup({
+      strategy: SURVEY_STRATEGY,
+      stored,
+      hasTaskSpecificStore: true,
+      incoming: {
+        personaPool: FILL_POOL,
+        selectedPersonaIds: ["gen-1"],
+        selectedCount: 1,
+        useEntirePool: false,
+      },
+      fallbackPersonaModel: MODEL,
+    });
+
+    expect(applied.personaPool).toBe(FILL_POOL);
+    expect(applied.selectedPersonaIds).toEqual(["gen-1"]);
+    expect(applied.useTaskDefaultStrategy).toBe(true);
+    expect(applied.samplingMode).toBe("stratified");
+  });
+
+  it("does not sticky-restore a fill pool onto the next task", () => {
+    const applied = resolveTaskHydrateSetup({
+      strategy: SURVEY_STRATEGY,
+      stored: storedDraft(),
+      hasTaskSpecificStore: false,
+      incoming: {
+        personaPool: FILL_POOL,
+        selectedPersonaIds: ["gen-1"],
+        selectedCount: 1,
+        useEntirePool: false,
+      },
+      fallbackPersonaModel: MODEL,
+    });
+
+    expect(applied.personaPool).toBe(PERSONA_BENCH_POOL);
+    expect(applied.selectedPersonaIds).toEqual([]);
+    expect(applied.useTaskDefaultStrategy).toBe(true);
+  });
+});
+
+describe("scrubTaskStrategyFillForCustomMode", () => {
+  it("falls back to the previous non-fill Dataset instead of always bench", () => {
+    const scrubbed = scrubTaskStrategyFillForCustomMode(
+      storedDraft({
+        personaPool: FILL_POOL,
+        selectedPersonaIds: ["gen-1"],
+        selectedCount: 1,
+      }),
+      MODEL,
+      PERSONA_PRODUCTION_1M_POOL,
+    );
+
+    expect(scrubbed.personaPool).toBe(PERSONA_PRODUCTION_1M_POOL);
+    expect(scrubbed.selectedPersonaIds).toEqual([]);
+    expect(scrubbed.useTaskDefaultStrategy).toBe(false);
+  });
+
+  it("leaves a durable Dataset untouched", () => {
+    const record = storedDraft({
+      personaPool: PERSONA_PRODUCTION_1M_POOL,
+      selectedPersonaIds: [CLARA],
+      selectedCount: 1,
+    });
+    expect(scrubTaskStrategyFillForCustomMode(record, MODEL)).toBe(record);
+  });
+});
+
+describe("keepOperatorCohort", () => {
+  it("never pairs leftover ids with a different pool", () => {
+    const next = keepOperatorCohort(defaultPersonaSetup(MODEL), {
+      personaPool: PERSONA_PRODUCTION_1M_POOL,
+      selectedPersonaIds: [CLARA],
+      selectedCount: 1,
+      useEntirePool: false,
+    });
+    expect(next.personaPool).toBe(PERSONA_PRODUCTION_1M_POOL);
+    expect(next.selectedPersonaIds).toEqual([CLARA]);
+    expect(next.useTaskDefaultStrategy).toBe(false);
+  });
+});

--- a/application/playground/frontend/src/components/cockpit/setup/cockpitPersonaSetupStorage.ts
+++ b/application/playground/frontend/src/components/cockpit/setup/cockpitPersonaSetupStorage.ts
@@ -40,6 +40,34 @@ export function sanitizePersonaPool(pool: string | null | undefined): string {
   return text;
 }
 
+/** Operator-picked Dataset + people (not a task-fill generate pool). */
+export function hasDurableOperatorCohort(input: {
+  personaPool?: string | null;
+  selectedPersonaIds?: string[];
+  selectedCount?: number;
+  useEntirePool?: boolean;
+}): boolean {
+  if (isTaskStrategyFillPool(input.personaPool)) return false;
+  if (!(input.personaPool ?? "").trim()) return false;
+  return (
+    input.useEntirePool === true ||
+    (input.selectedPersonaIds?.length ?? 0) > 0 ||
+    (input.selectedCount ?? 0) > 0
+  );
+}
+
+/** Sampling UI that matches an explicit launch cohort (not strategy stratified-N). */
+export function samplingModeForOperatorCohort(input: {
+  selectedPersonaIds: string[];
+  selectedCount?: number;
+  useEntirePool?: boolean;
+}): PersonaSamplingMode {
+  if (input.useEntirePool) return "all";
+  const size = Math.max(input.selectedCount ?? 0, input.selectedPersonaIds.length);
+  if (size <= 1) return "single";
+  return "random";
+}
+
 export interface CockpitPersonaSetupRecord {
   selectedPersonaIds: string[];
   /** Full cohort size (may exceed selectedPersonaIds when launching by pool ref). */
@@ -236,21 +264,120 @@ export function defaultPersonaSetup(fallbackPersonaModel: string): CockpitPerson
 
 /**
  * Custom mode (Task default off) must not keep a task-fill cohort as Dataset.
- * Returns a clean sandbox record when the stored pool is strategy-owned.
+ * Falls back to the previous non-fill dataset when one is known.
  */
 export function scrubTaskStrategyFillForCustomMode(
   record: CockpitPersonaSetupRecord,
   fallbackPersonaModel: string,
+  durablePool?: string | null,
 ): CockpitPersonaSetupRecord {
   if (!isTaskStrategyFillPool(record.personaPool)) return record;
   const defaults = defaultPersonaSetup(fallbackPersonaModel);
+  const fallbackPool =
+    durablePool && !isTaskStrategyFillPool(durablePool)
+      ? sanitizePersonaPool(durablePool)
+      : PERSONA_BENCH_POOL;
   return {
     ...defaults,
+    personaPool: fallbackPool,
     personaModel: record.personaModel || defaults.personaModel,
     parallelTrials: record.parallelTrials || defaults.parallelTrials,
     useTaskDefaultStrategy: false,
     taskDefaultStrategyDismissed: true,
   };
+}
+
+/** Keep Dataset + selected ids as one selection and dismiss Task default. */
+export function keepOperatorCohort(
+  base: CockpitPersonaSetupRecord,
+  cohort: {
+    personaPool: string;
+    selectedPersonaIds: string[];
+    selectedCount: number;
+    useEntirePool: boolean;
+  },
+): CockpitPersonaSetupRecord {
+  const selectedPersonaIds = cohort.selectedPersonaIds;
+  const selectedCount = cohort.selectedCount || selectedPersonaIds.length;
+  return {
+    ...base,
+    personaPool: sanitizePersonaPool(cohort.personaPool),
+    selectedPersonaIds,
+    selectedCount,
+    useEntirePool: cohort.useEntirePool,
+    samplingMode: samplingModeForOperatorCohort({
+      selectedPersonaIds,
+      selectedCount,
+      useEntirePool: cohort.useEntirePool,
+    }),
+    useTaskDefaultStrategy: false,
+    taskDefaultStrategyDismissed: true,
+  };
+}
+
+export type TaskHydrateIncomingCohort = {
+  personaPool: string;
+  selectedPersonaIds: string[];
+  selectedCount: number;
+  useEntirePool: boolean;
+};
+
+/**
+ * Resolve cockpit persona state when a task path hydrates.
+ *
+ * Invariant: never launch pool A with ids from pool B. An operator pick
+ * (Dataset + people) restores together and turns Task default off so the
+ * rail matches POST. Task-fill pools stay ephemeral.
+ */
+export function resolveTaskHydrateSetup(input: {
+  strategy: TaskPersonaStrategy | null | undefined;
+  stored: CockpitPersonaSetupRecord;
+  hasTaskSpecificStore: boolean;
+  incoming: TaskHydrateIncomingCohort;
+  fallbackPersonaModel: string;
+}): CockpitPersonaSetupRecord {
+  const { strategy, stored, hasTaskSpecificStore, incoming, fallbackPersonaModel } = input;
+  const dismissed = stored.taskDefaultStrategyDismissed === true;
+  const modelBase: CockpitPersonaSetupRecord = {
+    ...defaultPersonaSetup(fallbackPersonaModel),
+    personaModel: stored.personaModel || fallbackPersonaModel,
+    parallelTrials: stored.parallelTrials,
+  };
+
+  // First visit of this task: honor people already on screen (or kind-level draft).
+  if (!hasTaskSpecificStore && hasDurableOperatorCohort(incoming)) {
+    return keepOperatorCohort(modelBase, incoming);
+  }
+
+  if (hasTaskSpecificStore && (dismissed || !strategy)) {
+    return scrubTaskStrategyFillForCustomMode(
+      {
+        ...stored,
+        useTaskDefaultStrategy: Boolean(strategy) && stored.useTaskDefaultStrategy,
+        taskDefaultStrategyDismissed: dismissed,
+      },
+      fallbackPersonaModel,
+    );
+  }
+
+  // This task's own fill pool is owned by Task default ON.
+  if (hasTaskSpecificStore && isTaskStrategyFillPool(stored.personaPool)) {
+    const applied = setupFromPersonaStrategy(strategy, fallbackPersonaModel, modelBase);
+    applied.personaPool = sanitizePersonaPool(stored.personaPool);
+    applied.selectedPersonaIds = stored.selectedPersonaIds;
+    applied.selectedCount = stored.selectedCount || stored.selectedPersonaIds.length;
+    applied.useEntirePool = stored.useEntirePool;
+    return applied;
+  }
+
+  // Returning with an explicit Dataset pick: restore atomically, don't show
+  // strategy stratified-N while launch would send those ids.
+  if (hasTaskSpecificStore && hasDurableOperatorCohort(stored)) {
+    return keepOperatorCohort(modelBase, stored);
+  }
+
+  // Task owns the cohort — do not paste leftover ids from a previous screen.
+  return setupFromPersonaStrategy(strategy, fallbackPersonaModel, modelBase);
 }
 
 export function setupFromPersonaStrategy(
@@ -361,6 +488,8 @@ export function readCockpitPersonaSetup(
     return {
       ...defaultPersonaSetup(fallbackPersonaModel),
       selectedPersonaIds: batch.personaIds,
+      selectedCount: batch.selectedCount || batch.personaIds.length,
+      personaPool: sanitizePersonaPool(batch.personaPool || PERSONA_BENCH_POOL),
     };
   }
 
@@ -376,8 +505,12 @@ export function writeCockpitPersonaSetup(
   const path = taskPath?.trim() ?? "";
   if (path) {
     store.byTaskPath = { ...(store.byTaskPath ?? {}), [path]: record };
-  } else {
-    store.byKind = { ...(store.byKind ?? {}), [taskKind]: record };
   }
+  // Last operator draft for this kind. New task paths fall back to byKind;
+  // never sticky-restore a task-fill pool as Dataset.
+  store.byKind = {
+    ...(store.byKind ?? {}),
+    [taskKind]: scrubTaskStrategyFillForCustomMode(record, record.personaModel),
+  };
   writeStore(store);
 }

--- a/application/playground/frontend/src/components/cockpit/setup/useSetupPersonaSampling.ts
+++ b/application/playground/frontend/src/components/cockpit/setup/useSetupPersonaSampling.ts
@@ -14,6 +14,8 @@ import {
   hasStoredPersonaSetup,
   isTaskStrategyFillPool,
   readCockpitPersonaSetup,
+  resolveTaskHydrateSetup,
+  samplingModeForOperatorCohort,
   sanitizePersonaPool,
   scrubTaskStrategyFillForCustomMode,
   setupFromPersonaStrategy,
@@ -90,6 +92,23 @@ export function useSetupPersonaSampling(
   const hydratedPathRef = useRef<string | null>(null);
   const skipNextPersistRef = useRef(false);
   const handoffAppliedRef = useRef(false);
+  const incomingCohortRef = useRef({
+    personaPool,
+    selectedPersonaIds,
+    selectedCount,
+    useEntirePool,
+  });
+  incomingCohortRef.current = {
+    personaPool,
+    selectedPersonaIds,
+    selectedCount,
+    useEntirePool,
+  };
+  const lastDurablePersonaPoolRef = useRef(
+    isTaskStrategyFillPool(initial.personaPool)
+      ? PERSONA_BENCH_POOL
+      : sanitizePersonaPool(initial.personaPool),
+  );
   const { state: urlState, setState: setUrlState } = useUrlState();
 
   const strategyQuery = useQuery({
@@ -178,28 +197,53 @@ export function useSetupPersonaSampling(
         resetToTaskStrategy();
         return;
       }
-      // Explicit opt-out: leave the task-fill / strategy cohort and return to
-      // the stock Quick-pick sandbox (dev-sample + empty selection).
+      // Explicit opt-out: unlock filters. Keep Dataset + selection unless the
+      // current pool is a task-fill generate cohort.
       const defaults = defaultPersonaSetup(fallbackPersonaModel);
       setTaskDefaultStrategyDismissed(true);
       setUseTaskDefaultStrategyState(false);
-      setPersonaPool(PERSONA_BENCH_POOL);
-      setSelectedPersonaIds([]);
-      setSelectedCount(0);
-      setUseEntirePool(false);
-      setSamplingMode(defaults.samplingMode);
+      if (isTaskStrategyFillPool(personaPool)) {
+        setPersonaPool(
+          sanitizePersonaPool(lastDurablePersonaPoolRef.current) || PERSONA_BENCH_POOL,
+        );
+        setSelectedPersonaIds([]);
+        setSelectedCount(0);
+        setUseEntirePool(false);
+        setSamplingMode(defaults.samplingMode);
+      } else {
+        setSamplingMode(
+          samplingModeForOperatorCohort({
+            selectedPersonaIds,
+            selectedCount,
+            useEntirePool,
+          }),
+        );
+      }
       setGroupFilters(emptyPersonaDimensionFilters());
       setFields(defaults.fields);
       setStratifiedAllocationState(defaults.stratifiedAllocation);
       setSampleSize(defaults.sampleSize);
       setPerCell(defaults.perCell);
     },
-    [fallbackPersonaModel, resetToTaskStrategy],
+    [
+      fallbackPersonaModel,
+      personaPool,
+      resetToTaskStrategy,
+      selectedCount,
+      selectedPersonaIds,
+      useEntirePool,
+    ],
   );
 
   useEffect(() => {
     setTaskPersonaStrategy(strategyQuery.data ?? null);
   }, [strategyQuery.data]);
+
+  useEffect(() => {
+    if (!isTaskStrategyFillPool(personaPool)) {
+      lastDurablePersonaPoolRef.current = sanitizePersonaPool(personaPool);
+    }
+  }, [personaPool]);
 
   const appliedKeyRef = useRef<string | null>(null);
   useEffect(() => {
@@ -264,52 +308,15 @@ export function useSetupPersonaSampling(
 
     const stored = readCockpitPersonaSetup(taskKind, fallbackPersonaModel, path);
     const strategy = strategyQuery.data;
-    const dismissed = stored.taskDefaultStrategyDismissed === true;
-
     const hasTaskSpecificStore = hasStoredPersonaSetup(path);
-    const effectiveModel = hasTaskSpecificStore ? stored.personaModel : fallbackPersonaModel;
 
-    let applied: CockpitPersonaSetupRecord;
-    if (strategy && !dismissed) {
-      applied = setupFromPersonaStrategy(strategy, fallbackPersonaModel, {
-        ...defaultPersonaSetup(fallbackPersonaModel),
-        personaModel: effectiveModel,
-        parallelTrials: stored.parallelTrials,
-      });
-      // Keep last cohort selection across remount/navigation. Strategy apply
-      // clears preview ids intentionally for explicit "Task default" toggles,
-      // but hydrate must not wipe a selection the operator already made.
-      if (stored.selectedPersonaIds.length > 0 || stored.selectedCount > 0) {
-        applied.selectedPersonaIds = stored.selectedPersonaIds;
-        applied.selectedCount = stored.selectedCount || stored.selectedPersonaIds.length;
-        applied.useEntirePool = stored.useEntirePool;
-      }
-      // Task-fill pools belong to Task default ON — restore them with the cohort.
-      if (isTaskStrategyFillPool(stored.personaPool)) {
-        applied.personaPool = sanitizePersonaPool(stored.personaPool);
-      }
-    } else if (hasTaskSpecificStore) {
-      // Custom / dismissed: restore draft, but never sticky-restore a task-fill pool.
-      applied = scrubTaskStrategyFillForCustomMode(
-        {
-          ...stored,
-          useTaskDefaultStrategy: Boolean(strategy) && stored.useTaskDefaultStrategy,
-          taskDefaultStrategyDismissed: dismissed,
-        },
-        fallbackPersonaModel,
-      );
-    } else {
-      applied = setupFromPersonaStrategy(strategy, fallbackPersonaModel, {
-        ...defaultPersonaSetup(fallbackPersonaModel),
-        personaModel: effectiveModel,
-        parallelTrials: stored.parallelTrials,
-      });
-      if (stored.selectedPersonaIds.length > 0 || stored.selectedCount > 0) {
-        applied.selectedPersonaIds = stored.selectedPersonaIds;
-        applied.selectedCount = stored.selectedCount || stored.selectedPersonaIds.length;
-        applied.useEntirePool = stored.useEntirePool;
-      }
-    }
+    let applied = resolveTaskHydrateSetup({
+      strategy,
+      stored,
+      hasTaskSpecificStore,
+      incoming: incomingCohortRef.current,
+      fallbackPersonaModel,
+    });
 
     const handoff = isActive ? peekPersonaHandoff() : null;
     if (handoff && handoff.personaIds.length > 0) {
@@ -399,7 +406,11 @@ export function useSetupPersonaSampling(
       taskKind,
       useTaskDefaultStrategy
         ? draft
-        : scrubTaskStrategyFillForCustomMode(draft, fallbackPersonaModel),
+        : scrubTaskStrategyFillForCustomMode(
+            draft,
+            fallbackPersonaModel,
+            lastDurablePersonaPoolRef.current,
+          ),
       normalizedPath,
     );
   }, [
@@ -431,9 +442,9 @@ export function useSetupPersonaSampling(
     setPersona({
       id,
       name: `persona-${id}`,
-      source: "matraix-persona-dev-sample",
+      source: personaPool.split("/").filter(Boolean).pop() || "matraix-persona-dev-sample",
     });
-  }, [selectedPersonaIds]);
+  }, [personaPool, selectedPersonaIds]);
 
   const isBatchRun =
     samplingMode !== "single" || selectedCount > 1 || selectedPersonaIds.length > 1;

--- a/src/matraix/application_job.py
+++ b/src/matraix/application_job.py
@@ -163,7 +163,9 @@ def resolve_persona_entries(
             if pool_path.is_file():
                 entry = _persona_entry_from_path(pool_path, repo_root=repo_root)
             else:
-                raise ValueError("unknown persona: {}".format(persona_id))
+                raise ValueError(
+                    "unknown persona {} in pool {}".format(persona_id, persona_pool)
+                )
 
         path = str(entry.get("path") or "")
         if path in seen_paths:

--- a/tests/unit/playground_core/test_application_job.py
+++ b/tests/unit/playground_core/test_application_job.py
@@ -50,6 +50,26 @@ def test_resolve_persona_entries_accepts_persona_prefixed_ids(tmp_path: Path) ->
     assert chosen[0]["path"] == "persona/datasets/matraix-persona-dev-sample/persona_0042.yaml"
 
 
+def test_resolve_persona_entries_unknown_includes_pool(tmp_path: Path) -> None:
+    repo = tmp_path
+    pool = repo / "persona" / "datasets" / "matraix-persona-dev-sample"
+    pool.mkdir(parents=True)
+    (pool / "persona_0042.yaml").write_text(
+        "persona_id: '0042'\nversion: '1.0'\nsource: Nemotron\ndimensions: {}\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"unknown persona wiki-e690edb701e2 in pool persona/datasets/matraix-persona-dev-sample",
+    ):
+        resolve_persona_entries(
+            ["wiki-e690edb701e2"],
+            persona_pool="persona/datasets/matraix-persona-dev-sample",
+            repo_root=repo,
+        )
+
+
 def test_build_application_job_config_with_explicit_persona_ids(tmp_path: Path) -> None:
     repo = tmp_path
     pool = repo / "persona" / "datasets" / "matraix-persona-dev-sample"


### PR DESCRIPTION
## Summary
- Dataset and selected persona ids stay a pair. Turning Task default off no longer resets the pool while keeping ids from another dataset.
- First hydrate with an operator 1M pick keeps that Dataset + ids and turns Task default off. A fresh task with no pick still applies `persona_strategy.json`.
- Launch rejects unknown persona ids in the chosen pool (`unknown persona {id} in pool {pool}`).

Closes #129

## Test plan
- [ ] Reproduce #129: pick 1M personas, then toggle Task default off — Dataset and the selected ids stay together.
- [ ] Fresh task, no pick: strategy still applies.
- [ ] `npx vitest run src/components/cockpit/setup/cockpitPersonaSetupStorage.test.ts` in `application/playground/frontend`
- [ ] `PYTHONPATH=".:environment/runtime:packages/playground/src:application/playground" uv run python -m pytest tests/unit/playground_core/test_application_job.py -q`


Made with [Cursor](https://cursor.com)