### PR TITLE
feat(cli): dispatch matraix run -c through HarborJobService

### DIFF
--- a/application/scripts/generate_application_job.py
+++ b/application/scripts/generate_application_job.py
@@ -41,6 +41,7 @@ from persona_retrieval import (  # noqa: E402
 
 DEFAULT_JOBS_DIR = REPO_ROOT / "configs" / "jobs" / "application-task-job-recipe"
 _EXECUTION_MODES = frozenset({"auto", "force_docker", "smoke"})
+_DEFAULT_N_CONCURRENT_TRIALS = 2
 
 
 def _display_path(path: Path) -> str:
@@ -75,6 +76,7 @@ def _format_run_env_comment(
     *,
     model_name: str,
     sample_size: int,
+    compute_family: str = "local",
 ) -> str:
     primary_exports = export_hint_lines(model_name)
     needs_openai_sut = any(name == "MATRIX_CHATBOT_TASK_PATH" for name, _ in exports)
@@ -86,6 +88,12 @@ def _format_run_env_comment(
     for name, value in exports:
         lines.append(f"#   export {name}={value}")
     lines.append("#   uv run matraix run -c <this-file>")
+    if compute_family and compute_family != "local":
+        lines.append(
+            "#   sidecar computeFamily={} — matraix run uses HarborJobService".format(
+                compute_family
+            )
+        )
     lines.append("#")
     for line in format_credential_preflight(
         model_name,
@@ -233,6 +241,26 @@ def main() -> None:
         help="CUA backend override (e.g. macos, ios, docker) when execution-mode is auto.",
     )
     parser.add_argument(
+        "--compute-family",
+        default="local",
+        metavar="FAMILY",
+        help=(
+            "Execution family written into the sidecar (same field as Playground "
+            "computeFamily). Default: local. matraix run -c wraps Harbor for local "
+            "and uses HarborJobService for any other value."
+        ),
+    )
+    parser.add_argument(
+        "--n-concurrent-trials",
+        type=int,
+        default=_DEFAULT_N_CONCURRENT_TRIALS,
+        metavar="N",
+        help=(
+            "Parallel persona trials (same as Playground Parallel / "
+            "nConcurrentTrials). Default: %(default)s."
+        ),
+    )
+    parser.add_argument(
         "--name",
         default=None,
         help="Job basename for output YAML (default: derived from task + stratify fields)",
@@ -275,6 +303,9 @@ def main() -> None:
         parser.error("--persona-ids cannot be combined with --cohort-id")
     if args.no_strategy and args.strategy:
         parser.error("use either --strategy or --no-strategy, not both")
+    if args.n_concurrent_trials < 1:
+        parser.error("--n-concurrent-trials must be >= 1")
+    compute_family = (args.compute_family or "local").strip().lower() or "local"
 
     try:
         plan = build_retrieval_plan(
@@ -336,7 +367,7 @@ def main() -> None:
             "job_name": job_name,
             "jobs_dir": "jobs",
             "n_attempts": 1,
-            "n_concurrent_trials": 1,
+            "n_concurrent_trials": int(args.n_concurrent_trials),
             "timeout_multiplier": 1.0,
         },
     }
@@ -350,6 +381,7 @@ def main() -> None:
     meta = job_config.pop("_job_meta")
     meta.update(
         {
+            "computeFamily": compute_family,
             "retrieval": {
                 "pool": retrieved.persona_pool,
                 "matchedCount": retrieved.matched_count,
@@ -416,7 +448,7 @@ def main() -> None:
         f"# Retrieval: {retrieval_line}\n"
         f"# Personas: {', '.join(meta['selected_persona_ids'])}\n"
         f"#\n"
-        f"{_format_run_env_comment(run_env_exports, model_name=args.model_name, sample_size=meta['sample_size'])}"
+        f"{_format_run_env_comment(run_env_exports, model_name=args.model_name, sample_size=meta['sample_size'], compute_family=compute_family)}"
     )
     out_path.write_text(
         header + yaml.safe_dump(job_config, sort_keys=False),
@@ -447,6 +479,10 @@ def main() -> None:
     for name, value in run_env_exports:
         print(f"  export {name}={value}")
     print(f"  uv run matraix run -c {_display_path(out_path)}")
+    if compute_family != "local":
+        print(
+            f"  # sidecar computeFamily={compute_family} — matraix run uses HarborJobService"
+        )
     print("Preflight:")
     for line in format_credential_preflight(
         args.model_name,

--- a/src/matraix/cli.py
+++ b/src/matraix/cli.py
@@ -1,7 +1,9 @@
 """Product-facing ``matraix`` CLI.
 
-``matraix run`` wraps ``harbor run`` with the complete launch environment so
-commands printed by the job generator work from a clean documented setup.
+``matraix run -c`` is the only job executor. Local recipes wrap Harbor with
+the same PYTHONPATH and MATRIX_* exports Playground injects. A non-local
+sidecar ``computeFamily`` (or ``--compute-family``) uses HarborJobService —
+the same path as Playground / ``POST /api/harbor/jobs``.
 Harbor remains available directly as the underlying runtime.
 """
 
@@ -124,11 +126,53 @@ def _cmd_run(args: argparse.Namespace, passthrough: list[str]) -> None:
         if not config_path.is_file():
             sys.exit(f"matraix run: job config not found: {config_path}")
 
+    if args.compute_family and config_path is None:
+        sys.exit("matraix run: --compute-family requires -c <job.yaml>")
+    if args.plane and config_path is None:
+        sys.exit("matraix run: --plane requires -c <job.yaml>")
+
     repo_root = (
         Path(args.repo_root).resolve()
         if args.repo_root
         else find_repo_root(config_path.parent if config_path else None)
     )
+
+    if config_path is not None:
+        from matraix.job_run import run_via_harbor_job_service, should_dispatch_via_playground
+
+        try:
+            dispatch, family = should_dispatch_via_playground(
+                config_path=config_path,
+                cli_family=args.compute_family,
+            )
+        except ValueError as exc:
+            sys.exit(f"matraix run: {exc}")
+        if dispatch:
+            if passthrough:
+                print(
+                    "matraix run: ignoring extra harbor args on Playground dispatch: {}".format(
+                        " ".join(passthrough)
+                    ),
+                    file=sys.stderr,
+                )
+            extra_env: dict[str, str] = {}
+            if args.max_cost_usd is not None:
+                if args.max_cost_usd < 0:
+                    sys.exit("matraix run: --max-cost-usd must be >= 0")
+                extra_env["MATRIX_MAX_COST_USD"] = f"{args.max_cost_usd:g}"
+            os.chdir(repo_root)
+            try:
+                code = run_via_harbor_job_service(
+                    config_path=config_path,
+                    repo_root=repo_root,
+                    compute_family=args.compute_family or family,
+                    execution_plane=args.plane,
+                    extra_launch_env=extra_env or None,
+                )
+            except ValueError as exc:
+                sys.exit(f"matraix run: {exc}")
+            sys.exit(code)
+
     argv, env_updates = resolve_run_invocation(config_path, repo_root, passthrough)
     if args.max_cost_usd is not None:
         if args.max_cost_usd < 0:
@@ -247,9 +291,11 @@ def main(argv: list[str] | None = None) -> None:
         "run",
         help="Run a job with the complete MatrAIx launch environment.",
         description=(
-            "Runs `harbor run` with the same PYTHONPATH and MATRIX_* task exports "
-            "the Playground injects. All other arguments (e.g. -p/-a for ad-hoc "
-            "task runs) are passed through to harbor run."
+            "Runs a generated job YAML. Local recipes wrap Harbor with the same "
+            "PYTHONPATH and MATRIX_* exports Playground injects. A non-local "
+            "sidecar computeFamily (or --compute-family) uses HarborJobService — "
+            "the same path as Playground / POST /api/harbor/jobs. Ad-hoc "
+            "arguments (e.g. -p/-a) still pass through to Harbor."
         ),
     )
     run_parser.add_argument(
@@ -274,6 +320,25 @@ def main(argv: list[str] | None = None) -> None:
             "recorded spend meets this limit. Web/OS agents already report "
             "tokens/cost via their runtimes; this gate applies to host-native "
             "Survey/Chat today."
+        ),
+    )
+    run_parser.add_argument(
+        "--compute-family",
+        default=None,
+        metavar="FAMILY",
+        help=(
+            "Execution family for this job (same field as Playground computeFamily). "
+            "Default: sidecar computeFamily, else local. local wraps Harbor; "
+            "any other value uses HarborJobService."
+        ),
+    )
+    run_parser.add_argument(
+        "--plane",
+        choices=("harbor", "remote"),
+        default=None,
+        help=(
+            "Who starts Harbor on HarborJobService dispatch (same as Playground plane). "
+            "Default: MATRIX_EXECUTION_PLANE or harbor. Ignored for local recipes."
         ),
     )
 

--- a/src/matraix/job_run.py
+++ b/src/matraix/job_run.py
@@ -1,0 +1,222 @@
+"""Dispatch ``matraix run -c`` through Harbor or HarborJobService.
+
+``matraix run -c`` is the only job executor. Local recipes wrap the Harbor CLI
+with Playground's launch env. A non-local sidecar ``computeFamily`` (or
+``--compute-family``) uses ``HarborJobService.launch`` — the same path as
+Playground / ``POST /api/harbor/jobs``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from matraix.launch_env import required_pythonpath_entries
+from matraix.persona_job import DEFAULT_DATASET
+
+_TERMINAL_LAUNCH_STATUSES = frozenset(
+    {"completed", "completed_with_errors", "failed", "cancelled"}
+)
+
+
+def load_job_sidecar(config_path: Path) -> dict[str, Any]:
+    sidecar = config_path.with_suffix(".meta.json")
+    if not sidecar.is_file():
+        return {}
+    try:
+        payload = json.loads(sidecar.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def load_job_yaml(config_path: Path) -> dict[str, Any]:
+    try:
+        payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item).strip() for item in value if str(item).strip()]
+
+
+def _first_agent(job: dict[str, Any]) -> dict[str, Any]:
+    agents = job.get("agents")
+    if isinstance(agents, list) and agents and isinstance(agents[0], dict):
+        return agents[0]
+    return {}
+
+
+def resolve_run_compute_family(
+    *,
+    cli_family: str | None,
+    sidecar: dict[str, Any],
+) -> str | None:
+    """CLI flag, then sidecar ``computeFamily``. Do not inherit process env.
+
+    A hand-written local YAML must stay on the Harbor wrap unless the sidecar
+    or ``--compute-family`` says otherwise.
+    """
+    if cli_family:
+        raw = cli_family.strip().lower()
+        return raw or None
+    sidecar_family = sidecar.get("computeFamily") or sidecar.get("compute_family")
+    if sidecar_family:
+        raw = str(sidecar_family).strip().lower()
+        return raw or None
+    return None
+
+
+def launch_kwargs_from_job_config(
+    config_path: Path,
+    *,
+    execution_plane: str | None = None,
+) -> dict[str, Any]:
+    """Rebuild ``HarborJobService.launch`` kwargs from a generated recipe."""
+    sidecar = load_job_sidecar(config_path)
+    job = load_job_yaml(config_path)
+    task_path = str(sidecar.get("task") or "").strip()
+    if not task_path:
+        raise ValueError(
+            "this job YAML has no sidecar task; re-run "
+            "generate_application_job.py so .meta.json exists"
+        )
+
+    retrieval = sidecar.get("retrieval") if isinstance(sidecar.get("retrieval"), dict) else {}
+    persona_pool = (
+        str(retrieval.get("pool") or sidecar.get("persona_pool") or DEFAULT_DATASET).strip()
+        or DEFAULT_DATASET
+    )
+    persona_ids = _string_list(sidecar.get("selected_persona_ids")) or _string_list(
+        sidecar.get("persona_ids")
+    )
+    agent = _first_agent(job)
+    kwargs = agent.get("kwargs") if isinstance(agent.get("kwargs"), dict) else {}
+    cua_backend = (
+        sidecar.get("cua_backend")
+        or sidecar.get("cuaBackend")
+        or kwargs.get("cua_backend")
+    )
+    n_concurrent = job.get("n_concurrent_trials")
+    seed = sidecar.get("seed")
+    sample_size = sidecar.get("sample_size")
+    launch_kwargs: dict[str, Any] = {
+        "task_path": task_path,
+        "persona_pool": persona_pool,
+        "execution_mode": str(sidecar.get("execution_mode") or "auto"),
+        "execution_plane": execution_plane,
+    }
+    if persona_ids:
+        launch_kwargs["persona_ids"] = persona_ids
+    elif sample_size:
+        launch_kwargs["sample_size"] = int(sample_size)
+    if seed is not None:
+        launch_kwargs["seed"] = int(seed)
+    if agent.get("name"):
+        launch_kwargs["agent_name"] = str(agent["name"])
+    if agent.get("model_name"):
+        launch_kwargs["persona_model"] = str(agent["model_name"])
+    if n_concurrent is not None:
+        launch_kwargs["n_concurrent_trials"] = max(1, int(n_concurrent))
+    job_name = str(job.get("job_name") or sidecar.get("job_slug") or "").strip()
+    if job_name:
+        launch_kwargs["job_name"] = job_name
+    if cua_backend:
+        launch_kwargs["cua_backend"] = str(cua_backend)
+    return launch_kwargs
+
+
+def jobs_dir_from_job_config(config_path: Path, repo_root: Path) -> Path:
+    job = load_job_yaml(config_path)
+    raw = str(job.get("jobs_dir") or "jobs").strip() or "jobs"
+    path = Path(raw)
+    if path.is_absolute():
+        return path
+    return repo_root / path
+
+
+def wait_for_harbor_job(service: object, job_name: str, *, poll_s: float = 2.0) -> dict[str, Any]:
+    """Block until HarborJobService reports a terminal launch status."""
+    while True:
+        detail = service.get_job(job_name)  # type: ignore[attr-defined]
+        if isinstance(detail, dict):
+            launch = detail.get("launch")
+            status = launch.get("status") if isinstance(launch, dict) else None
+            if status in _TERMINAL_LAUNCH_STATUSES:
+                return detail
+        time.sleep(poll_s)
+
+
+def ensure_playground_imports(repo_root: Path) -> None:
+    for entry in reversed(required_pythonpath_entries(repo_root)):
+        if entry not in sys.path:
+            sys.path.insert(0, entry)
+
+
+def should_dispatch_via_playground(
+    *,
+    config_path: Path,
+    cli_family: str | None,
+) -> tuple[bool, str | None]:
+    sidecar = load_job_sidecar(config_path)
+    family = resolve_run_compute_family(cli_family=cli_family, sidecar=sidecar)
+    if family is None or family == "local":
+        return False, family
+    return True, family
+
+
+def run_via_harbor_job_service(
+    *,
+    config_path: Path,
+    repo_root: Path,
+    compute_family: str | None,
+    execution_plane: str | None,
+    extra_launch_env: dict[str, str] | None = None,
+) -> int:
+    """Launch and wait. Return process exit code."""
+    ensure_playground_imports(repo_root)
+    from backend.service.harbor_job_service import HarborJobService
+
+    if extra_launch_env:
+        os.environ.update(extra_launch_env)
+
+    sidecar = load_job_sidecar(config_path)
+    family = resolve_run_compute_family(cli_family=compute_family, sidecar=sidecar)
+    kwargs = launch_kwargs_from_job_config(
+        config_path,
+        execution_plane=execution_plane,
+    )
+    service = HarborJobService.from_repo(
+        repo_root=repo_root,
+        jobs_dir=jobs_dir_from_job_config(config_path, repo_root),
+    )
+    try:
+        job_name = service.launch(**kwargs)
+        print(
+            "matraix run: HarborJobService job={} family={}".format(
+                job_name, family or "local"
+            ),
+            file=sys.stderr,
+        )
+        detail = wait_for_harbor_job(service, job_name)
+        launch = detail.get("launch") if isinstance(detail, dict) else None
+        status = launch.get("status") if isinstance(launch, dict) else "unknown"
+        error = launch.get("error") if isinstance(launch, dict) else None
+        print("matraix run: status={}".format(status), file=sys.stderr)
+        if error:
+            print("matraix run: {}".format(error), file=sys.stderr)
+        if status == "failed":
+            return 1
+        return 0
+    finally:
+        service.shutdown()

--- a/tests/unit/matraix/test_job_run.py
+++ b/tests/unit/matraix/test_job_run.py
@@ -1,0 +1,220 @@
+"""Tests for ``matraix run`` Playground dispatch helpers."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from matraix.job_run import (
+    launch_kwargs_from_job_config,
+    should_dispatch_via_playground,
+    wait_for_harbor_job,
+)
+
+
+def _write_recipe(
+    tmp_path: Path,
+    *,
+    sidecar: dict | None = None,
+    yaml_body: str | None = None,
+) -> Path:
+    folder = tmp_path / "configs" / "jobs" / "application-task-job-recipe"
+    folder.mkdir(parents=True, exist_ok=True)
+    config = folder / "survey.yaml"
+    config.write_text(
+        yaml_body
+        or (
+            "job_name: cli-survey\n"
+            "jobs_dir: jobs\n"
+            "n_concurrent_trials: 32\n"
+            "agents:\n"
+            "  - name: persona-json-survey\n"
+            "    model_name: anthropic/claude-haiku-4-5\n"
+            "tasks:\n"
+            "  - path: application/tasks/example-survey_product-feedback\n"
+        ),
+        encoding="utf-8",
+    )
+    if sidecar is not None:
+        config.with_suffix(".meta.json").write_text(
+            json.dumps(sidecar), encoding="utf-8"
+        )
+    return config
+
+
+def test_should_dispatch_local_sidecar_stays_on_harbor_wrap(tmp_path: Path) -> None:
+    config = _write_recipe(
+        tmp_path,
+        sidecar={
+            "task": "application/tasks/example-survey_product-feedback",
+            "trial_profile": "json_survey",
+            "execution_mode": "auto",
+            "computeFamily": "local",
+        },
+    )
+    dispatch, family = should_dispatch_via_playground(
+        config_path=config, cli_family=None
+    )
+    assert dispatch is False
+    assert family == "local"
+
+
+def test_should_dispatch_non_local_sidecar(tmp_path: Path) -> None:
+    config = _write_recipe(
+        tmp_path,
+        sidecar={
+            "task": "application/tasks/example-survey_product-feedback",
+            "trial_profile": "json_survey",
+            "execution_mode": "auto",
+            "computeFamily": "hosted",
+        },
+    )
+    dispatch, family = should_dispatch_via_playground(
+        config_path=config, cli_family=None
+    )
+    assert dispatch is True
+    assert family == "hosted"
+
+
+def test_cli_family_overrides_sidecar(tmp_path: Path) -> None:
+    config = _write_recipe(
+        tmp_path,
+        sidecar={
+            "task": "application/tasks/example-survey_product-feedback",
+            "trial_profile": "json_survey",
+            "execution_mode": "auto",
+            "computeFamily": "hosted",
+        },
+    )
+    dispatch, family = should_dispatch_via_playground(
+        config_path=config, cli_family="local"
+    )
+    assert dispatch is False
+    assert family == "local"
+
+
+def test_process_env_does_not_hijack_local_yaml(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("MATRIX_COMPUTE_FAMILY", "hosted")
+    config = _write_recipe(tmp_path)
+    dispatch, family = should_dispatch_via_playground(
+        config_path=config, cli_family=None
+    )
+    assert dispatch is False
+    assert family is None
+
+
+def test_launch_kwargs_from_sidecar_and_yaml(tmp_path: Path) -> None:
+    config = _write_recipe(
+        tmp_path,
+        sidecar={
+            "task": "application/tasks/example-survey_product-feedback",
+            "selected_persona_ids": ["0042", "0007"],
+            "seed": 42,
+            "execution_mode": "auto",
+            "trial_profile": "json_survey",
+            "computeFamily": "hosted",
+            "retrieval": {"pool": "persona/datasets/matraix-persona-dev-sample"},
+        },
+    )
+    kwargs = launch_kwargs_from_job_config(config, execution_plane="harbor")
+    assert kwargs["task_path"] == "application/tasks/example-survey_product-feedback"
+    assert kwargs["persona_ids"] == ["0042", "0007"]
+    assert kwargs["persona_pool"] == "persona/datasets/matraix-persona-dev-sample"
+    assert kwargs["job_name"] == "cli-survey"
+    assert kwargs["n_concurrent_trials"] == 32
+    assert kwargs["agent_name"] == "persona-json-survey"
+    assert kwargs["persona_model"] == "anthropic/claude-haiku-4-5"
+    assert kwargs["execution_plane"] == "harbor"
+    assert kwargs["seed"] == 42
+    assert "compute_family" not in kwargs
+
+
+def test_launch_kwargs_requires_sidecar_task(tmp_path: Path) -> None:
+    config = _write_recipe(tmp_path)
+    with pytest.raises(ValueError, match="sidecar task"):
+        launch_kwargs_from_job_config(config)
+
+
+def test_wait_for_harbor_job_returns_terminal(monkeypatch: pytest.MonkeyPatch) -> None:
+    class Fake:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def get_job(self, job_name: str) -> dict:
+            self.calls += 1
+            if self.calls < 2:
+                return {"launch": {"status": "running"}}
+            return {"launch": {"status": "completed"}}
+
+    monkeypatch.setattr("matraix.job_run.time.sleep", lambda _s: None)
+    detail = wait_for_harbor_job(Fake(), "job-1", poll_s=0)
+    assert detail["launch"]["status"] == "completed"
+
+
+def test_run_via_harbor_job_service_forwards_launch_kwargs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import types
+
+    from matraix.job_run import run_via_harbor_job_service
+
+    config = _write_recipe(
+        tmp_path,
+        sidecar={
+            "task": "application/tasks/example-survey_product-feedback",
+            "selected_persona_ids": ["0042"],
+            "seed": 7,
+            "execution_mode": "auto",
+            "trial_profile": "json_survey",
+            "computeFamily": "hosted",
+            "retrieval": {"pool": "persona/datasets/matraix-persona-dev-sample"},
+        },
+    )
+    captured: dict[str, object] = {}
+
+    class FakeService:
+        def launch(self, **kwargs):
+            captured.update(kwargs)
+            return "launched-job"
+
+        def get_job(self, job_name: str) -> dict:
+            return {"launch": {"status": "completed"}}
+
+        def shutdown(self) -> None:
+            captured["shutdown"] = True
+
+    class HarborJobService:
+        @classmethod
+        def from_repo(cls, *, repo_root, jobs_dir=None):
+            captured["repo_root"] = repo_root
+            captured["jobs_dir"] = jobs_dir
+            return FakeService()
+
+    for name in ("backend", "backend.service"):
+        if name not in sys.modules:
+            pkg = types.ModuleType(name)
+            pkg.__path__ = []  # type: ignore[attr-defined]
+            monkeypatch.setitem(sys.modules, name, pkg)
+
+    fake_mod = types.ModuleType("backend.service.harbor_job_service")
+    fake_mod.HarborJobService = HarborJobService
+    monkeypatch.setitem(sys.modules, "backend.service.harbor_job_service", fake_mod)
+    monkeypatch.setattr("matraix.job_run.time.sleep", lambda _s: None)
+
+    code = run_via_harbor_job_service(
+        config_path=config,
+        repo_root=tmp_path,
+        compute_family="hosted",
+        execution_plane="harbor",
+    )
+    assert code == 0
+    assert captured["persona_ids"] == ["0042"]
+    assert captured["job_name"] == "cli-survey"
+    assert captured["execution_plane"] == "harbor"
+    assert "compute_family" not in captured
+    assert captured["shutdown"] is True

--- a/tests/unit/matraix/test_matraix_cli.py
+++ b/tests/unit/matraix/test_matraix_cli.py
@@ -237,6 +237,54 @@ def test_main_run_sets_max_cost_usd_env(tmp_path: Path, monkeypatch) -> None:
     ]
 
 
+def test_main_run_non_local_sidecar_uses_harbor_job_service(
+    tmp_path: Path, monkeypatch
+) -> None:
+    root = _fake_checkout(tmp_path)
+    config = _write_job(
+        root,
+        sidecar={
+            "task": "application/tasks/foo",
+            "trial_profile": "json_survey",
+            "execution_mode": "auto",
+            "computeFamily": "hosted",
+            "selected_persona_ids": ["0042"],
+            "seed": 1,
+        },
+    )
+    captured: dict[str, object] = {}
+
+    def fake_run_via_harbor_job_service(**kwargs):
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(
+        "matraix.job_run.run_via_harbor_job_service",
+        fake_run_via_harbor_job_service,
+    )
+    harbor_calls = _stub_harbor(monkeypatch)
+
+    original_cwd = Path.cwd()
+    original_sys_path = list(sys.path)
+    try:
+        with pytest.raises(SystemExit) as excinfo:
+            cli.main(["run", "-c", str(config), "--compute-family", "hosted"])
+    finally:
+        os.chdir(original_cwd)
+        sys.path[:] = original_sys_path
+
+    assert excinfo.value.code == 0
+    assert captured["compute_family"] == "hosted"
+    assert captured["config_path"] == config
+    assert "args" not in harbor_calls
+
+
+def test_main_run_compute_family_without_config_exits() -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(["run", "--compute-family", "hosted", "-p", "application/tasks/foo"])
+    assert "--compute-family requires" in str(excinfo.value)
+
+
 def test_main_results_prints_text_summary(tmp_path: Path, monkeypatch, capsys) -> None:
     from matraix.job_results import collect_job_results
 


### PR DESCRIPTION
## Summary
- `matraix run -c` is the job executor. Local recipes wrap Harbor; a non-local sidecar `computeFamily` (or `--compute-family`) uses `HarborJobService.launch`, the same path as Playground.
- The generator writes `computeFamily` on the sidecar and prints `uv run matraix run -c …`. Hand-written local YAML stays on the Harbor wrap unless the sidecar or flag says otherwise.
- Ready to plug hosted execution later without changing the user-facing command.

## Test plan
- [ ] `PYTHONPATH=".:environment/runtime:packages/playground/src:application/playground" uv run python -m pytest tests/unit/matraix/test_job_run.py tests/unit/matraix/test_matraix_cli.py tests/unit/application/test_generate_application_job.py -q`
- [ ] `uv run matraix run -c <local-recipe.yaml>` still wraps Harbor.
- [ ] A sidecar with a non-local `computeFamily` goes through `HarborJobService.launch`.


Made with [Cursor](https://cursor.com)