### PR TITLE
docs(tasks): mark example-survey filter dims as eligible-not-mix

### DIFF
--- a/application/tasks/example-survey_product-feedback/README.md
+++ b/application/tasks/example-survey_product-feedback/README.md
@@ -8,8 +8,9 @@ Task contents:
 - `instruction.md`, `task.toml`, `tests/`
 - `input/context.md`, `input/questionnaire.yaml`
 - `persona_strategy.json`, `reporting.json` (task root; part of the task).
-  The strategy is a **40 / 35 / 25** mix on `economic_motivation` (Form B
-  weighted filters). Playground Task-plan / Dataset Pull and
+  The strategy is a **40 / 35 / 25** mix on `economic_motivation`. Other
+  filter dims use `{value: null}` (eligible, not in the mix). Playground
+  Task-plan / Dataset Pull and
   `generate_dev_personas.py --strategy application/tasks/example-survey_product-feedback`
   all honor that mix. `--task … --per-cell` is grounding cells, not this file.
 

--- a/application/tasks/example-survey_product-feedback/persona_strategy.json
+++ b/application/tasks/example-survey_product-feedback/persona_strategy.json
@@ -2,15 +2,15 @@
   "schemaVersion": "1.0",
   "sources": [],
   "dimensionFilters": {
-    "life_stage": [
-      "Parent of young kids",
-      "Mid-life",
-      "Early career"
-    ],
-    "age_bracket": [
-      "25-34",
-      "35-44"
-    ],
+    "life_stage": {
+      "Parent of young kids": null,
+      "Mid-life": null,
+      "Early career": null
+    },
+    "age_bracket": {
+      "25-34": null,
+      "35-44": null
+    },
     "economic_motivation": {
       "Cost-sensitive": 0.4,
       "Value-driven": 0.35,


### PR DESCRIPTION
## Summary
- `life_stage` and `age_bracket` on the product-feedback survey stay as `{value: null}` filters: eligible for the task, not in the mix.
- Only `economic_motivation` keeps the 40 / 35 / 25 portions.

## Test plan
- [ ] Open `application/tasks/example-survey_product-feedback/persona_strategy.json` and confirm filter dims are `{value: null}`.
- [ ] Playground Task-plan / Dataset Pull on this task still mixes on `economic_motivation` only.


Made with [Cursor](https://cursor.com)