### PR TITLE
feat(playground): add Modal and GKE remote compute families

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.venv
+**/node_modules
+**/__pycache__
+**/.pytest_cache
+**/.mypy_cache
+**/jobs
+**/.env
+**/.env.*
+docs/in-the-wild
+docs/intake
+application/playground/frontend
+*.pyc

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -53,8 +53,11 @@ jobs:
             application/playground/backend/tests/test_api_schemas.py \
             application/playground/backend/tests/test_application_types.py \
             application/playground/backend/tests/test_application_task_spec.py \
+            application/playground/backend/tests/test_chatbot_reachability.py \
             application/playground/backend/tests/test_chatbot_sidecar_service.py \
+            application/playground/backend/tests/test_cohort_shard_planner.py \
             application/playground/backend/tests/test_config.py \
+            application/playground/backend/tests/test_gke_host_job.py \
             application/playground/backend/tests/test_harbor_chat_eval.py \
             application/playground/backend/tests/test_harbor_chat_mcp_session.py \
             application/playground/backend/tests/test_harbor_job_service.py \
@@ -63,6 +66,7 @@ jobs:
             application/playground/backend/tests/test_harbor_survey_eval.py \
             application/playground/backend/tests/test_harbor_web_trace.py \
             application/playground/backend/tests/test_job_aggregation.py \
+            application/playground/backend/tests/test_job_result_rollup.py \
             application/playground/backend/tests/test_mcp_client_contract.py \
             application/playground/backend/tests/test_persona_1m_index.py \
             application/playground/backend/tests/test_persona_1m_pool.py \
@@ -74,6 +78,9 @@ jobs:
             application/playground/backend/tests/test_remote_runner_server.py \
             application/playground/backend/tests/test_task_detail_service.py \
             application/playground/backend/tests/test_trial_events.py \
+            application/playground/backend/tests/test_modal_compute_launch.py \
+            application/playground/backend/tests/test_modal_docker_prebuild.py \
+            application/playground/backend/tests/test_modal_host_job.py \
             packages/playground/src/playground/tests/test_chatbot_sidecar_compose.py \
             packages/playground/src/playground/tests/test_model_client.py \
             packages/playground/src/playground/tests/test_model_client_openrouter.py \

--- a/application/playground/.env.local.example
+++ b/application/playground/.env.local.example
@@ -81,11 +81,11 @@ ANTHROPIC_API_KEY=sk-ant-your-key-here
 # at it:
 # CHATBOT_API_URL=http://127.0.0.1:8000
 #
-# Modal / GKE cannot call localhost. On launch, Playground opens a temporary
-# public URL to this sidecar if `cloudflared` is installed
-# (`brew install cloudflared`). Optional override / disable:
+# Modal / GKE workers cannot call 127.0.0.1. Set a public URL, or set
+# MATRIX_CHATBOT_TUNNEL=auto so Playground starts cloudflared for this API
+# process (`brew install cloudflared`).
 # MATRIX_CHATBOT_PUBLIC_URL=https://your-tunnel.example
-# MATRIX_CHATBOT_TUNNEL=0
+# MATRIX_CHATBOT_TUNNEL=auto
 #
 # Remote compute (Modal / GKE). Default is local. See docs/environment/runtime.md.
 # MATRIX_COMPUTE_FAMILY=local

--- a/application/playground/.env.local.example
+++ b/application/playground/.env.local.example
@@ -81,6 +81,21 @@ ANTHROPIC_API_KEY=sk-ant-your-key-here
 # at it:
 # CHATBOT_API_URL=http://127.0.0.1:8000
 #
+# Modal / GKE cannot call localhost. On launch, Playground opens a temporary
+# public URL to this sidecar if `cloudflared` is installed
+# (`brew install cloudflared`). Optional override / disable:
+# MATRIX_CHATBOT_PUBLIC_URL=https://your-tunnel.example
+# MATRIX_CHATBOT_TUNNEL=0
+#
+# Remote compute (Modal / GKE). Default is local. See docs/environment/runtime.md.
+# MATRIX_COMPUTE_FAMILY=local
+# MODAL_TOKEN_ID=
+# MODAL_TOKEN_SECRET=
+# MATRIX_GKE_CLUSTER=
+# MATRIX_GKE_REGION=
+# MATRIX_GKE_REGISTRY=
+# MATRIX_GKE_HOST_IMAGE=
+#
 # To bypass the shared router, point each application at its own sidecar:
 # CHATBOT_UPSTREAM_FINANCE=http://127.0.0.1:8901
 #

--- a/application/playground/backend/api/app.py
+++ b/application/playground/backend/api/app.py
@@ -868,6 +868,7 @@ def create_app(catalog_path: Optional[str] = None) -> FastAPI:
                 n_concurrent_trials=body.nConcurrentTrials,
                 execution_mode=body.mode,
                 execution_plane=resolved_plane,
+                compute_family=body.computeFamily,
                 job_name=body.jobName,
                 os_app_submission_profile=body.osAppSubmissionProfile,
                 os_app_backend=body.osAppBackend,

--- a/application/playground/backend/api/schemas.py
+++ b/application/playground/backend/api/schemas.py
@@ -723,6 +723,7 @@ class HarborJobLaunchRequest(BaseModel):
     nConcurrentTrials: int = 2
     mode: str = "auto"
     plane: Optional[str] = None
+    computeFamily: Optional[str] = None
     jobName: Optional[str] = None
     osAppSubmissionProfile: Optional[str] = Field(
         None,
@@ -753,6 +754,16 @@ class HarborJobLaunchRequest(BaseModel):
         normalized = value.strip().lower()
         if normalized not in {"harbor", "remote"}:
             raise ValueError("plane must be one of harbor, remote")
+        return normalized
+
+    @field_validator("computeFamily")
+    @classmethod
+    def _validate_compute_family(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return value
+        normalized = value.strip().lower().replace("-", "_")
+        if normalized not in {"local", "modal", "gcp"}:
+            raise ValueError("computeFamily must be one of local, modal, gcp")
         return normalized
 
     @field_validator("personaModel")

--- a/application/playground/backend/service/build_gke_host_image.sh
+++ b/application/playground/backend/service/build_gke_host_image.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Build the survey/chat GKE host-worker image from the repository root.
+# Usage: application/playground/backend/service/build_gke_host_image.sh IMAGE_TAG
+set -euo pipefail
+
+IMAGE="${1:?usage: build_gke_host_image.sh IMAGE_TAG}"
+ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
+
+docker build \
+  -f "$ROOT/application/playground/backend/service/gke_host_worker.Dockerfile" \
+  -t "$IMAGE" \
+  "$ROOT"

--- a/application/playground/backend/service/chatbot_dev_tunnel.py
+++ b/application/playground/backend/service/chatbot_dev_tunnel.py
@@ -1,11 +1,8 @@
-"""Open a temporary public URL to a local chatbot sidecar (dev Modal/GKE).
+"""Public URL for a local chatbot sidecar (Modal/GKE chat).
 
-Production already has a public ``CHATBOT_API_URL``. Local sidecars bind
-localhost, which Modal/GKE cannot call. If ``cloudflared`` (preferred) or
-``ngrok`` is on PATH, Playground starts a quick tunnel and stores the URL in
-``MATRIX_CHATBOT_PUBLIC_URL`` for the API process lifetime.
-
-Set ``MATRIX_CHATBOT_TUNNEL=0`` to disable. ``=ngrok`` skips cloudflared.
+Production already has ``CHATBOT_API_URL``. Local sidecars bind localhost, which
+Modal and GKE cannot call. ``MATRIX_CHATBOT_TUNNEL=auto`` starts cloudflared or
+ngrok and stores the URL in ``MATRIX_CHATBOT_PUBLIC_URL`` for this API process.
 """
 
 from __future__ import annotations
@@ -46,14 +43,16 @@ class ChatbotTunnelError(RuntimeError):
 
 
 def tunnel_mode() -> str:
-    raw = (os.environ.get(CHATBOT_TUNNEL_ENV) or "auto").strip().lower()
-    if raw in {"0", "false", "no", "off", "disable", "disabled"}:
+    raw = (os.environ.get(CHATBOT_TUNNEL_ENV) or "off").strip().lower()
+    if raw in {"", "0", "false", "no", "off", "disable", "disabled"}:
         return "off"
     if raw in {"ngrok"}:
         return "ngrok"
     if raw in {"cloudflared", "cloudflare"}:
         return "cloudflared"
-    return "auto"
+    if raw in {"1", "true", "yes", "on", "enable", "enabled", "auto"}:
+        return "auto"
+    return "off"
 
 
 def loopback_origin(url: str) -> str:
@@ -127,7 +126,7 @@ def _start_tunnel(
             errors.append(str(exc))
     hint = (
         "Install cloudflared (`brew install cloudflared`) so Playground can "
-        "open a temporary public URL to your local chat sidecar, or set {}, "
+        "publish a URL to your local chat sidecar, or set {}, "
         "or use computeFamily=local."
     ).format(CHATBOT_PUBLIC_URL_ENV)
     detail = "; ".join(errors) if errors else "no tunnel backend"

--- a/application/playground/backend/service/chatbot_dev_tunnel.py
+++ b/application/playground/backend/service/chatbot_dev_tunnel.py
@@ -1,0 +1,223 @@
+"""Open a temporary public URL to a local chatbot sidecar (dev Modal/GKE).
+
+Production already has a public ``CHATBOT_API_URL``. Local sidecars bind
+localhost, which Modal/GKE cannot call. If ``cloudflared`` (preferred) or
+``ngrok`` is on PATH, Playground starts a quick tunnel and stores the URL in
+``MATRIX_CHATBOT_PUBLIC_URL`` for the API process lifetime.
+
+Set ``MATRIX_CHATBOT_TUNNEL=0`` to disable. ``=ngrok`` skips cloudflared.
+"""
+
+from __future__ import annotations
+
+import atexit
+import logging
+import os
+import re
+import shutil
+import subprocess
+import threading
+import time
+from typing import Callable
+from urllib.parse import urlparse
+
+from backend.service.chatbot_reachability import (
+    CHATBOT_PUBLIC_URL_ENV,
+    CHATBOT_URL_ENV_KEYS,
+    is_loopback_chatbot_url,
+    public_chatbot_url,
+)
+
+logger = logging.getLogger(__name__)
+
+CHATBOT_TUNNEL_ENV = "MATRIX_CHATBOT_TUNNEL"
+_CLOUDFLARED_URL_RE = re.compile(r"https://[a-z0-9-]+\.trycloudflare\.com", re.I)
+_NGROK_URL_RE = re.compile(
+    r"https://[a-z0-9.-]+\.ngrok(?:-free|-http)?\.(?:app|io)",
+    re.I,
+)
+
+_lock = threading.Lock()
+_tunnels: dict[str, tuple[subprocess.Popen[str], str]] = {}
+
+
+class ChatbotTunnelError(RuntimeError):
+    """Could not open a public tunnel to the local sidecar."""
+
+
+def tunnel_mode() -> str:
+    raw = (os.environ.get(CHATBOT_TUNNEL_ENV) or "auto").strip().lower()
+    if raw in {"0", "false", "no", "off", "disable", "disabled"}:
+        return "off"
+    if raw in {"ngrok"}:
+        return "ngrok"
+    if raw in {"cloudflared", "cloudflare"}:
+        return "cloudflared"
+    return "auto"
+
+
+def loopback_origin(url: str) -> str:
+    parsed = urlparse((url or "").strip())
+    host = (parsed.hostname or "127.0.0.1").strip()
+    if host in {"0.0.0.0", "[::]", "::"}:
+        host = "127.0.0.1"
+    port = parsed.port
+    if port is None:
+        port = 443 if (parsed.scheme or "http").lower() == "https" else 80
+    return "http://{}:{}".format(host, port)
+
+
+def first_loopback_chatbot_url() -> str:
+    for key in CHATBOT_URL_ENV_KEYS:
+        value = (os.environ.get(key) or "").strip()
+        if is_loopback_chatbot_url(value):
+            return value
+    return ""
+
+
+def ensure_dev_chatbot_tunnel(
+    *,
+    which: Callable[[str], str | None] = shutil.which,
+    popen: Callable[..., subprocess.Popen[str]] = subprocess.Popen,
+) -> str:
+    """Return a worker-reachable chatbot URL, starting a tunnel if needed."""
+    existing = public_chatbot_url()
+    if existing and not is_loopback_chatbot_url(existing):
+        return existing
+    if tunnel_mode() == "off":
+        return ""
+    local = first_loopback_chatbot_url()
+    if not local:
+        return ""
+    origin = loopback_origin(local)
+    with _lock:
+        cached = _tunnels.get(origin)
+        if cached is not None:
+            proc, url = cached
+            if proc.poll() is None:
+                os.environ[CHATBOT_PUBLIC_URL_ENV] = url
+                return url
+            _tunnels.pop(origin, None)
+        url, proc = _start_tunnel(origin, which=which, popen=popen)
+        _tunnels[origin] = (proc, url)
+        os.environ[CHATBOT_PUBLIC_URL_ENV] = url
+        logger.info("Chat sidecar tunnel %s -> %s", origin, url)
+        return url
+
+
+def _start_tunnel(
+    origin: str,
+    *,
+    which: Callable[[str], str | None],
+    popen: Callable[..., subprocess.Popen[str]],
+) -> tuple[str, subprocess.Popen[str]]:
+    mode = tunnel_mode()
+    errors: list[str] = []
+    order = ("ngrok",) if mode == "ngrok" else ("cloudflared", "ngrok")
+    if mode == "cloudflared":
+        order = ("cloudflared",)
+    for name in order:
+        try:
+            if name == "cloudflared":
+                return _start_cloudflared(origin, which=which, popen=popen)
+            return _start_ngrok(origin, which=which, popen=popen)
+        except FileNotFoundError:
+            errors.append("{} not on PATH".format(name))
+        except ChatbotTunnelError as exc:
+            errors.append(str(exc))
+    hint = (
+        "Install cloudflared (`brew install cloudflared`) so Playground can "
+        "open a temporary public URL to your local chat sidecar, or set {}, "
+        "or use computeFamily=local."
+    ).format(CHATBOT_PUBLIC_URL_ENV)
+    detail = "; ".join(errors) if errors else "no tunnel backend"
+    raise ChatbotTunnelError("{} ({})".format(hint, detail))
+
+
+def _start_cloudflared(
+    origin: str,
+    *,
+    which: Callable[[str], str | None],
+    popen: Callable[..., subprocess.Popen[str]],
+) -> tuple[str, subprocess.Popen[str]]:
+    binary = which("cloudflared")
+    if not binary:
+        raise FileNotFoundError("cloudflared")
+    proc = popen(
+        [binary, "tunnel", "--url", origin, "--no-autoupdate"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    url = _wait_for_url(proc, _CLOUDFLARED_URL_RE, timeout_sec=30.0)
+    return url, proc
+
+
+def _start_ngrok(
+    origin: str,
+    *,
+    which: Callable[[str], str | None],
+    popen: Callable[..., subprocess.Popen[str]],
+) -> tuple[str, subprocess.Popen[str]]:
+    binary = which("ngrok")
+    if not binary:
+        raise FileNotFoundError("ngrok")
+    port = urlparse(origin).port or 80
+    proc = popen(
+        [binary, "http", str(port), "--log", "stdout", "--log-format", "json"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    url = _wait_for_url(proc, _NGROK_URL_RE, timeout_sec=30.0)
+    return url, proc
+
+
+def _wait_for_url(
+    proc: subprocess.Popen[str],
+    pattern: re.Pattern[str],
+    *,
+    timeout_sec: float,
+) -> str:
+    chunks: list[str] = []
+
+    def _read() -> None:
+        stream = proc.stdout
+        if stream is None:
+            return
+        try:
+            for line in stream:
+                chunks.append(line)
+        except Exception:
+            return
+
+    reader = threading.Thread(target=_read, name="chatbot-tunnel-log", daemon=True)
+    reader.start()
+    deadline = time.monotonic() + timeout_sec
+    while time.monotonic() < deadline:
+        match = pattern.search("".join(chunks))
+        if match:
+            return match.group(0).rstrip("/")
+        if proc.poll() is not None:
+            break
+        time.sleep(0.1)
+    log = "".join(chunks).strip()
+    raise ChatbotTunnelError(
+        "tunnel started but no public URL appeared{}".format(
+            ": " + log[-400:] if log else ""
+        )
+    )
+
+
+def _stop_tunnels() -> None:
+    with _lock:
+        items = list(_tunnels.values())
+        _tunnels.clear()
+    for proc, _url in items:
+        try:
+            proc.terminate()
+        except Exception:
+            pass
+
+
+atexit.register(_stop_tunnels)

--- a/application/playground/backend/service/chatbot_reachability.py
+++ b/application/playground/backend/service/chatbot_reachability.py
@@ -36,11 +36,10 @@ _LOOPBACK_HOSTS = frozenset(
 
 _CLOUD_CHAT_ERROR = (
     "Chat on Modal/GKE needs a chatbot URL the worker can reach. "
-    "Production: set CHATBOT_API_URL (or the task upstream) to the public "
-    "endpoint. Local dev: Playground can open a temporary public URL if "
-    "cloudflared is installed (`brew install cloudflared`), or set "
-    "{public_env} yourself, or use computeFamily=local. "
-    "Set MATRIX_CHATBOT_TUNNEL=0 to disable the automatic tunnel."
+    "Set CHATBOT_API_URL (or the task upstream) to a public endpoint, "
+    "or set {public_env}, or set MATRIX_CHATBOT_TUNNEL=auto so Playground "
+    "can start cloudflared (`brew install cloudflared`). "
+    "Or run with computeFamily=local."
 ).format(public_env=CHATBOT_PUBLIC_URL_ENV)
 
 
@@ -96,8 +95,7 @@ def _chatbot_worker_urls() -> list[str]:
 def require_cloud_reachable_chatbot_url() -> None:
     """Raise if a Modal/GKE chat worker would only see localhost.
 
-    Local dev: if the sidecar is on localhost, Playground tries to open a
-    cloudflared/ngrok tunnel first (unless ``MATRIX_CHATBOT_TUNNEL=0``).
+    Set ``MATRIX_CHATBOT_PUBLIC_URL`` or ``MATRIX_CHATBOT_TUNNEL=auto``.
     """
     urls = _chatbot_worker_urls()
     if urls and not any(is_loopback_chatbot_url(url) for url in urls):

--- a/application/playground/backend/service/chatbot_reachability.py
+++ b/application/playground/backend/service/chatbot_reachability.py
@@ -1,0 +1,113 @@
+"""Chat sidecar URLs that Modal / GKE workers can actually call.
+
+Production sets ``CHATBOT_API_URL`` (or a task-specific upstream) to a public
+or VPC-reachable endpoint. Local sidecars on ``127.0.0.1`` are invisible from
+those workers. Dev can expose the sidecar with a tunnel and set
+``MATRIX_CHATBOT_PUBLIC_URL``.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+from urllib.parse import urlparse
+
+CHATBOT_PUBLIC_URL_ENV = "MATRIX_CHATBOT_PUBLIC_URL"
+CHATBOT_URL_ENV_KEYS = (
+    "CHATBOT_API_URL",
+    "CHATBOT_UPSTREAM_FINANCE",
+    "CHATBOT_UPSTREAM_MEDICAL",
+    "FINANCE_CHATBOT_URL",
+    "MEDICAL_CHATBOT_URL",
+    "CHATBOT_MCP_URL",
+)
+
+_LOOPBACK_HOSTS = frozenset(
+    {
+        "localhost",
+        "127.0.0.1",
+        "::1",
+        "[::1]",
+        "0.0.0.0",
+        "[::]",
+        "host.docker.internal",
+    }
+)
+
+_CLOUD_CHAT_ERROR = (
+    "Chat on Modal/GKE needs a chatbot URL the worker can reach. "
+    "Production: set CHATBOT_API_URL (or the task upstream) to the public "
+    "endpoint. Local dev: Playground can open a temporary public URL if "
+    "cloudflared is installed (`brew install cloudflared`), or set "
+    "{public_env} yourself, or use computeFamily=local. "
+    "Set MATRIX_CHATBOT_TUNNEL=0 to disable the automatic tunnel."
+).format(public_env=CHATBOT_PUBLIC_URL_ENV)
+
+
+def is_loopback_chatbot_url(url: str) -> bool:
+    raw = (url or "").strip()
+    if not raw:
+        return False
+    host = (urlparse(raw).hostname or "").strip().lower()
+    if not host:
+        return False
+    if host in _LOOPBACK_HOSTS or host.endswith(".localhost"):
+        return True
+    try:
+        ip = ipaddress.ip_address(host.strip("[]"))
+    except ValueError:
+        return False
+    return bool(ip.is_loopback or ip.is_unspecified or ip.is_link_local)
+
+
+def public_chatbot_url() -> str:
+    return (os.environ.get(CHATBOT_PUBLIC_URL_ENV) or "").strip().rstrip("/")
+
+
+def rewrite_chatbot_urls_for_cloud(env: dict[str, str]) -> dict[str, str]:
+    """Replace loopback sidecar URLs with ``MATRIX_CHATBOT_PUBLIC_URL`` when set."""
+    public = public_chatbot_url()
+    rewritten = dict(env)
+    if not public:
+        return rewritten
+    for key in CHATBOT_URL_ENV_KEYS:
+        value = (rewritten.get(key) or "").strip()
+        if value and is_loopback_chatbot_url(value):
+            rewritten[key] = public
+    if not any((rewritten.get(key) or "").strip() for key in CHATBOT_URL_ENV_KEYS):
+        rewritten["CHATBOT_API_URL"] = public
+    return rewritten
+
+
+def collect_chatbot_url_env() -> dict[str, str]:
+    payload = {
+        key: value
+        for key in CHATBOT_URL_ENV_KEYS
+        if (value := (os.environ.get(key) or "").strip())
+    }
+    return rewrite_chatbot_urls_for_cloud(payload)
+
+
+def _chatbot_worker_urls() -> list[str]:
+    env = collect_chatbot_url_env()
+    return [env[key] for key in CHATBOT_URL_ENV_KEYS if env.get(key)]
+
+
+def require_cloud_reachable_chatbot_url() -> None:
+    """Raise if a Modal/GKE chat worker would only see localhost.
+
+    Local dev: if the sidecar is on localhost, Playground tries to open a
+    cloudflared/ngrok tunnel first (unless ``MATRIX_CHATBOT_TUNNEL=0``).
+    """
+    urls = _chatbot_worker_urls()
+    if urls and not any(is_loopback_chatbot_url(url) for url in urls):
+        return
+    from backend.service.chatbot_dev_tunnel import ChatbotTunnelError, ensure_dev_chatbot_tunnel
+
+    try:
+        ensure_dev_chatbot_tunnel()
+    except ChatbotTunnelError as exc:
+        raise ValueError(str(exc)) from exc
+    urls = _chatbot_worker_urls()
+    if not urls or any(is_loopback_chatbot_url(url) for url in urls):
+        raise ValueError(_CLOUD_CHAT_ERROR)

--- a/application/playground/backend/service/chatbot_sidecar_service.py
+++ b/application/playground/backend/service/chatbot_sidecar_service.py
@@ -81,6 +81,30 @@ def _default_health_url(spec: SidecarSpec) -> str:
     return "http://127.0.0.1:{}".format(spec.host_port)
 
 
+def ensure_sidecar_url_env(application_id: str | None) -> str:
+    """Write the local sidecar URL into env when Playground never set it.
+
+    Compose sidecars bind ``127.0.0.1:<port>`` without exporting
+    ``CHATBOT_API_URL``. Modal/GKE tunnel code only looks at env, so an
+    unset key means the tunnel never starts and the worker still sees
+    localhost as missing.
+    """
+    app_id = (application_id or "").strip()
+    spec = _SIDECAR_SPECS.get(app_id)
+    if spec is None:
+        return ""
+    existing = (os.environ.get(spec.primary_env) or "").strip()
+    if existing:
+        return existing
+    if spec.legacy_env:
+        legacy = (os.environ.get(spec.legacy_env) or "").strip()
+        if legacy:
+            return legacy
+    url = _default_health_url(spec)
+    os.environ[spec.primary_env] = url
+    return url
+
+
 def resolve_health_url(application_id: str) -> str:
     spec = _SIDECAR_SPECS.get(application_id)
     if spec is None:

--- a/application/playground/backend/service/cohort_shard_planner.py
+++ b/application/playground/backend/service/cohort_shard_planner.py
@@ -1,0 +1,383 @@
+"""Split a large Harbor job into internal workers (same job_name).
+
+Playground Parallel is the global in-flight cap. Env vars only cap packing
+and cluster width. See docs/environment/large-scale-runs.md.
+"""
+
+from __future__ import annotations
+
+import copy
+import os
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+
+DEFAULT_SHARD_SIZE = 100
+DEFAULT_SHARD_CONCURRENCY = 8
+DEFAULT_HOST_PACK_CONCURRENCY = 32
+DEFAULT_WEB_PACK_CONCURRENCY = 1
+SHARD_SIZE_ENV = "MATRIX_SHARD_SIZE"
+SHARD_CONCURRENCY_ENV = "MATRIX_SHARD_CONCURRENCY"
+HOST_PACK_CONCURRENCY_ENV = "MATRIX_HOST_PACK_CONCURRENCY"
+WEB_PACK_CONCURRENCY_ENV = "MATRIX_WEB_PACK_CONCURRENCY"
+MAX_CONCURRENT_TRIALS_ENV = "MATRIX_MAX_CONCURRENT_TRIALS"
+_NATIVE_TRIAL_PROFILES = frozenset({"json_survey", "user_sim_chat"})
+
+
+@dataclass(frozen=True)
+class CohortShard:
+    """One internal work slice under a run."""
+
+    shard_index: int
+    shard_count: int
+    persona_ids: tuple[str, ...]
+    offset: int
+    limit: int
+
+    @property
+    def key(self) -> str:
+        return "s{}".format(self.shard_index)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["key"] = self.key
+        return payload
+
+
+@dataclass(frozen=True)
+class ShardLayout:
+    """How N people and Parallel map onto workers.
+
+    ``requested_parallel`` is what the operator set (report / parent YAML).
+    ``effective_parallel`` is global in-flight after env caps: min(N, Parallel,
+    pack * max_workers, MATRIX_MAX_CONCURRENT_TRIALS).
+    """
+
+    requested_parallel: int
+    effective_parallel: int
+    pack: int
+    worker_count: int
+    shard_size: int
+    per_shard_concurrent: tuple[int, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "requestedParallel": self.requested_parallel,
+            "effectiveParallel": self.effective_parallel,
+            "pack": self.pack,
+            "workerCount": self.worker_count,
+            "shardSize": self.shard_size,
+            "perShardConcurrent": list(self.per_shard_concurrent),
+        }
+
+
+@dataclass(frozen=True)
+class JobShardPlan:
+    layout: ShardLayout
+    shards: list[tuple[CohortShard, dict[str, Any]]]
+
+
+def _positive_int(raw: str, default: int) -> int:
+    try:
+        return max(1, int(raw))
+    except (TypeError, ValueError):
+        return default
+
+
+def _ceil_div(num: int, den: int) -> int:
+    den = max(1, int(den))
+    return (max(0, int(num)) + den - 1) // den
+
+
+def shard_size_from_env() -> int:
+    return _positive_int((os.environ.get(SHARD_SIZE_ENV) or "").strip(), DEFAULT_SHARD_SIZE)
+
+
+def shard_concurrency_from_env() -> int:
+    return _positive_int(
+        (os.environ.get(SHARD_CONCURRENCY_ENV) or "").strip(),
+        DEFAULT_SHARD_CONCURRENCY,
+    )
+
+
+def host_pack_concurrency_from_env() -> int:
+    return _positive_int(
+        (os.environ.get(HOST_PACK_CONCURRENCY_ENV) or "").strip(),
+        DEFAULT_HOST_PACK_CONCURRENCY,
+    )
+
+
+def web_pack_concurrency_from_env() -> int:
+    return _positive_int(
+        (os.environ.get(WEB_PACK_CONCURRENCY_ENV) or "").strip(),
+        DEFAULT_WEB_PACK_CONCURRENCY,
+    )
+
+
+def max_concurrent_trials_from_env() -> int | None:
+    raw = (os.environ.get(MAX_CONCURRENT_TRIALS_ENV) or "").strip()
+    if not raw:
+        return None
+    try:
+        value = int(raw)
+    except ValueError:
+        return None
+    if value <= 0:
+        return None
+    return value
+
+
+def pack_concurrency_for_profile(trial_profile: str | None) -> int:
+    if (trial_profile or "").strip().lower() in _NATIVE_TRIAL_PROFILES:
+        return host_pack_concurrency_from_env()
+    return web_pack_concurrency_from_env()
+
+
+def _allocate_concurrency(
+    parallel: int, pack: int, shard_limits: Sequence[int]
+) -> tuple[int, ...]:
+    remaining = max(0, int(parallel))
+    pack = max(1, int(pack))
+    allocated: list[int] = []
+    for limit in shard_limits:
+        take = min(pack, max(0, int(limit)), remaining)
+        allocated.append(take)
+        remaining -= take
+    return tuple(allocated)
+
+
+def plan_shard_layout(
+    *,
+    n: int,
+    parallel: int,
+    pack: int,
+    max_workers: int | None = None,
+    max_parallel: int | None = None,
+) -> ShardLayout:
+    """Map cohort size and Parallel onto workers without rewriting Parallel.
+
+    in_flight ≈ min(N, Parallel, pack * max_workers [, MATRIX_MAX_CONCURRENT_TRIALS])
+    workers = ceil(in_flight / pack), then min with N and max_workers.
+    """
+    n = max(0, int(n))
+    requested = max(1, int(parallel or 1))
+    pack = max(1, int(pack))
+    max_workers = max(1, int(max_workers if max_workers is not None else shard_concurrency_from_env()))
+    cap = requested
+    if max_parallel is not None:
+        cap = min(cap, max(1, int(max_parallel)))
+    if n <= 0:
+        return ShardLayout(
+            requested_parallel=requested,
+            effective_parallel=0,
+            pack=pack,
+            worker_count=0,
+            shard_size=1,
+            per_shard_concurrent=(),
+        )
+    cluster = pack * max_workers
+    effective = min(cap, n, cluster)
+    workers = min(n, max_workers, _ceil_div(effective, pack))
+    workers = max(1, workers)
+    shard_size = _ceil_div(n, workers)
+    limits: list[int] = []
+    remaining_people = n
+    for _ in range(workers):
+        take = min(shard_size, remaining_people)
+        if take <= 0:
+            break
+        limits.append(take)
+        remaining_people -= take
+    concurrent = _allocate_concurrency(effective, pack, limits)
+    return ShardLayout(
+        requested_parallel=requested,
+        effective_parallel=int(sum(concurrent)),
+        pack=pack,
+        worker_count=len(limits),
+        shard_size=shard_size,
+        per_shard_concurrent=concurrent,
+    )
+
+
+def plan_cohort_shards(
+    persona_ids: Sequence[str] | Iterable[str],
+    *,
+    shard_size: int = DEFAULT_SHARD_SIZE,
+) -> list[CohortShard]:
+    """Split persona IDs into contiguous internal shards of at most ``shard_size``.
+
+    Empty input yields no shards. ``shard_size`` must be >= 1.
+    Callers attach the result to the run’s control-plane plan; do not expose
+    each shard as its own product-level run or job name.
+    """
+    ids = [str(pid).strip() for pid in persona_ids if str(pid).strip()]
+    size = max(1, int(shard_size))
+    if not ids:
+        return []
+    shard_count = (len(ids) + size - 1) // size
+    shards: list[CohortShard] = []
+    for index in range(shard_count):
+        offset = index * size
+        chunk = tuple(ids[offset : offset + size])
+        shards.append(
+            CohortShard(
+                shard_index=index,
+                shard_count=shard_count,
+                persona_ids=chunk,
+                offset=offset,
+                limit=len(chunk),
+            )
+        )
+    return shards
+
+
+def plan_pool_shards_from_manifest(
+    manifest_personas: Sequence[dict[str, Any]],
+    *,
+    shard_size: int = DEFAULT_SHARD_SIZE,
+) -> list[CohortShard]:
+    """Plan internal shards from a persona pool manifest ``personas`` list."""
+    ids: list[str] = []
+    for row in manifest_personas:
+        if not isinstance(row, dict):
+            continue
+        pid = str(row.get("persona_id") or row.get("personaId") or "").strip()
+        if pid:
+            ids.append(pid)
+    return plan_cohort_shards(ids, shard_size=shard_size)
+
+
+def _agent_persona_id(agent: dict[str, Any], index: int) -> str:
+    kwargs = agent.get("kwargs") if isinstance(agent.get("kwargs"), dict) else {}
+    path = str((kwargs or {}).get("persona_path") or "")
+    stem = Path(path).stem
+    if stem.startswith("persona_"):
+        return stem[len("persona_") :]
+    return stem or str(index)
+
+
+def _slice_job_config(
+    job_config: dict[str, Any],
+    agents: list[dict[str, Any]],
+    ids: list[str],
+    *,
+    shard_size: int,
+    per_shard_concurrent: Sequence[int] | None = None,
+) -> list[tuple[CohortShard, dict[str, Any]]]:
+    planned = plan_cohort_shards(ids, shard_size=shard_size)
+    shards: list[tuple[CohortShard, dict[str, Any]]] = []
+    for index, shard in enumerate(planned):
+        config = copy.deepcopy(job_config)
+        config["agents"] = [
+            copy.deepcopy(agent)
+            for agent in agents[shard.offset : shard.offset + shard.limit]
+        ]
+        if per_shard_concurrent is not None and index < len(per_shard_concurrent):
+            concurrent = max(0, int(per_shard_concurrent[index]))
+            if concurrent:
+                config["n_concurrent_trials"] = concurrent
+        shards.append((shard, config))
+    return shards
+
+
+def plan_job_config_shards(
+    job_config: dict[str, Any],
+    *,
+    shard_size: int | None = None,
+    trial_profile: str | None = None,
+    pack: int | None = None,
+    max_workers: int | None = None,
+    max_parallel: int | None = None,
+) -> list[tuple[CohortShard, dict[str, Any]]]:
+    """Slice ``agents`` into shard configs that keep the same ``job_name``.
+
+    Pass ``shard_size`` alone for a fixed-size split (tests). Otherwise workers
+    and per-shard ``n_concurrent_trials`` follow Parallel and pack caps.
+    """
+    return plan_job_shards(
+        job_config,
+        shard_size=shard_size,
+        trial_profile=trial_profile,
+        pack=pack,
+        max_workers=max_workers,
+        max_parallel=max_parallel,
+    ).shards
+
+
+def plan_job_shards(
+    job_config: dict[str, Any],
+    *,
+    shard_size: int | None = None,
+    trial_profile: str | None = None,
+    pack: int | None = None,
+    max_workers: int | None = None,
+    max_parallel: int | None = None,
+) -> JobShardPlan:
+    """Demand-driven shard plan. Parent ``n_concurrent_trials`` stays requested."""
+    agents = [row for row in (job_config.get("agents") or []) if isinstance(row, dict)]
+    ids = [_agent_persona_id(agent, index) for index, agent in enumerate(agents)]
+    requested = max(1, int(job_config.get("n_concurrent_trials") or 1))
+    legacy = shard_size is not None and pack is None and trial_profile is None
+    if not agents:
+        layout = plan_shard_layout(
+            n=0,
+            parallel=requested,
+            pack=max(1, int(pack or pack_concurrency_for_profile(trial_profile))),
+            max_workers=max_workers,
+            max_parallel=max_parallel if max_parallel is not None else max_concurrent_trials_from_env(),
+        )
+        return JobShardPlan(layout=layout, shards=[])
+    if legacy:
+        size = max(1, int(shard_size))
+        shards = _slice_job_config(job_config, agents, ids, shard_size=size)
+        layout = ShardLayout(
+            requested_parallel=requested,
+            effective_parallel=requested,
+            pack=size,
+            worker_count=len(shards),
+            shard_size=size,
+            per_shard_concurrent=tuple(
+                max(1, int((row[1].get("n_concurrent_trials") or requested)))
+                for row in shards
+            ),
+        )
+        return JobShardPlan(layout=layout, shards=shards)
+    resolved_pack = max(1, int(pack if pack is not None else pack_concurrency_for_profile(trial_profile)))
+    resolved_max_parallel = (
+        max_parallel if max_parallel is not None else max_concurrent_trials_from_env()
+    )
+    layout = plan_shard_layout(
+        n=len(agents),
+        parallel=requested,
+        pack=resolved_pack,
+        max_workers=max_workers,
+        max_parallel=resolved_max_parallel,
+    )
+    shards = _slice_job_config(
+        job_config,
+        agents,
+        ids,
+        shard_size=layout.shard_size,
+        per_shard_concurrent=layout.per_shard_concurrent,
+    )
+    return JobShardPlan(layout=layout, shards=shards)
+
+
+def should_fanout_cloud_shards(dispatch: str | None, shard_count: int) -> bool:
+    return dispatch in {"modal_jobs", "gke_workers"} and shard_count > 1
+
+
+def should_fanout_harbor_shards(
+    *,
+    family: str | None,
+    environment: str | None,
+    dispatch: str | None,
+    shard_count: int,
+) -> bool:
+    """Split web/linux Harbor processes on Modal/GKE when Parallel needs more workers."""
+    if shard_count <= 1 or dispatch:
+        return False
+    if (family or "").strip().lower() not in {"modal", "gcp"}:
+        return False
+    return (environment or "").strip().lower() in {"modal", "gke"}

--- a/application/playground/backend/service/config.py
+++ b/application/playground/backend/service/config.py
@@ -484,7 +484,7 @@ class ConfigManager:
                     {
                         "value": "modal",
                         "label": "Modal",
-                        "description": "Modal Jobs: survey/chat host agents, web/linux Docker workers with cached task images",
+                        "description": "Modal: survey/chat as a Function, web/linux as a Docker Sandbox with cached task images",
                     },
                     {
                         "value": "gcp",

--- a/application/playground/backend/service/config.py
+++ b/application/playground/backend/service/config.py
@@ -228,6 +228,14 @@ def default_execution_plane() -> str:
     return _default_plane()
 
 
+def default_compute_family() -> str:
+    """Return the default compute family from ``MATRIX_COMPUTE_FAMILY``."""
+    raw = (os.environ.get("MATRIX_COMPUTE_FAMILY") or "local").strip().lower().replace("-", "_")
+    if raw in {"local", "modal", "gcp"}:
+        return raw
+    return "local"
+
+
 def remote_runner_configured() -> bool:
     from backend.service.execution_plane import remote_runner_configured as _configured
 
@@ -466,6 +474,24 @@ class ConfigManager:
                 "executionPlane": default_execution_plane(),
                 "remoteRunnerConfigured": remote_runner_configured(),
                 "personaModel": persona_model(),
+                "computeFamily": default_compute_family(),
+                "computeFamilies": [
+                    {
+                        "value": "local",
+                        "label": "Local",
+                        "description": "Run on the Harbor orchestrator (host agents or local Docker)",
+                    },
+                    {
+                        "value": "modal",
+                        "label": "Modal",
+                        "description": "Modal Jobs: survey/chat host agents, web/linux Docker workers with cached task images",
+                    },
+                    {
+                        "value": "gcp",
+                        "label": "GCP / GKE",
+                        "description": "Survey/chat: packed GKE host Jobs. Web/linux: Harbor environment.type=gke. Switch when daily concurrency saturates Modal.",
+                    },
+                ],
             },
         }
 

--- a/application/playground/backend/service/gke_host_job.py
+++ b/application/playground/backend/service/gke_host_job.py
@@ -1,0 +1,518 @@
+"""Schedule survey/chat host-agent Harbor jobs as GKE Jobs.
+
+Harbor ``environment.type`` stays ``host``. Artifacts merge into the same
+``jobs/<job_name>/`` tree as local / Modal Jobs runs.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import shlex
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Protocol
+
+from backend.service.modal_host_job import (
+    HARBOR_MODULE_COMMAND,
+    MODAL_REMOTE_REPO,
+    ModalHostJobResult,
+    apply_live_overlay,
+    merge_job_artifacts,
+    modal_pythonpath,
+    prepare_modal_job_config,
+    rewrite_job_artifact_paths,
+)
+from matraix.gke_settings import (
+    GKE_HOST_IMAGE_ENV,
+    GKE_JOBS_PVC_ENV,
+    ensure_gke_kubeconfig,
+    gke_host_image,
+    gke_namespace,
+)
+
+GKE_REMOTE_REPO = MODAL_REMOTE_REPO
+_EXIT_MARKER = "/tmp/matraix-exit"
+_ARTIFACT_TAR = "/tmp/matraix-job.tgz"
+_LIVE_STATUS_REMOTE = "/tmp/matraix-live.json"
+_LIVE_PUSH_ENV = "MATRIX_GKE_LIVE_PUSH_SEC"
+
+# Stdlib-only watcher so the mosaic can tick before Harbor finishes packing.
+_GKE_LIVE_WATCH_PY = (
+    "import json, os, time\n"
+    "from pathlib import Path\n"
+    "job = os.environ.get('MATRIX_GKE_LIVE_JOB') or ''\n"
+    "root = Path(os.environ.get('MATRIX_REPO_ROOT') or '/matraix') / 'jobs' / job\n"
+    "dest = Path({live_path!r})\n"
+    "exit_marker = Path({exit_path!r})\n"
+    "markers = ('config.json', 'trial.log', 'persona_meta.json')\n"
+    "try:\n"
+    "    interval = float(os.environ.get({push_env!r}) or '5')\n"
+    "except ValueError:\n"
+    "    interval = 5.0\n"
+    "interval = 5.0 if interval <= 0 else max(interval, 0.5)\n"
+    "while True:\n"
+    "    status = {{}}\n"
+    "    if job and root.is_dir():\n"
+    "        for trial in sorted(p for p in root.iterdir() if p.is_dir() and not p.name.startswith('_')):\n"
+    "            result = trial / 'result.json'\n"
+    "            if result.is_file():\n"
+    "                try:\n"
+    "                    payload = json.loads(result.read_text())\n"
+    "                except Exception:\n"
+    "                    payload = None\n"
+    "                if isinstance(payload, dict) and (payload.get('exception_info') or payload.get('error')):\n"
+    "                    status[trial.name] = 'error'\n"
+    "                else:\n"
+    "                    status[trial.name] = 'done'\n"
+    "            elif any((trial / name).is_file() for name in markers) or (trial / 'agent').is_dir():\n"
+    "                status[trial.name] = 'running'\n"
+    "            else:\n"
+    "                status[trial.name] = 'pending'\n"
+    "    dest.write_text(json.dumps(status, sort_keys=True) + '\\n')\n"
+    "    if exit_marker.is_file():\n"
+    "        break\n"
+    "    time.sleep(interval)\n"
+).format(live_path=_LIVE_STATUS_REMOTE, exit_path=_EXIT_MARKER, push_env=_LIVE_PUSH_ENV)
+
+
+class GkeHostJobError(RuntimeError):
+    """GKE host workers could not be scheduled or completed."""
+
+
+@dataclass(frozen=True)
+class GkeHostJobRequest:
+    job_name: str
+    config_yaml: str
+    env: dict[str, str]
+    secret_env: dict[str, str] = field(default_factory=dict)
+    shard_key: str = ""
+    live_jobs_dir: str = ""
+
+
+class GkeHostJobRunner(Protocol):
+    def run(self, request: GkeHostJobRequest) -> ModalHostJobResult: ...
+
+
+def gke_job_name(job_name: str, shard_key: str = "") -> str:
+    slug = "".join(ch.lower() if ch.isalnum() else "-" for ch in job_name).strip("-")
+    base = "matraix-host-{}".format(slug[:40]).strip("-") or "matraix-host-job"
+    extra = "".join(ch.lower() if ch.isalnum() else "-" for ch in shard_key).strip("-")
+    if not extra:
+        return base[:63]
+    return "{}-{}".format(base[:55], extra)[:63]
+
+
+def gke_host_worker_script(job_name: str) -> str:
+    """Run Harbor, pack ``jobs/<name>/``, then stay up so the API can pull the tar."""
+    harbor = " ".join(shlex.quote(part) for part in HARBOR_MODULE_COMMAND)
+    job_q = shlex.quote(job_name)
+    repo_q = shlex.quote(GKE_REMOTE_REPO)
+    watch = shlex.quote(_GKE_LIVE_WATCH_PY)
+    return (
+        "set +e\n"
+        "export MATRIX_GKE_LIVE_JOB={job}\n"
+        "python -c {watch} &\n"
+        "LIVE_PID=$!\n"
+        "{harbor} --yes -c /config/job.yaml\n"
+        "echo $? > {marker}\n"
+        "wait \"$LIVE_PID\" 2>/dev/null || true\n"
+        "if [ -d {repo}/jobs/{job} ]; then\n"
+        "  tar czf {artifact} -C {repo}/jobs {job}\n"
+        "fi\n"
+        "sleep 3600\n"
+    ).format(
+        harbor=harbor,
+        marker=_EXIT_MARKER,
+        repo=repo_q,
+        job=job_q,
+        artifact=_ARTIFACT_TAR,
+        watch=watch,
+    )
+
+
+def apply_gke_live_status(dest: Path, raw: bytes | str) -> dict[str, str]:
+    """Merge a worker ``live_status.json`` blob into the orchestrator overlay."""
+    text = raw.decode("utf-8", errors="replace") if isinstance(raw, bytes) else raw
+    try:
+        loaded = json.loads(text)
+    except Exception:
+        return {}
+    if not isinstance(loaded, dict):
+        return {}
+    status = {str(key): str(value) for key, value in loaded.items() if str(key)}
+    if status:
+        apply_live_overlay(dest, status)
+    return status
+
+
+def gke_live_dest(request: GkeHostJobRequest) -> Path | None:
+    root = (request.live_jobs_dir or "").strip()
+    if not root:
+        return None
+    dest = Path(root) / request.job_name
+    dest.mkdir(parents=True, exist_ok=True)
+    return dest
+
+
+def build_gke_job_manifest(
+    request: GkeHostJobRequest,
+    *,
+    image: str,
+    namespace: str,
+    pvc_name: str | None = None,
+) -> dict[str, Any]:
+    env_vars = [
+        {"name": key, "value": value}
+        for key, value in {**request.env, **request.secret_env}.items()
+        if value
+    ]
+    env_vars.append({"name": "PYTHONPATH", "value": modal_pythonpath(Path(GKE_REMOTE_REPO))})
+    env_vars.append({"name": "MATRIX_REPO_ROOT", "value": GKE_REMOTE_REPO})
+    volumes = [
+        {"name": "config", "configMap": {"name": gke_job_name(request.job_name, request.shard_key) + "-cfg"}}
+    ]
+    mounts = [
+        {"name": "config", "mountPath": "/config", "readOnly": True},
+        {"name": "jobs", "mountPath": "{}/jobs".format(GKE_REMOTE_REPO)},
+    ]
+    if pvc_name:
+        volumes.append({"name": "jobs", "persistentVolumeClaim": {"claimName": pvc_name}})
+    else:
+        volumes.append({"name": "jobs", "emptyDir": {}})
+    return {
+        "apiVersion": "batch/v1",
+        "kind": "Job",
+        "metadata": {
+            "name": gke_job_name(request.job_name, request.shard_key),
+            "namespace": namespace,
+            "labels": {"app": "matraix-host-job", "matraix-job": request.job_name},
+        },
+        "spec": {
+            "backoffLimit": 0,
+            "template": {
+                "metadata": {"labels": {"app": "matraix-host-job"}},
+                "spec": {
+                    "restartPolicy": "Never",
+                    "containers": [
+                        {
+                            "name": "harbor",
+                            "image": image,
+                            "workingDir": GKE_REMOTE_REPO,
+                            "command": ["/bin/sh", "-c"],
+                            "args": [gke_host_worker_script(request.job_name)],
+                            "env": env_vars,
+                            "volumeMounts": mounts,
+                            "resources": {
+                                "requests": {"cpu": "1", "memory": "4Gi"},
+                                "limits": {"cpu": "2", "memory": "8Gi"},
+                            },
+                        }
+                    ],
+                    "volumes": volumes,
+                },
+            },
+        },
+    }
+
+
+class SdkGkeHostJobRunner:
+    """Create a Kubernetes Job, wait for Harbor to finish, and pull ``jobs/<name>/``."""
+
+    poll_sec: float = 3.0
+    timeout_sec: float = 60 * 60
+
+    def spawn(self, request: GkeHostJobRequest) -> tuple[str, Any]:
+        ctx = self._connect(request)
+        yaml_text = prepare_modal_job_config(request.config_yaml, job_name=request.job_name)
+        config_map = ctx["client"].V1ConfigMap(
+            metadata=ctx["client"].V1ObjectMeta(name=ctx["cfg_name"], namespace=ctx["namespace"]),
+            data={"job.yaml": yaml_text},
+        )
+        pvc = (os.environ.get(GKE_JOBS_PVC_ENV) or "").strip() or None
+        manifest = build_gke_job_manifest(
+            request,
+            image=ctx["image"],
+            namespace=ctx["namespace"],
+            pvc_name=pvc,
+        )
+        try:
+            self._replace_config_map(ctx["core"], ctx["cfg_name"], ctx["namespace"], config_map)
+            self._replace_job(ctx["batch"], ctx["name"], ctx["namespace"], manifest)
+        except Exception as exc:  # noqa: BLE001
+            raise GkeHostJobError(str(exc)) from exc
+        return ctx["name"], None
+
+    def wait(
+        self,
+        request: GkeHostJobRequest,
+        *,
+        call: Any | None = None,
+        call_id: str = "",
+    ) -> ModalHostJobResult:
+        del call
+        ctx = self._connect(request)
+        name = (call_id or "").strip() or ctx["name"]
+        cfg_name = name + "-cfg" if name == ctx["name"] else name + "-cfg"
+        if name != ctx["name"]:
+            cfg_name = name + "-cfg"
+        try:
+            from kubernetes import stream
+        except ImportError as exc:
+            raise GkeHostJobError(
+                "computeFamily=gcp requires the kubernetes extra (pip install 'matraix[gke]')"
+            ) from exc
+        try:
+            dest = gke_live_dest(request)
+            pod, exit_code = self._wait_for_exit_marker(
+                stream, ctx["core"], name, ctx["namespace"], dest=dest
+            )
+            artifact = self._read_artifact_tar(stream, ctx["core"], pod, ctx["namespace"])
+        except GkeHostJobError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            raise GkeHostJobError(str(exc)) from exc
+        finally:
+            self._delete_job(ctx["batch"], ctx["core"], name, cfg_name, ctx["namespace"])
+        error = None if exit_code == 0 else "GKE host workers exited with code {}".format(exit_code)
+        if exit_code == 0 and not artifact:
+            raise GkeHostJobError(
+                "GKE host workers finished without returning jobs/{}/ artifacts".format(
+                    request.job_name
+                )
+            )
+        return ModalHostJobResult(
+            exit_code=exit_code,
+            artifact_tar=artifact,
+            error=error,
+            volume_path=request.job_name,
+        )
+
+    def run(self, request: GkeHostJobRequest) -> ModalHostJobResult:
+        call_id, _ = self.spawn(request)
+        return self.wait(request, call_id=call_id)
+
+    def _connect(self, request: GkeHostJobRequest) -> dict[str, Any]:
+        image = gke_host_image()
+        if not image:
+            raise GkeHostJobError(
+                "computeFamily=gcp for survey/chat requires {} "
+                "(container image with MatrAIx + Harbor)".format(GKE_HOST_IMAGE_ENV)
+            )
+        try:
+            from kubernetes import client, config
+        except ImportError as exc:
+            raise GkeHostJobError(
+                "computeFamily=gcp requires the kubernetes extra (pip install 'matraix[gke]')"
+            ) from exc
+        self._load_kube_config(config)
+        namespace = gke_namespace()
+        name = gke_job_name(request.job_name, request.shard_key)
+        return {
+            "client": client,
+            "batch": client.BatchV1Api(),
+            "core": client.CoreV1Api(),
+            "namespace": namespace,
+            "name": name,
+            "cfg_name": name + "-cfg",
+            "image": image,
+        }
+
+    def _load_kube_config(self, config: Any) -> None:
+        try:
+            config.load_incluster_config()
+            return
+        except Exception:
+            pass
+        try:
+            config.load_kube_config()
+            return
+        except Exception:
+            pass
+        ensure_gke_kubeconfig()
+        try:
+            config.load_kube_config()
+        except Exception as exc:
+            raise GkeHostJobError(
+                "computeFamily=gcp (GKE host workers) requires a kubeconfig "
+                "(KUBECONFIG or ~/.kube/config) or in-cluster credentials"
+            ) from exc
+
+    def _replace_config_map(self, core: Any, name: str, namespace: str, body: Any) -> None:
+        try:
+            core.delete_namespaced_config_map(name, namespace)
+        except Exception:
+            pass
+        core.create_namespaced_config_map(namespace, body)
+
+    def _replace_job(self, batch: Any, name: str, namespace: str, manifest: dict[str, Any]) -> None:
+        try:
+            batch.delete_namespaced_job(name, namespace, propagation_policy="Background")
+        except Exception:
+            pass
+        batch.create_namespaced_job(namespace, manifest)
+
+    def _delete_job(
+        self,
+        batch: Any,
+        core: Any,
+        job_name: str,
+        cfg_name: str,
+        namespace: str,
+    ) -> None:
+        try:
+            batch.delete_namespaced_job(job_name, namespace, propagation_policy="Background")
+        except Exception:
+            pass
+        try:
+            core.delete_namespaced_config_map(cfg_name, namespace)
+        except Exception:
+            pass
+
+    def _wait_for_exit_marker(
+        self,
+        stream: Any,
+        core: Any,
+        job_name: str,
+        namespace: str,
+        *,
+        dest: Path | None = None,
+    ) -> tuple[str, int]:
+        deadline = time.time() + self.timeout_sec
+        while time.time() < deadline:
+            pod, phase = self._job_pod(core, job_name, namespace)
+            if phase == "Failed":
+                raise GkeHostJobError("GKE Job {} failed".format(job_name))
+            if pod and phase == "Running":
+                if dest is not None:
+                    try:
+                        self._pull_live_progress(stream, core, pod, namespace, dest)
+                    except Exception:
+                        pass
+                try:
+                    raw = self._exec(stream, core, pod, namespace, ["cat", _EXIT_MARKER])
+                    text = raw.decode("utf-8", errors="replace").strip()
+                    if text.isdigit():
+                        return pod, int(text)
+                except Exception:
+                    pass
+            time.sleep(self.poll_sec)
+        raise GkeHostJobError("GKE Job {} timed out".format(job_name))
+
+    def _pull_live_progress(
+        self,
+        stream: Any,
+        core: Any,
+        pod: str,
+        namespace: str,
+        dest: Path,
+    ) -> None:
+        raw = self._exec(stream, core, pod, namespace, ["cat", _LIVE_STATUS_REMOTE])
+        apply_gke_live_status(dest, raw)
+
+    def _job_pod(self, core: Any, job_name: str, namespace: str) -> tuple[str | None, str]:
+        pods = core.list_namespaced_pod(
+            namespace,
+            label_selector="job-name={}".format(job_name),
+        )
+        items = list(getattr(pods, "items", []) or [])
+        if not items:
+            return None, ""
+        pod = items[0]
+        phase = str(getattr(getattr(pod, "status", None), "phase", "") or "")
+        return pod.metadata.name, phase
+
+    def _read_artifact_tar(
+        self,
+        stream: Any,
+        core: Any,
+        pod: str,
+        namespace: str,
+    ) -> bytes | None:
+        try:
+            encoded = self._exec(
+                stream,
+                core,
+                pod,
+                namespace,
+                ["base64", _ARTIFACT_TAR],
+            )
+        except Exception:
+            return None
+        text = encoded.decode("ascii", errors="ignore").strip()
+        if not text:
+            return None
+        try:
+            return base64.b64decode(text)
+        except Exception:
+            return None
+
+    def _exec(
+        self,
+        stream: Any,
+        core: Any,
+        pod: str,
+        namespace: str,
+        command: list[str],
+    ) -> bytes:
+        resp = stream.stream(
+            core.connect_get_namespaced_pod_exec,
+            pod,
+            namespace,
+            command=command,
+            stderr=True,
+            stdin=False,
+            stdout=True,
+            tty=False,
+            _preload_content=False,
+        )
+        chunks: list[bytes] = []
+        try:
+            while resp.is_open():
+                resp.update(timeout=60)
+                if resp.peek_stdout():
+                    data = resp.read_stdout()
+                    if isinstance(data, bytes):
+                        chunks.append(data)
+                    else:
+                        chunks.append(str(data).encode("latin1"))
+        finally:
+            resp.close()
+        return b"".join(chunks)
+
+
+def default_gke_host_job_runner() -> GkeHostJobRunner:
+    return SdkGkeHostJobRunner()
+
+
+def materialize_gke_artifacts(
+    result: ModalHostJobResult,
+    *,
+    jobs_dir: Path,
+    job_name: str,
+) -> Path:
+    dest = jobs_dir / job_name
+    dest.mkdir(parents=True, exist_ok=True)
+    if result.artifact_tar:
+        merge_job_artifacts(
+            result.artifact_tar,
+            jobs_dir=jobs_dir,
+            job_name=job_name,
+            remote_repo=GKE_REMOTE_REPO,
+        )
+    else:
+        rewrite_job_artifact_paths(
+            dest,
+            remote_repo=GKE_REMOTE_REPO,
+            local_job_dir=dest,
+            job_name=job_name,
+        )
+        if not any(path.name != "compute.json" for path in dest.iterdir()):
+            raise GkeHostJobError(
+                "GKE host workers finished without returning jobs/{}/ artifacts".format(
+                    job_name
+                )
+            )
+    return dest

--- a/application/playground/backend/service/gke_host_job.py
+++ b/application/playground/backend/service/gke_host_job.py
@@ -1,15 +1,17 @@
-"""Schedule survey/chat host-agent Harbor jobs as GKE Jobs.
+"""Schedule survey/chat Harbor jobs as GKE Jobs.
 
 Harbor ``environment.type`` stays ``host``. Artifacts merge into the same
-``jobs/<job_name>/`` tree as local / Modal Jobs runs.
+``jobs/<job_name>/`` tree as a local or Modal run.
 """
 
 from __future__ import annotations
 
 import base64
-import json
+import gzip
+import hashlib
 import os
 import shlex
+import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -19,7 +21,7 @@ from backend.service.modal_host_job import (
     HARBOR_MODULE_COMMAND,
     MODAL_REMOTE_REPO,
     ModalHostJobResult,
-    apply_live_overlay,
+    apply_worker_live_status,
     merge_job_artifacts,
     modal_pythonpath,
     prepare_modal_job_config,
@@ -38,13 +40,17 @@ _EXIT_MARKER = "/tmp/matraix-exit"
 _ARTIFACT_TAR = "/tmp/matraix-job.tgz"
 _LIVE_STATUS_REMOTE = "/tmp/matraix-live.json"
 _LIVE_PUSH_ENV = "MATRIX_GKE_LIVE_PUSH_SEC"
+_CONFIGMAP_MAX_BYTES = 900_000
+_MAX_ARTIFACT_BYTES = 256 * 1024 * 1024
+_JOBS_DIR_ENV = "MATRIX_GKE_JOBS_DIR"
 
 # Stdlib-only watcher so the mosaic can tick before Harbor finishes packing.
 _GKE_LIVE_WATCH_PY = (
     "import json, os, time\n"
     "from pathlib import Path\n"
     "job = os.environ.get('MATRIX_GKE_LIVE_JOB') or ''\n"
-    "root = Path(os.environ.get('MATRIX_REPO_ROOT') or '/matraix') / 'jobs' / job\n"
+    "jobs_dir = os.environ.get('MATRIX_GKE_JOBS_DIR') or 'jobs'\n"
+    "root = Path(os.environ.get('MATRIX_REPO_ROOT') or '/matraix') / jobs_dir / job\n"
     "dest = Path({live_path!r})\n"
     "exit_marker = Path({exit_path!r})\n"
     "markers = ('config.json', 'trial.log', 'persona_meta.json')\n"
@@ -97,30 +103,78 @@ class GkeHostJobRunner(Protocol):
 
 
 def gke_job_name(job_name: str, shard_key: str = "") -> str:
-    slug = "".join(ch.lower() if ch.isalnum() else "-" for ch in job_name).strip("-")
-    base = "matraix-host-{}".format(slug[:40]).strip("-") or "matraix-host-job"
+    """Kubernetes Job name (≤63 characters) for this Harbor job and shard."""
+    digest = hashlib.sha1(
+        "{}\0{}".format(job_name, shard_key).encode("utf-8")
+    ).hexdigest()[:10]
     extra = "".join(ch.lower() if ch.isalnum() else "-" for ch in shard_key).strip("-")
-    if not extra:
-        return base[:63]
-    return "{}-{}".format(base[:55], extra)[:63]
+    base = "matraix-h-{}".format(digest)
+    if extra:
+        return "{}-{}".format(base, extra)[:63]
+    return base[:63]
 
 
-def gke_host_worker_script(job_name: str) -> str:
-    """Run Harbor, pack ``jobs/<name>/``, then stay up so the API can pull the tar."""
+def gke_jobs_dir(shard_key: str = "") -> str:
+    """Harbor output directory on the PVC: ``jobs/<shard>/`` when sharded."""
+    shard = (shard_key or "").strip()
+    if shard:
+        return "jobs/{}".format(shard)
+    return "jobs"
+
+
+def encode_gke_job_config(yaml_text: str) -> dict[str, str]:
+    """Store job YAML in a ConfigMap, gzipping when the file is large."""
+    raw = yaml_text.encode("utf-8")
+    if len(raw) <= _CONFIGMAP_MAX_BYTES:
+        return {"job.yaml": yaml_text}
+    compressed = gzip.compress(raw)
+    if len(compressed) > _CONFIGMAP_MAX_BYTES:
+        raise GkeHostJobError(
+            "job YAML is too large for a Kubernetes ConfigMap "
+            "({} bytes, {} gzipped). Lower MATRIX_SHARD_SIZE.".format(
+                len(raw), len(compressed)
+            )
+        )
+    return {"job.yaml.gz.b64": base64.b64encode(compressed).decode("ascii")}
+
+
+def _is_not_found(exc: BaseException) -> bool:
+    status = getattr(exc, "status", None)
+    if status == 404:
+        return True
+    text = str(exc).lower()
+    return "not found" in text or "404" in text
+
+
+def gke_host_worker_script(job_name: str, *, jobs_dir: str = "jobs") -> str:
+    """Run Harbor, pack ``<jobs_dir>/<name>/``, then stay up so the API can pull the tar."""
     harbor = " ".join(shlex.quote(part) for part in HARBOR_MODULE_COMMAND)
     job_q = shlex.quote(job_name)
     repo_q = shlex.quote(GKE_REMOTE_REPO)
+    jobs_q = shlex.quote(jobs_dir or "jobs")
     watch = shlex.quote(_GKE_LIVE_WATCH_PY)
+    decode = shlex.quote(
+        "import base64, gzip, pathlib\n"
+        "src = pathlib.Path('/config/job.yaml.gz.b64')\n"
+        "dst = pathlib.Path('/tmp/job.yaml')\n"
+        "dst.write_bytes(gzip.decompress(base64.b64decode(src.read_text())))\n"
+    )
     return (
         "set +e\n"
         "export MATRIX_GKE_LIVE_JOB={job}\n"
+        "export MATRIX_GKE_JOBS_DIR={jobs}\n"
+        "CONFIG=/config/job.yaml\n"
+        "if [ -f /config/job.yaml.gz.b64 ]; then\n"
+        "  python -c {decode}\n"
+        "  CONFIG=/tmp/job.yaml\n"
+        "fi\n"
         "python -c {watch} &\n"
         "LIVE_PID=$!\n"
-        "{harbor} --yes -c /config/job.yaml\n"
+        "{harbor} --yes -c \"$CONFIG\"\n"
         "echo $? > {marker}\n"
         "wait \"$LIVE_PID\" 2>/dev/null || true\n"
-        "if [ -d {repo}/jobs/{job} ]; then\n"
-        "  tar czf {artifact} -C {repo}/jobs {job}\n"
+        "if [ -d {repo}/{jobs}/{job} ]; then\n"
+        "  tar czf {artifact} -C {repo}/{jobs} {job}\n"
         "fi\n"
         "sleep 3600\n"
     ).format(
@@ -128,24 +182,16 @@ def gke_host_worker_script(job_name: str) -> str:
         marker=_EXIT_MARKER,
         repo=repo_q,
         job=job_q,
+        jobs=jobs_q,
         artifact=_ARTIFACT_TAR,
         watch=watch,
+        decode=decode,
     )
 
 
 def apply_gke_live_status(dest: Path, raw: bytes | str) -> dict[str, str]:
     """Merge a worker ``live_status.json`` blob into the orchestrator overlay."""
-    text = raw.decode("utf-8", errors="replace") if isinstance(raw, bytes) else raw
-    try:
-        loaded = json.loads(text)
-    except Exception:
-        return {}
-    if not isinstance(loaded, dict):
-        return {}
-    status = {str(key): str(value) for key, value in loaded.items() if str(key)}
-    if status:
-        apply_live_overlay(dest, status)
-    return status
+    return apply_worker_live_status(dest, raw)
 
 
 def gke_live_dest(request: GkeHostJobRequest) -> Path | None:
@@ -163,16 +209,23 @@ def build_gke_job_manifest(
     image: str,
     namespace: str,
     pvc_name: str | None = None,
+    secret_name: str | None = None,
 ) -> dict[str, Any]:
+    jobs_dir = gke_jobs_dir(request.shard_key)
+    kube_name = gke_job_name(request.job_name, request.shard_key)
     env_vars = [
         {"name": key, "value": value}
-        for key, value in {**request.env, **request.secret_env}.items()
+        for key, value in request.env.items()
         if value
     ]
     env_vars.append({"name": "PYTHONPATH", "value": modal_pythonpath(Path(GKE_REMOTE_REPO))})
     env_vars.append({"name": "MATRIX_REPO_ROOT", "value": GKE_REMOTE_REPO})
+    env_vars.append({"name": _JOBS_DIR_ENV, "value": jobs_dir})
+    env_from: list[dict[str, Any]] = []
+    if secret_name and request.secret_env:
+        env_from.append({"secretRef": {"name": secret_name}})
     volumes = [
-        {"name": "config", "configMap": {"name": gke_job_name(request.job_name, request.shard_key) + "-cfg"}}
+        {"name": "config", "configMap": {"name": kube_name + "-cfg"}}
     ]
     mounts = [
         {"name": "config", "mountPath": "/config", "readOnly": True},
@@ -182,11 +235,26 @@ def build_gke_job_manifest(
         volumes.append({"name": "jobs", "persistentVolumeClaim": {"claimName": pvc_name}})
     else:
         volumes.append({"name": "jobs", "emptyDir": {}})
+    container: dict[str, Any] = {
+        "name": "harbor",
+        "image": image,
+        "workingDir": GKE_REMOTE_REPO,
+        "command": ["/bin/sh", "-c"],
+        "args": [gke_host_worker_script(request.job_name, jobs_dir=jobs_dir)],
+        "env": env_vars,
+        "volumeMounts": mounts,
+        "resources": {
+            "requests": {"cpu": "1", "memory": "4Gi"},
+            "limits": {"cpu": "2", "memory": "8Gi"},
+        },
+    }
+    if env_from:
+        container["envFrom"] = env_from
     return {
         "apiVersion": "batch/v1",
         "kind": "Job",
         "metadata": {
-            "name": gke_job_name(request.job_name, request.shard_key),
+            "name": kube_name,
             "namespace": namespace,
             "labels": {"app": "matraix-host-job", "matraix-job": request.job_name},
         },
@@ -196,21 +264,7 @@ def build_gke_job_manifest(
                 "metadata": {"labels": {"app": "matraix-host-job"}},
                 "spec": {
                     "restartPolicy": "Never",
-                    "containers": [
-                        {
-                            "name": "harbor",
-                            "image": image,
-                            "workingDir": GKE_REMOTE_REPO,
-                            "command": ["/bin/sh", "-c"],
-                            "args": [gke_host_worker_script(request.job_name)],
-                            "env": env_vars,
-                            "volumeMounts": mounts,
-                            "resources": {
-                                "requests": {"cpu": "1", "memory": "4Gi"},
-                                "limits": {"cpu": "2", "memory": "8Gi"},
-                            },
-                        }
-                    ],
+                    "containers": [container],
                     "volumes": volumes,
                 },
             },
@@ -226,10 +280,14 @@ class SdkGkeHostJobRunner:
 
     def spawn(self, request: GkeHostJobRequest) -> tuple[str, Any]:
         ctx = self._connect(request)
-        yaml_text = prepare_modal_job_config(request.config_yaml, job_name=request.job_name)
+        yaml_text = prepare_modal_job_config(
+            request.config_yaml,
+            job_name=request.job_name,
+            jobs_dir=gke_jobs_dir(request.shard_key),
+        )
         config_map = ctx["client"].V1ConfigMap(
             metadata=ctx["client"].V1ObjectMeta(name=ctx["cfg_name"], namespace=ctx["namespace"]),
-            data={"job.yaml": yaml_text},
+            data=encode_gke_job_config(yaml_text),
         )
         pvc = (os.environ.get(GKE_JOBS_PVC_ENV) or "").strip() or None
         manifest = build_gke_job_manifest(
@@ -237,10 +295,23 @@ class SdkGkeHostJobRunner:
             image=ctx["image"],
             namespace=ctx["namespace"],
             pvc_name=pvc,
+            secret_name=ctx["secret_name"] if request.secret_env else None,
         )
         try:
             self._replace_config_map(ctx["core"], ctx["cfg_name"], ctx["namespace"], config_map)
+            if request.secret_env:
+                secret = ctx["client"].V1Secret(
+                    metadata=ctx["client"].V1ObjectMeta(
+                        name=ctx["secret_name"],
+                        namespace=ctx["namespace"],
+                    ),
+                    type="Opaque",
+                    string_data=dict(request.secret_env),
+                )
+                self._replace_secret(ctx["core"], ctx["secret_name"], ctx["namespace"], secret)
             self._replace_job(ctx["batch"], ctx["name"], ctx["namespace"], manifest)
+        except GkeHostJobError:
+            raise
         except Exception as exc:  # noqa: BLE001
             raise GkeHostJobError(str(exc)) from exc
         return ctx["name"], None
@@ -255,9 +326,6 @@ class SdkGkeHostJobRunner:
         del call
         ctx = self._connect(request)
         name = (call_id or "").strip() or ctx["name"]
-        cfg_name = name + "-cfg" if name == ctx["name"] else name + "-cfg"
-        if name != ctx["name"]:
-            cfg_name = name + "-cfg"
         try:
             from kubernetes import stream
         except ImportError as exc:
@@ -271,13 +339,14 @@ class SdkGkeHostJobRunner:
             )
             artifact = self._read_artifact_tar(stream, ctx["core"], pod, ctx["namespace"])
         except GkeHostJobError:
+            self.cleanup(request)
             raise
         except Exception as exc:  # noqa: BLE001
+            self.cleanup(request)
             raise GkeHostJobError(str(exc)) from exc
-        finally:
-            self._delete_job(ctx["batch"], ctx["core"], name, cfg_name, ctx["namespace"])
         error = None if exit_code == 0 else "GKE host workers exited with code {}".format(exit_code)
         if exit_code == 0 and not artifact:
+            self.cleanup(request)
             raise GkeHostJobError(
                 "GKE host workers finished without returning jobs/{}/ artifacts".format(
                     request.job_name
@@ -290,9 +359,23 @@ class SdkGkeHostJobRunner:
             volume_path=request.job_name,
         )
 
+    def cleanup(self, request: GkeHostJobRequest) -> None:
+        ctx = self._connect(request)
+        self._delete_job(
+            ctx["batch"],
+            ctx["core"],
+            ctx["name"],
+            ctx["cfg_name"],
+            ctx["namespace"],
+            secret_name=ctx["secret_name"],
+        )
+
     def run(self, request: GkeHostJobRequest) -> ModalHostJobResult:
         call_id, _ = self.spawn(request)
-        return self.wait(request, call_id=call_id)
+        try:
+            return self.wait(request, call_id=call_id)
+        finally:
+            self.cleanup(request)
 
     def _connect(self, request: GkeHostJobRequest) -> dict[str, Any]:
         image = gke_host_image()
@@ -317,6 +400,7 @@ class SdkGkeHostJobRunner:
             "namespace": namespace,
             "name": name,
             "cfg_name": name + "-cfg",
+            "secret_name": name + "-sec",
             "image": image,
         }
 
@@ -340,18 +424,43 @@ class SdkGkeHostJobRunner:
                 "(KUBECONFIG or ~/.kube/config) or in-cluster credentials"
             ) from exc
 
+    def _wait_for_absent(self, getter: Any, *, timeout_sec: float = 60.0) -> None:
+        deadline = time.time() + timeout_sec
+        while time.time() < deadline:
+            try:
+                getter()
+            except Exception as exc:  # noqa: BLE001
+                if _is_not_found(exc):
+                    return
+                raise
+            time.sleep(0.4)
+        raise GkeHostJobError("timed out waiting for Kubernetes object deletion")
+
     def _replace_config_map(self, core: Any, name: str, namespace: str, body: Any) -> None:
         try:
             core.delete_namespaced_config_map(name, namespace)
-        except Exception:
-            pass
+        except Exception as exc:  # noqa: BLE001
+            if not _is_not_found(exc):
+                pass
+        self._wait_for_absent(lambda: core.read_namespaced_config_map(name, namespace))
         core.create_namespaced_config_map(namespace, body)
+
+    def _replace_secret(self, core: Any, name: str, namespace: str, body: Any) -> None:
+        try:
+            core.delete_namespaced_secret(name, namespace)
+        except Exception as exc:  # noqa: BLE001
+            if not _is_not_found(exc):
+                pass
+        self._wait_for_absent(lambda: core.read_namespaced_secret(name, namespace))
+        core.create_namespaced_secret(namespace, body)
 
     def _replace_job(self, batch: Any, name: str, namespace: str, manifest: dict[str, Any]) -> None:
         try:
-            batch.delete_namespaced_job(name, namespace, propagation_policy="Background")
-        except Exception:
-            pass
+            batch.delete_namespaced_job(name, namespace, propagation_policy="Foreground")
+        except Exception as exc:  # noqa: BLE001
+            if not _is_not_found(exc):
+                pass
+        self._wait_for_absent(lambda: batch.read_namespaced_job(name, namespace))
         batch.create_namespaced_job(namespace, manifest)
 
     def _delete_job(
@@ -361,6 +470,8 @@ class SdkGkeHostJobRunner:
         job_name: str,
         cfg_name: str,
         namespace: str,
+        *,
+        secret_name: str | None = None,
     ) -> None:
         try:
             batch.delete_namespaced_job(job_name, namespace, propagation_policy="Background")
@@ -370,6 +481,11 @@ class SdkGkeHostJobRunner:
             core.delete_namespaced_config_map(cfg_name, namespace)
         except Exception:
             pass
+        if secret_name:
+            try:
+                core.delete_namespaced_secret(secret_name, namespace)
+            except Exception:
+                pass
 
     def _wait_for_exit_marker(
         self,
@@ -431,23 +547,53 @@ class SdkGkeHostJobRunner:
         pod: str,
         namespace: str,
     ) -> bytes | None:
+        tmp_path: str | None = None
         try:
-            encoded = self._exec(
-                stream,
-                core,
+            handle, tmp_path = tempfile.mkstemp(suffix=".tgz")
+            os.close(handle)
+            written = 0
+            resp = stream.stream(
+                core.connect_get_namespaced_pod_exec,
                 pod,
                 namespace,
-                ["base64", _ARTIFACT_TAR],
+                command=["cat", _ARTIFACT_TAR],
+                stderr=True,
+                stdin=False,
+                stdout=True,
+                tty=False,
+                _preload_content=False,
             )
+            try:
+                with open(tmp_path, "wb") as out:
+                    while resp.is_open():
+                        resp.update(timeout=60)
+                        if resp.peek_stdout():
+                            data = resp.read_stdout()
+                            chunk = (
+                                data
+                                if isinstance(data, (bytes, bytearray))
+                                else str(data).encode("latin1")
+                            )
+                            written += len(chunk)
+                            if written > _MAX_ARTIFACT_BYTES:
+                                raise GkeHostJobError(
+                                    "GKE artifact tar exceeded {} bytes".format(
+                                        _MAX_ARTIFACT_BYTES
+                                    )
+                                )
+                            out.write(chunk)
+            finally:
+                resp.close()
+            if written <= 0:
+                return None
+            return Path(tmp_path).read_bytes()
+        except GkeHostJobError:
+            raise
         except Exception:
             return None
-        text = encoded.decode("ascii", errors="ignore").strip()
-        if not text:
-            return None
-        try:
-            return base64.b64decode(text)
-        except Exception:
-            return None
+        finally:
+            if tmp_path:
+                Path(tmp_path).unlink(missing_ok=True)
 
     def _exec(
         self,

--- a/application/playground/backend/service/gke_host_worker.Dockerfile
+++ b/application/playground/backend/service/gke_host_worker.Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.12-slim-bookworm
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git build-essential ca-certificates tar \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+WORKDIR /matraix
+COPY pyproject.toml README.md /matraix/
+COPY src /matraix/src
+COPY environment /matraix/environment
+COPY packages /matraix/packages
+COPY application /matraix/application
+COPY persona /matraix/persona
+
+RUN uv pip install --system --compile-bytecode -e '.[gke]'
+
+ENV PYTHONPATH=/matraix:/matraix/src:/matraix/environment/runtime:/matraix/environment/agents:/matraix/packages/playground/src:/matraix/application/playground
+ENV MATRIX_REPO_ROOT=/matraix

--- a/application/playground/backend/service/harbor_job_service.py
+++ b/application/playground/backend/service/harbor_job_service.py
@@ -1342,7 +1342,7 @@ class HarborJobService:
                     "computeFamily=modal requires Modal credentials "
                     "(MODAL_TOKEN_ID and MODAL_TOKEN_SECRET, or ~/.modal.toml) "
                     "and a deployed matraix-host-jobs app "
-                    "(harbor_host_job / harbor_docker_job)"
+                    "(application/playground/backend/service/modal_host_app.py)"
                 )
         if compute_plan.dispatch == "gke_workers":
             from matraix.gke_settings import (
@@ -2241,6 +2241,13 @@ class HarborJobService:
                 by_key[key] = row
                 state["shards"] = list(by_key.values())
                 save_cloud_run(job_dir, state)
+                request = handles[key][2]
+                cleanup = getattr(runner, "cleanup", None)
+                if dispatch == "gke_workers" and callable(cleanup):
+                    try:
+                        cleanup(request)
+                    except Exception:
+                        pass
         return codes, errors
 
     def _invoke_modal_host(
@@ -2281,7 +2288,9 @@ class HarborJobService:
             exit_code = int(result.exit_code)
             error = result.error
             if exit_code != 0 and not error:
-                error = "Modal Jobs exited with code {}".format(exit_code)
+                error = "Modal shard {} exited with code {}".format(
+                    shard_key, exit_code
+                )
             return exit_code, error
         except ModalHostJobError as exc:
             return 1, str(exc)

--- a/application/playground/backend/service/harbor_job_service.py
+++ b/application/playground/backend/service/harbor_job_service.py
@@ -11,7 +11,7 @@ import threading
 import time
 import tomllib
 import uuid
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -41,7 +41,10 @@ from playground.remote_runner.dispatch import filter_remote_harbor_payload_env
 from matraix.application_job import (
     DEFAULT_APPLICATION_JOBS_DIR,
     build_application_job_config,
-    resolve_job_environment,
+)
+from matraix.compute_family import (
+    normalize_compute_family,
+    resolve_compute_plan,
 )
 from matraix.launch_env import build_launch_env
 
@@ -206,7 +209,28 @@ def _utc_now() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def _trial_result_error(result: dict[str, Any] | None) -> str | None:
+def _exception_type(result: dict[str, Any] | None) -> str:
+    if not result:
+        return ""
+    exc = result.get("exception_info")
+    if isinstance(exc, dict):
+        return str(exc.get("exception_type") or "")
+    return ""
+
+
+def _reward_gap_with_artifact(result: dict[str, Any] | None, trial_dir: Path) -> bool:
+    """Harbor errored only because ``reward.txt`` is missing, but artifacts exist."""
+    if "RewardFileNotFoundError" not in _exception_type(result):
+        return False
+    return (trial_dir / "verifier" / "structured_output.json").is_file()
+
+
+def _trial_result_error(
+    result: dict[str, Any] | None,
+    trial_dir: Path | None = None,
+) -> str | None:
+    if trial_dir is not None and _reward_gap_with_artifact(result, trial_dir):
+        return None
     if not result:
         return None
     exc = result.get("exception_info")
@@ -386,7 +410,13 @@ def _external_run_activity_ts(
 ) -> float | None:
     """Latest evidence that an externally driven job is still writing artifacts."""
     latest = _job_result_activity_ts(job_result)
-    for path in (job_dir / "result.json", job_dir / "job.log"):
+    generated = job_dir / "_generated"
+    for path in (
+        job_dir / "result.json",
+        job_dir / "job.log",
+        generated / "live_overlay.json",
+        generated / "cloud_run.json",
+    ):
         mtime = _path_mtime(path)
         if mtime is not None:
             latest = mtime if latest is None else max(latest, mtime)
@@ -405,6 +435,34 @@ def _activity_is_live(*, activity_ts: float | None, now_ts: float) -> bool:
     if activity_ts is None:
         return False
     return (now_ts - activity_ts) <= EXTERNAL_RUN_STALE_AFTER_SEC
+
+
+def _job_source(job_name: str) -> str:
+    """Playground launches vs experiment-arm jobs (``exp-…-cN``)."""
+    return "experiment" if job_name.startswith("exp-") else "playground"
+
+
+def _missing_reward_only(job_dir: Path) -> bool:
+    """True when every Harbor trial error is a missing ``reward.txt`` with artifacts."""
+    saw_reward_gap = False
+    for child in job_dir.iterdir() if job_dir.is_dir() else []:
+        if not child.is_dir():
+            continue
+        result_path = child / "result.json"
+        if not result_path.is_file():
+            continue
+        try:
+            payload = json.loads(result_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if not _exception_type(payload):
+            continue
+        if not _reward_gap_with_artifact(payload, child):
+            return False
+        saw_reward_gap = True
+    return saw_reward_gap
 
 
 def _job_list_status(
@@ -553,6 +611,21 @@ class _JobStatusState:
     history: list[list[tuple[int, int]]] = field(default_factory=list)
 
 
+def _job_executor_max_workers() -> int:
+    """Concurrent Harbor job launches (each arm holds one worker for its whole
+    run). Default 8 so a typical A/B/N launches every arm in parallel instead of
+    the old cap of 2; override with ``MATRIX_JOB_MAX_WORKERS``."""
+    raw = os.environ.get("MATRIX_JOB_MAX_WORKERS", "").strip()
+    if raw:
+        try:
+            n = int(raw)
+        except ValueError:
+            n = 0
+        if n >= 1:
+            return n
+    return 8
+
+
 @dataclass
 class HarborLaunchRecord:
     job_name: str
@@ -563,6 +636,9 @@ class HarborLaunchRecord:
     finished_at: str | None = None
     exit_code: int | None = None
     execution_plane: str = "harbor"
+    compute_family: str = "local"
+    compute_environment: str | None = None
+    compute_dispatch: str | None = None
     remote_run_id: str | None = None
 
 
@@ -576,8 +652,17 @@ class HarborJobService:
     command_runner: Callable[..., int] = _run_subprocess
     harbor_command: tuple[str, ...] = field(default_factory=lambda: tuple(_default_harbor_command()))
     remote_runner_client: Any | None = None
-    _executor: ThreadPoolExecutor = field(default_factory=lambda: ThreadPoolExecutor(max_workers=2))
+    modal_host_job_runner: Any | None = None
+    gke_host_job_runner: Any | None = None
+    _executor: ThreadPoolExecutor = field(
+        default_factory=lambda: ThreadPoolExecutor(
+            max_workers=_job_executor_max_workers()
+        )
+    )
     _launches: dict[str, HarborLaunchRecord] = field(default_factory=dict)
+    # Per-job extra launch env (e.g. experiment MATRIX_PARAM_* / EXPERIMENTS_TASK_DIR),
+    # merged in _build_harbor_launch_env so each experiment cell's stimulus is injected.
+    _extra_launch_env: dict[str, dict[str, str]] = field(default_factory=dict)
     _reporting_jobs: set[str] = field(default_factory=set)
     _guard: threading.Lock = field(default_factory=threading.Lock)
     _status_states: dict[str, "_JobStatusState"] = field(default_factory=dict)
@@ -592,11 +677,13 @@ class HarborJobService:
     def from_repo(cls, *, repo_root: Path | None = None, jobs_dir: Path | None = None) -> "HarborJobService":
         root = Path(repo_root) if repo_root is not None else _repo_root()
         resolved_jobs = Path(jobs_dir) if jobs_dir is not None else root / "jobs"
-        return cls(
+        service = cls(
             repo_root=root,
             jobs_dir=resolved_jobs,
             generated_configs_dir=root / DEFAULT_APPLICATION_JOBS_DIR,
         )
+        service.resume_detached_cloud_runs()
+        return service
 
     def _list_job_names(self) -> list[str]:
         if not self.jobs_dir.is_dir():
@@ -611,16 +698,76 @@ class HarborJobService:
         if not job_dir.is_dir():
             return []
         skip = {"_inputs", "_generated"}
-        return sorted(
-            [
-                d.name
-                for d in job_dir.iterdir()
-                if d.is_dir() and d.name not in skip and not d.name.startswith(".")
-            ]
-        )
+        names = {
+            d.name
+            for d in job_dir.iterdir()
+            if d.is_dir() and d.name not in skip and not d.name.startswith(".")
+        }
+        try:
+            from backend.service.modal_host_job import read_live_overlay
+
+            names.update(read_live_overlay(job_dir))
+        except Exception:
+            pass
+        return sorted(names)
 
     def _trial_has_result(self, job_name: str, trial_name: str) -> bool:
         return (self.jobs_dir / job_name / trial_name / "result.json").is_file()
+
+    def _job_config_for_listing(self, job_name: str, job_dir: Path) -> dict[str, Any] | None:
+        meta = self._read_json(self._launch_meta_path(job_name)) or {}
+        job_config = meta.get("jobConfig") if isinstance(meta.get("jobConfig"), dict) else None
+        if isinstance(job_config, dict):
+            return job_config
+        return self._read_json(job_dir / "config.json")
+
+    def _expected_trial_count(self, job_name: str, job_dir: Path) -> int:
+        job_config = self._job_config_for_listing(job_name, job_dir)
+        if not isinstance(job_config, dict):
+            return 0
+        agents = job_config.get("agents")
+        if not isinstance(agents, list):
+            return 0
+        return sum(1 for row in agents if isinstance(row, dict))
+
+    def _in_flight_listing_progress(
+        self, job_name: str, job_dir: Path
+    ) -> tuple[int, int, int]:
+        """trial_count, completed_trials, failed_on_disk for a still-running job.
+
+        Overlay-only dones (no ``result.json`` yet) still move the Runs bar;
+        expected size comes from launch-time ``agents`` so 10/1000 is visible
+        before trial trees flush.
+        """
+        overlay: dict[str, str] = {}
+        try:
+            from backend.service.modal_host_job import read_live_overlay
+
+            overlay = read_live_overlay(job_dir)
+        except Exception:  # noqa: BLE001
+            overlay = {}
+        names = set(self._list_trial_names(job_name)) | set(overlay)
+        trial_count = max(self._expected_trial_count(job_name, job_dir), len(names))
+        completed = 0
+        failed = 0
+        for name in names:
+            if self._trial_has_result(job_name, name):
+                completed += 1
+                if (
+                    _trial_result_error(
+                        self._read_json(job_dir / name / "result.json"),
+                        job_dir / name,
+                    )
+                    is not None
+                ):
+                    failed += 1
+                continue
+            state = overlay.get(name)
+            if state in {"done", "error"}:
+                completed += 1
+            if state == "error":
+                failed += 1
+        return trial_count, completed, failed
 
     def _read_json(self, path: Path) -> dict[str, Any] | None:
         if not path.is_file():
@@ -914,26 +1061,24 @@ class HarborJobService:
                 failed_trials_on_disk = int(stats.get("n_errored_trials") or 0)
                 activity_ts = None
             else:
-                trials = self._list_trial_names(job_name)
-                trial_count = len(trials)
-                completed_trials = sum(
-                    1 for trial_name in trials if self._trial_has_result(job_name, trial_name)
-                )
-                failed_trials_on_disk = sum(
-                    1
-                    for trial_name in trials
-                    if _trial_result_error(
-                        self._read_json(job_dir / trial_name / "result.json")
-                    )
-                    is not None
+                trial_count, completed_trials, failed_trials_on_disk = (
+                    self._in_flight_listing_progress(job_name, job_dir)
                 )
                 activity_ts = _external_run_activity_ts(
                     job_dir,
                     job_result=job_result,
-                    trial_names=trials,
+                    trial_names=self._list_trial_names(job_name),
                 )
             with self._guard:
                 launch = self._launches.get(job_name)
+            if failed_trials_on_disk > 0 and _missing_reward_only(job_dir):
+                failed_trials_on_disk = 0
+                if isinstance(job_result, dict):
+                    patched = dict(job_result)
+                    stats = dict(patched.get("stats") or {})
+                    stats["n_errored_trials"] = 0
+                    patched["stats"] = stats
+                    job_result = patched
             status, failed_trials = _job_list_status(
                 trial_count=trial_count,
                 completed_trials=completed_trials,
@@ -946,6 +1091,7 @@ class HarborJobService:
             summaries.append(
                 {
                     "jobName": job_name,
+                    "source": _job_source(job_name),
                     "applicationType": self._job_application_type(job_name, job_dir),
                     "taskTitle": task_meta.get("taskTitle"),
                     "taskName": task_meta.get("taskName"),
@@ -1007,7 +1153,7 @@ class HarborJobService:
             trial_dir = job_dir / trial_name
             result = self._read_json(trial_dir / "result.json")
             completed = self._trial_has_result(job_name, trial_name)
-            error = _trial_result_error(result)
+            error = _trial_result_error(result, trial_dir)
             persona_meta = _persona_meta_from_trial(trial_dir)
             vnc_url = _read_vnc_url(trial_dir)
             sandbox_id = _read_sandbox_id(trial_dir)
@@ -1087,6 +1233,8 @@ class HarborJobService:
         os_app_backend: str | None = None,
         cua_backend: str | None = None,
         execution_plane: str | None = None,
+        compute_family: str | None = None,
+        extra_launch_env: dict[str, str] | None = None,
     ) -> str:
         from backend.service.execution_plane import (
             ExecutionPlaneError,
@@ -1095,6 +1243,10 @@ class HarborJobService:
             remote_runner_configured,
         )
 
+        try:
+            resolved_compute_family = normalize_compute_family(compute_family)
+        except ValueError as exc:
+            raise ValueError(str(exc)) from exc
         try:
             resolved_plane = normalize_execution_plane(
                 execution_plane or default_execution_plane()
@@ -1176,6 +1328,62 @@ class HarborJobService:
             mode=execution_mode,
             repo_root=self.repo_root,
         )
+        compute_plan = resolve_compute_plan(
+            execution_mode=execution_mode,
+            trial_profile=trial_profile,
+            cua_backend=os_app_backend,
+            compute_family=resolved_compute_family,
+        )
+        if compute_plan.dispatch == "modal_jobs":
+            from backend.service.modal_host_job import modal_credentials_configured
+
+            if self.modal_host_job_runner is None and not modal_credentials_configured():
+                raise ValueError(
+                    "computeFamily=modal requires Modal credentials "
+                    "(MODAL_TOKEN_ID and MODAL_TOKEN_SECRET, or ~/.modal.toml) "
+                    "and a deployed matraix-host-jobs app "
+                    "(harbor_host_job / harbor_docker_job)"
+                )
+        if compute_plan.dispatch == "gke_workers":
+            from matraix.gke_settings import (
+                GKE_CLUSTER_ENV,
+                GKE_HOST_IMAGE_ENV,
+                GKE_REGION_ENV,
+                gke_host_workers_ready,
+            )
+
+            if self.gke_host_job_runner is None and not gke_host_workers_ready():
+                raise ValueError(
+                    "computeFamily=gcp for survey/chat requires {} "
+                    "(image with MatrAIx + Harbor) and kubeconfig "
+                    "or {} + {} for gcloud get-credentials".format(
+                        GKE_HOST_IMAGE_ENV,
+                        GKE_CLUSTER_ENV,
+                        GKE_REGION_ENV,
+                    )
+                )
+        if compute_plan.environment == "gke":
+            from matraix.gke_settings import missing_gke_harbor_keys
+
+            missing = missing_gke_harbor_keys()
+            if missing:
+                raise ValueError(
+                    "computeFamily=gcp for web/linux requires GKE settings "
+                    "(missing {}). Set MATRIX_GKE_CLUSTER, MATRIX_GKE_REGION, "
+                    "MATRIX_GKE_REGISTRY, and GCP_PROJECT.".format(", ".join(missing))
+                )
+        if trial_profile == "user_sim_chat" and compute_plan.dispatch in {
+            "modal_jobs",
+            "gke_workers",
+        }:
+            from backend.service.chatbot_reachability import (
+                require_cloud_reachable_chatbot_url,
+            )
+            from backend.service.chatbot_sidecar_service import ensure_sidecar_url_env
+
+            ensure_sidecar_url_env(chat_application_id)
+            require_cloud_reachable_chatbot_url()
+        n_concurrent_trials = max(1, int(n_concurrent_trials or 1))
         resolved_survey_task_path: str | None = None
         resolved_chat_task_path: str | None = None
         if trial_profile == "json_survey":
@@ -1209,6 +1417,7 @@ class HarborJobService:
             "execution_mode": execution_mode,
             "trial_profile": trial_profile,
             "cua_backend": os_app_backend,
+            "compute_family": compute_plan.family,
             "agent": {"name": agent, "model_name": model},
             "job": {
                 "job_name": resolved_job_name,
@@ -1230,12 +1439,8 @@ class HarborJobService:
                 )
         # os_app_submission_profile / cua_submission_profile are no longer injected:
         # agents mirror final_answer only; task verifiers recover named JSON.
+        job_config["environment"] = compute_plan.harbor_environment()
         if os_app_backend:
-            job_config["environment"] = resolve_job_environment(
-                execution_mode=execution_mode,
-                trial_profile=trial_profile,
-                cua_backend=os_app_backend,
-            )
             env_type = ""
             env_block = job_config.get("environment")
             if isinstance(env_block, dict):
@@ -1273,6 +1478,7 @@ class HarborJobService:
         config_path = self.generated_configs_dir / "{}.yaml".format(resolved_job_name)
         header = (
             "# Generated by Playground POST /api/harbor/jobs\n"
+            "{}\n"
             "# Task: {}\n"
             "# Harbor task: {}\n"
             "# Mode: {}\n"
@@ -1284,6 +1490,7 @@ class HarborJobService:
             "# Persona filters: {}\n"
             "# Personas: {}\n"
             "# Jobs output: {}/\n\n".format(
+                compute_plan.header_comment(),
                 task_path,
                 resolved_task_path,
                 job_meta.get("execution_mode", "auto") if job_meta else "auto",
@@ -1306,21 +1513,112 @@ class HarborJobService:
             encoding="utf-8",
         )
 
+        from backend.service.cohort_shard_planner import (
+            plan_job_shards,
+            should_fanout_cloud_shards,
+            should_fanout_harbor_shards,
+        )
+
+        shard_records: list[dict[str, Any]] = []
+        job_shards = plan_job_shards(job_config, trial_profile=trial_profile)
+        planned_shards = job_shards.shards
+        fanout_cloud = should_fanout_cloud_shards(compute_plan.dispatch, len(planned_shards))
+        fanout_harbor = should_fanout_harbor_shards(
+            family=compute_plan.family,
+            environment=compute_plan.environment,
+            dispatch=compute_plan.dispatch,
+            shard_count=len(planned_shards),
+        )
+        if fanout_cloud or fanout_harbor:
+            for shard, shard_cfg in planned_shards:
+                if fanout_harbor:
+                    shard_cfg["jobs_dir"] = _rel_path(
+                        self.jobs_dir
+                        / resolved_job_name
+                        / "_generated"
+                        / "work"
+                        / shard.key,
+                        self.repo_root,
+                    )
+                shard_path = self.generated_configs_dir / "{}.shard-{:02d}.yaml".format(
+                    resolved_job_name,
+                    shard.shard_index,
+                )
+                shard_header = header + "# Internal shard {}/{} offset={} limit={}\n\n".format(
+                    shard.shard_index + 1,
+                    shard.shard_count,
+                    shard.offset,
+                    shard.limit,
+                )
+                shard_path.write_text(
+                    shard_header + yaml.safe_dump(shard_cfg, sort_keys=False),
+                    encoding="utf-8",
+                )
+                shard_records.append(
+                    {
+                        "index": shard.shard_index,
+                        "count": shard.shard_count,
+                        "offset": shard.offset,
+                        "limit": shard.limit,
+                        "key": shard.key,
+                        "kind": "harbor" if fanout_harbor else "cloud",
+                        "personaIds": list(shard.persona_ids),
+                        "nConcurrentTrials": int(
+                            shard_cfg.get("n_concurrent_trials") or 1
+                        ),
+                        "configPath": _rel_path(shard_path, self.repo_root),
+                    }
+                )
+            generated = self.jobs_dir / resolved_job_name / "_generated"
+            generated.mkdir(parents=True, exist_ok=True)
+            (generated / "shards.json").write_text(
+                json.dumps(
+                    {
+                        "jobName": resolved_job_name,
+                        **job_shards.layout.to_dict(),
+                        "shards": shard_records,
+                    },
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
         record = HarborLaunchRecord(
             job_name=resolved_job_name,
             status="queued",
             config_path=_rel_path(config_path, self.repo_root),
             started_at=_utc_now(),
             execution_plane=resolved_plane,
+            compute_family=compute_plan.family,
+            compute_environment=compute_plan.environment,
+            compute_dispatch=compute_plan.dispatch,
         )
+        normalized_extra_env = {str(k): str(v) for k, v in (extra_launch_env or {}).items()}
         with self._guard:
             self._launches[resolved_job_name] = record
+            if normalized_extra_env:
+                self._extra_launch_env[resolved_job_name] = normalized_extra_env
 
-        use_local_distributed = _should_use_local_distributed_harbor(
-            execution_mode=execution_mode,
-            execution_plane=resolved_plane,
-            trial_profile=trial_profile,
+        use_local_distributed = (
+            compute_plan.dispatch is None
+            and _should_use_local_distributed_harbor(
+                execution_mode=execution_mode,
+                execution_plane=resolved_plane,
+                trial_profile=trial_profile,
+            )
         )
+
+        from backend.service.modal_host_job import write_compute_json
+
+        write_compute_json(self.jobs_dir / resolved_job_name, compute_plan)
+        try:
+            (self.jobs_dir / resolved_job_name / "config.json").write_text(
+                json.dumps(job_config, indent=2, default=str) + "\n",
+                encoding="utf-8",
+            )
+        except Exception:  # noqa: BLE001
+            pass
 
         # Persist the exact dispatch inputs so "retry failed" can replay the
         # identical run in-place (Harbor resumes and only re-runs deleted trials).
@@ -1329,6 +1627,9 @@ class HarborJobService:
             {
                 "configPath": _rel_path(config_path, self.repo_root),
                 "executionPlane": resolved_plane,
+                "computeFamily": compute_plan.family,
+                "computeEnvironment": compute_plan.environment,
+                "computeDispatch": compute_plan.dispatch,
                 "executionMode": execution_mode,
                 "useLocalDistributed": use_local_distributed,
                 "trialProfile": trial_profile,
@@ -1339,7 +1640,9 @@ class HarborJobService:
                 "chatApplicationId": chat_application_id,
                 "chatApplicationContext": chat_application_context,
                 "chatMaxTurns": chat_max_turns,
+                "extraLaunchEnv": normalized_extra_env or None,
                 "jobConfig": job_config,
+                "shards": shard_records,
             },
         )
 
@@ -1369,7 +1672,11 @@ class HarborJobService:
                 chat_max_turns,
                 trial_profile,
             )
-            if resolved_plane == "remote":
+            if compute_plan.dispatch == "modal_jobs":
+                self._executor.submit(self._dispatch_modal_host, *dispatch_kwargs)
+            elif compute_plan.dispatch == "gke_workers":
+                self._executor.submit(self._dispatch_gke_host, *dispatch_kwargs)
+            elif resolved_plane == "remote":
                 self._executor.submit(self._dispatch_remote, *dispatch_kwargs)
             else:
                 self._executor.submit(self._run_harbor, *dispatch_kwargs)
@@ -1386,10 +1693,15 @@ class HarborJobService:
         chat_application_context: str | None,
         chat_max_turns: int | None,
         for_remote: bool = False,
+        job_name: str | None = None,
     ) -> dict[str, str]:
         # PYTHONPATH entries are shared with the `matraix run` CLI so GUI and
         # CLI launches cannot drift apart (issue #78).
         env = build_launch_env(self.repo_root, base_env={} if for_remote else None)
+        if job_name:
+            with self._guard:
+                extra = dict(self._extra_launch_env.get(job_name) or {})
+            env.update(extra)
         if survey_task_path:
             env["MATRIX_SURVEY_TASK_PATH"] = survey_task_path
         if trial_profile == "user_sim_chat":
@@ -1438,6 +1750,7 @@ class HarborJobService:
             chat_application_id=chat_application_id,
             chat_application_context=chat_application_context,
             chat_max_turns=chat_max_turns,
+            job_name=job_name,
         )
         try:
             from backend.service.local_distributed_harbor import (
@@ -1485,15 +1798,13 @@ class HarborJobService:
         chat_max_turns: int | None = None,
         trial_profile: str | None = None,
     ) -> None:
+        del os_app_submission_profile
+        from backend.service.cohort_shard_planner import shard_concurrency_from_env
+
         with self._guard:
             record = self._launches[job_name]
             record.status = "running"
 
-        command = list(self.harbor_command) + [
-            "--yes",
-            "-c",
-            _rel_path(config_path, self.repo_root),
-        ]
         env = self._build_harbor_launch_env(
             survey_task_path=survey_task_path,
             chat_task_path=chat_task_path,
@@ -1502,17 +1813,28 @@ class HarborJobService:
             chat_application_id=chat_application_id,
             chat_application_context=chat_application_context,
             chat_max_turns=chat_max_turns,
+            job_name=job_name,
         )
+        work = self._cloud_shard_work_items(job_name, config_path)
         try:
             held: dict[str, Any] = {}
 
             def _invoke() -> None:
-                code = self.command_runner(
-                    command,
-                    cwd=self.repo_root,
-                    env=env,
-                )
-                held["exit_code"] = code
+                if len(work) == 1:
+                    held["exit_code"] = self._invoke_harbor_config(work[0][1], env)
+                    self._merge_harbor_shard_tree(job_name, work[0][0])
+                    return
+                codes: list[int] = []
+                workers = min(shard_concurrency_from_env(), len(work))
+                with ThreadPoolExecutor(max_workers=workers) as pool:
+                    futures = [
+                        pool.submit(self._invoke_harbor_config, path, env)
+                        for _, path in work
+                    ]
+                    for (shard_key, _), future in zip(work, futures):
+                        codes.append(int(future.result()))
+                        self._merge_harbor_shard_tree(job_name, shard_key)
+                held["exit_code"] = 0 if codes and all(code == 0 for code in codes) else 1
 
             self._run_with_trial_host_scoring(job_name, _invoke)
             exit_code = int(held.get("exit_code", 1))
@@ -1530,9 +1852,478 @@ class HarborJobService:
             record.error = error
             record.finished_at = _utc_now()
         # Rescue anything the per-trial watcher missed (idempotent).
+        self._maybe_rollup_job_result(job_name)
         self._maybe_run_host_verifier(job_name)
         self._maybe_generate_post_run_feedback(job_name)
         self._maybe_schedule_reporting(job_name, self.jobs_dir / job_name)
+
+    def _invoke_harbor_config(self, config_path: Path, env: dict[str, str]) -> int:
+        command = list(self.harbor_command) + [
+            "--yes",
+            "-c",
+            _rel_path(config_path, self.repo_root),
+        ]
+        return int(self.command_runner(command, cwd=self.repo_root, env=env))
+
+    def _merge_harbor_shard_tree(self, job_name: str, shard_key: str) -> None:
+        staged = self.jobs_dir / job_name / "_generated" / "work" / shard_key / job_name
+        if not staged.is_dir():
+            return
+        from backend.service.modal_host_job import merge_job_dir
+
+        merge_job_dir(staged, self.jobs_dir / job_name)
+        shutil.rmtree(staged.parent, ignore_errors=True)
+
+    def _dispatch_modal_host(
+        self,
+        job_name: str,
+        config_path: Path,
+        survey_task_path: str | None = None,
+        chat_task_path: str | None = None,
+        os_app_submission_profile: str | None = None,
+        chat_domain: str | None = None,
+        chat_application_id: str | None = None,
+        chat_application_context: str | None = None,
+        chat_max_turns: int | None = None,
+        trial_profile: str | None = None,
+    ) -> None:
+        self._dispatch_cloud_host(
+            "modal_jobs",
+            job_name,
+            config_path,
+            survey_task_path=survey_task_path,
+            chat_task_path=chat_task_path,
+            os_app_submission_profile=os_app_submission_profile,
+            chat_domain=chat_domain,
+            chat_application_id=chat_application_id,
+            chat_application_context=chat_application_context,
+            chat_max_turns=chat_max_turns,
+            trial_profile=trial_profile,
+        )
+
+    def _dispatch_gke_host(
+        self,
+        job_name: str,
+        config_path: Path,
+        survey_task_path: str | None = None,
+        chat_task_path: str | None = None,
+        os_app_submission_profile: str | None = None,
+        chat_domain: str | None = None,
+        chat_application_id: str | None = None,
+        chat_application_context: str | None = None,
+        chat_max_turns: int | None = None,
+        trial_profile: str | None = None,
+    ) -> None:
+        self._dispatch_cloud_host(
+            "gke_workers",
+            job_name,
+            config_path,
+            survey_task_path=survey_task_path,
+            chat_task_path=chat_task_path,
+            os_app_submission_profile=os_app_submission_profile,
+            chat_domain=chat_domain,
+            chat_application_id=chat_application_id,
+            chat_application_context=chat_application_context,
+            chat_max_turns=chat_max_turns,
+            trial_profile=trial_profile,
+        )
+
+    def _cloud_shard_work_items(
+        self,
+        job_name: str,
+        config_path: Path,
+    ) -> list[tuple[str, Path]]:
+        meta = self._read_json(self._launch_meta_path(job_name)) or {}
+        shards = meta.get("retryShards") if isinstance(meta.get("retryShards"), list) else []
+        if not shards:
+            shards = meta.get("shards") if isinstance(meta.get("shards"), list) else []
+        items: list[tuple[str, Path]] = []
+        for row in shards:
+            if not isinstance(row, dict):
+                continue
+            rel = str(row.get("configPath") or "").strip()
+            if not rel:
+                continue
+            path = self.repo_root / rel
+            if path.is_file():
+                items.append((str(row.get("key") or "s{}".format(len(items))), path))
+        if items:
+            return items
+        return [("s0", config_path)]
+
+    def _dispatch_cloud_host(
+        self,
+        dispatch: str,
+        job_name: str,
+        config_path: Path,
+        *,
+        survey_task_path: str | None,
+        chat_task_path: str | None,
+        os_app_submission_profile: str | None,
+        chat_domain: str | None,
+        chat_application_id: str | None,
+        chat_application_context: str | None,
+        chat_max_turns: int | None,
+        trial_profile: str | None,
+    ) -> None:
+        del os_app_submission_profile
+        from backend.service.cohort_shard_planner import shard_concurrency_from_env
+
+        with self._guard:
+            record = self._launches[job_name]
+            record.status = "running"
+
+        env = self._build_harbor_launch_env(
+            survey_task_path=survey_task_path,
+            chat_task_path=chat_task_path,
+            trial_profile=trial_profile,
+            chat_domain=chat_domain,
+            chat_application_id=chat_application_id,
+            chat_application_context=chat_application_context,
+            chat_max_turns=chat_max_turns,
+            for_remote=True,
+            job_name=job_name,
+        )
+        work = self._cloud_shard_work_items(job_name, config_path)
+        errors: list[str] = []
+        codes: list[int] = []
+
+        def _run_one(item: tuple[str, Path]) -> tuple[int, str | None]:
+            shard_key, shard_path = item
+            if dispatch == "gke_workers":
+                return self._invoke_gke_host(job_name, shard_path, shard_key, env)
+            if dispatch != "modal_jobs":
+                raise ValueError("unknown cloud host dispatch {!r}".format(dispatch))
+            return self._invoke_modal_host(job_name, shard_path, shard_key, env)
+
+        try:
+            runner = self._cloud_host_runner(dispatch)
+            if self._runner_supports_spawn(runner):
+                codes, errors = self._spawn_and_wait_cloud_shards(
+                    dispatch, job_name, work, env, runner
+                )
+            elif len(work) == 1:
+                code, error = _run_one(work[0])
+                codes.append(code)
+                if error:
+                    errors.append(error)
+            else:
+                workers = min(shard_concurrency_from_env(), len(work))
+                with ThreadPoolExecutor(max_workers=workers) as pool:
+                    futures = [pool.submit(_run_one, item) for item in work]
+                    for future in as_completed(futures):
+                        code, error = future.result()
+                        codes.append(code)
+                        if error:
+                            errors.append(error)
+            exit_code = 0 if codes and all(code == 0 for code in codes) else 1
+            error = "; ".join(errors) if errors else None
+            if exit_code != 0 and not error:
+                error = "cloud host shards exited with codes {}".format(codes)
+            status = "completed" if exit_code == 0 else "failed"
+        except Exception as exc:  # noqa: BLE001
+            status = "failed"
+            error = str(exc)
+            exit_code = 1
+
+        with self._guard:
+            record = self._launches[job_name]
+            record.status = status
+            record.exit_code = exit_code
+            record.error = error
+            record.finished_at = _utc_now()
+        try:
+            from backend.service.modal_host_job import load_cloud_run, save_cloud_run
+
+            job_dir = self.jobs_dir / job_name
+            cloud_state = load_cloud_run(job_dir)
+            if cloud_state:
+                cloud_state["status"] = status
+                save_cloud_run(job_dir, cloud_state)
+        except Exception:
+            pass
+        self._maybe_rollup_job_result(job_name)
+        self._maybe_run_host_verifier(job_name)
+        self._maybe_generate_post_run_feedback(job_name)
+        self._maybe_schedule_reporting(job_name, self.jobs_dir / job_name)
+
+    def resume_detached_cloud_runs(self) -> list[str]:
+        """Reattach Modal/GKE shards that kept running after this API process died."""
+        from backend.service.modal_host_job import load_cloud_run
+
+        resumed: list[str] = []
+        for job_name in self._list_job_names():
+            data = load_cloud_run(self.jobs_dir / job_name)
+            if not data or data.get("status") != "running":
+                continue
+            with self._guard:
+                existing = self._launches.get(job_name)
+                if existing is not None and existing.status in {"running", "queued"}:
+                    continue
+                meta = self._read_json(self._launch_meta_path(job_name)) or {}
+                self._launches[job_name] = HarborLaunchRecord(
+                    job_name=job_name,
+                    status="running",
+                    config_path=str(meta.get("configPath") or "") or None,
+                    started_at=str(meta.get("startedAt") or _utc_now()),
+                    execution_plane=str(meta.get("executionPlane") or "harbor"),
+                    compute_family=str(meta.get("computeFamily") or "modal"),
+                    compute_environment=str(meta.get("computeEnvironment") or "host"),
+                    compute_dispatch=str(
+                        data.get("dispatch") or meta.get("computeDispatch") or "modal_jobs"
+                    ),
+                )
+                extra = meta.get("extraLaunchEnv")
+                if isinstance(extra, dict):
+                    self._extra_launch_env[job_name] = {
+                        str(key): str(value) for key, value in extra.items()
+                    }
+            config_rel = str(meta.get("configPath") or "")
+            config_path = self.repo_root / config_rel if config_rel else (
+                self.generated_configs_dir / "{}.yaml".format(job_name)
+            )
+            self._executor.submit(self._resume_cloud_host_job, job_name, config_path, meta)
+            resumed.append(job_name)
+        return resumed
+
+    def _resume_cloud_host_job(
+        self,
+        job_name: str,
+        config_path: Path,
+        meta: dict[str, Any],
+    ) -> None:
+        dispatch = str(meta.get("computeDispatch") or "modal_jobs")
+        if not config_path.is_file():
+            config_path = self.generated_configs_dir / "{}.yaml".format(job_name)
+        self._dispatch_cloud_host(
+            dispatch,
+            job_name,
+            config_path,
+            survey_task_path=meta.get("surveyTaskPath"),
+            chat_task_path=meta.get("chatTaskPath"),
+            os_app_submission_profile=meta.get("osAppSubmissionProfile"),
+            chat_domain=meta.get("chatDomain"),
+            chat_application_id=meta.get("chatApplicationId"),
+            chat_application_context=meta.get("chatApplicationContext"),
+            chat_max_turns=meta.get("chatMaxTurns"),
+            trial_profile=meta.get("trialProfile"),
+        )
+
+    def _cloud_host_runner(self, dispatch: str) -> Any:
+        if dispatch == "gke_workers":
+            from backend.service.gke_host_job import default_gke_host_job_runner
+
+            return self.gke_host_job_runner or default_gke_host_job_runner()
+        from backend.service.modal_host_job import default_modal_host_job_runner
+
+        return self.modal_host_job_runner or default_modal_host_job_runner()
+
+    def _runner_supports_spawn(self, runner: Any) -> bool:
+        return callable(getattr(runner, "spawn", None)) and callable(
+            getattr(runner, "wait", None)
+        )
+
+    def _cloud_host_request(
+        self,
+        dispatch: str,
+        job_name: str,
+        config_path: Path,
+        shard_key: str,
+        env: dict[str, str],
+    ) -> Any:
+        from backend.service.modal_host_job import (
+            HARBOR_MODULE_COMMAND,
+            collect_orchestrator_secret_env,
+        )
+
+        if dispatch == "gke_workers":
+            from backend.service.gke_host_job import GkeHostJobRequest
+
+            return GkeHostJobRequest(
+                job_name=job_name,
+                config_yaml=config_path.read_text(encoding="utf-8"),
+                env=filter_remote_harbor_payload_env(env),
+                secret_env=collect_orchestrator_secret_env(),
+                shard_key=shard_key,
+                live_jobs_dir=str(self.jobs_dir.resolve()),
+            )
+        from backend.service.modal_host_job import ModalHostJobRequest
+
+        return ModalHostJobRequest(
+            job_name=job_name,
+            config_yaml=config_path.read_text(encoding="utf-8"),
+            repo_root=str(self.repo_root.resolve()),
+            jobs_dir="jobs",
+            env=filter_remote_harbor_payload_env(env),
+            harbor_command=HARBOR_MODULE_COMMAND,
+            secret_env=collect_orchestrator_secret_env(),
+            shard_key=shard_key,
+            live_jobs_dir=str(self.jobs_dir.resolve()),
+        )
+
+    def _spawn_and_wait_cloud_shards(
+        self,
+        dispatch: str,
+        job_name: str,
+        work: list[tuple[str, Path]],
+        env: dict[str, str],
+        runner: Any,
+    ) -> tuple[list[int], list[str]]:
+        from backend.service.modal_host_job import load_cloud_run, save_cloud_run
+
+        job_dir = self.jobs_dir / job_name
+        state = load_cloud_run(job_dir) or {
+            "jobName": job_name,
+            "dispatch": dispatch,
+            "status": "running",
+            "shards": [],
+        }
+        state["dispatch"] = dispatch
+        state["status"] = "running"
+        by_key: dict[str, dict[str, Any]] = {}
+        for row in state.get("shards") or []:
+            if isinstance(row, dict) and row.get("key"):
+                by_key[str(row["key"])] = row
+        handles: dict[str, tuple[Any, str, Any]] = {}
+        for shard_key, shard_path in work:
+            request = self._cloud_host_request(dispatch, job_name, shard_path, shard_key, env)
+            row = by_key.get(shard_key) or {"key": shard_key}
+            call_id = str(row.get("callId") or "").strip()
+            call = None
+            if not call_id:
+                call_id, call = runner.spawn(request)
+                row["callId"] = call_id
+                row["state"] = "spawned"
+                by_key[shard_key] = row
+                state["shards"] = list(by_key.values())
+                save_cloud_run(job_dir, state)
+            handles[shard_key] = (call, call_id, request)
+
+        def _wait_one(shard_key: str) -> tuple[int, str | None]:
+            call, call_id, request = handles[shard_key]
+            try:
+                result = runner.wait(request, call=call, call_id=call_id)
+                if dispatch == "gke_workers":
+                    from backend.service.gke_host_job import materialize_gke_artifacts
+
+                    materialize_gke_artifacts(
+                        result, jobs_dir=self.jobs_dir, job_name=job_name
+                    )
+                else:
+                    from backend.service.modal_host_job import materialize_modal_artifacts
+
+                    materialize_modal_artifacts(
+                        result, jobs_dir=self.jobs_dir, job_name=job_name
+                    )
+                exit_code = int(result.exit_code)
+                error = result.error
+                if exit_code != 0 and not error:
+                    error = "cloud host shard {} exited with code {}".format(
+                        shard_key, exit_code
+                    )
+                return exit_code, error
+            except Exception as exc:  # noqa: BLE001
+                return 1, str(exc)
+
+        codes: list[int] = []
+        errors: list[str] = []
+        workers = max(1, len(handles))
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            futures = {pool.submit(_wait_one, key): key for key in handles}
+            for future in as_completed(futures):
+                key = futures[future]
+                code, error = future.result()
+                codes.append(code)
+                if error:
+                    errors.append(error)
+                row = by_key.get(key) or {"key": key}
+                row["state"] = "completed" if code == 0 else "failed"
+                by_key[key] = row
+                state["shards"] = list(by_key.values())
+                save_cloud_run(job_dir, state)
+        return codes, errors
+
+    def _invoke_modal_host(
+        self,
+        job_name: str,
+        config_path: Path,
+        shard_key: str,
+        env: dict[str, str],
+    ) -> tuple[int, str | None]:
+        from backend.service.modal_host_job import (
+            HARBOR_MODULE_COMMAND,
+            ModalHostJobError,
+            ModalHostJobRequest,
+            collect_orchestrator_secret_env,
+            default_modal_host_job_runner,
+            materialize_modal_artifacts,
+        )
+
+        request = ModalHostJobRequest(
+            job_name=job_name,
+            config_yaml=config_path.read_text(encoding="utf-8"),
+            repo_root=str(self.repo_root.resolve()),
+            jobs_dir="jobs",
+            env=filter_remote_harbor_payload_env(env),
+            harbor_command=HARBOR_MODULE_COMMAND,
+            secret_env=collect_orchestrator_secret_env(),
+            shard_key=shard_key,
+            live_jobs_dir=str(self.jobs_dir.resolve()),
+        )
+        try:
+            runner = self.modal_host_job_runner or default_modal_host_job_runner()
+            result = runner.run(request)
+            materialize_modal_artifacts(
+                result,
+                jobs_dir=self.jobs_dir,
+                job_name=job_name,
+            )
+            exit_code = int(result.exit_code)
+            error = result.error
+            if exit_code != 0 and not error:
+                error = "Modal Jobs exited with code {}".format(exit_code)
+            return exit_code, error
+        except ModalHostJobError as exc:
+            return 1, str(exc)
+
+    def _invoke_gke_host(
+        self,
+        job_name: str,
+        config_path: Path,
+        shard_key: str,
+        env: dict[str, str],
+    ) -> tuple[int, str | None]:
+        from backend.service.gke_host_job import (
+            GkeHostJobError,
+            GkeHostJobRequest,
+            default_gke_host_job_runner,
+            materialize_gke_artifacts,
+        )
+        from backend.service.modal_host_job import collect_orchestrator_secret_env
+
+        request = GkeHostJobRequest(
+            job_name=job_name,
+            config_yaml=config_path.read_text(encoding="utf-8"),
+            env=filter_remote_harbor_payload_env(env),
+            secret_env=collect_orchestrator_secret_env(),
+            shard_key=shard_key,
+            live_jobs_dir=str(self.jobs_dir.resolve()),
+        )
+        try:
+            runner = self.gke_host_job_runner or default_gke_host_job_runner()
+            result = runner.run(request)
+            materialize_gke_artifacts(
+                result,
+                jobs_dir=self.jobs_dir,
+                job_name=job_name,
+            )
+            exit_code = int(result.exit_code)
+            error = result.error
+            if exit_code != 0 and not error:
+                error = "GKE host workers exited with code {}".format(exit_code)
+            return exit_code, error
+        except GkeHostJobError as exc:
+            return 1, str(exc)
 
     def _dispatch_remote(
         self,
@@ -1561,23 +2352,29 @@ class HarborJobService:
             chat_application_context=chat_application_context,
             chat_max_turns=chat_max_turns,
             for_remote=True,
+            job_name=job_name,
         )
-        payload = {
-            "jobName": job_name,
-            "configYaml": config_path.read_text(encoding="utf-8"),
-            "repoRoot": str(self.repo_root.resolve()),
-            "jobsDir": _rel_path(self.jobs_dir, self.repo_root),
-            "env": filter_remote_harbor_payload_env(env),
-        }
+        work = self._cloud_shard_work_items(job_name, config_path)
         try:
             client = self._remote_client()
-            run = client.create_run(task_type="harbor_job", payload=payload)
-            with self._guard:
-                record = self._launches[job_name]
-                record.remote_run_id = run.id
-            client.wait_for_run(run.id)
+            last_error: str | None = None
+            for index, (shard_key, shard_path) in enumerate(work):
+                payload = {
+                    "jobName": job_name,
+                    "configYaml": shard_path.read_text(encoding="utf-8"),
+                    "repoRoot": str(self.repo_root.resolve()),
+                    "jobsDir": _rel_path(self.jobs_dir, self.repo_root),
+                    "env": filter_remote_harbor_payload_env(env),
+                }
+                run = client.create_run(task_type="harbor_job", payload=payload)
+                if index == 0:
+                    with self._guard:
+                        record = self._launches[job_name]
+                        record.remote_run_id = run.id
+                client.wait_for_run(run.id)
+                self._merge_harbor_shard_tree(job_name, shard_key)
             status = "completed"
-            error = None
+            error = last_error
             exit_code = 0
         except Exception as exc:  # noqa: BLE001
             status = "failed"
@@ -1591,6 +2388,7 @@ class HarborJobService:
             record.error = error
             record.finished_at = _utc_now()
         # Remote trials land locally after wait; job-end scoring is the primary path.
+        self._maybe_rollup_job_result(job_name)
         self._maybe_run_host_verifier(job_name)
         self._maybe_generate_post_run_feedback(job_name)
         self._maybe_schedule_reporting(job_name, self.jobs_dir / job_name)
@@ -1701,9 +2499,18 @@ class HarborJobService:
         *,
         after: int = 0,
     ) -> dict[str, Any]:
-        trial_dir = self.jobs_dir / job_name / trial_name
+        job_dir = self.jobs_dir / job_name
+        if not job_dir.is_dir():
+            with self._guard:
+                known = job_name in self._launches
+            if not known:
+                raise ValueError("Job not found: {}".format(job_name))
+            return {"events": [], "offset": after}
+        trial_dir = job_dir / trial_name
         if not trial_dir.is_dir():
-            raise ValueError("Trial not found: {}/{}".format(job_name, trial_name))
+            # Overlay-only / not-yet-flushed trials (Modal, GKE) are listed on
+            # /live before the tree exists. Empty is the pollable not-ready state.
+            return {"events": [], "offset": after}
         from playground.harbor.trial_events import (
             EVENTS_FILENAME,
             read_events_after,
@@ -1716,9 +2523,15 @@ class HarborJobService:
         from backend.service.harbor_trial_debrief import find_trial_logs_dir
         from backend.service.harbor_web_trace import read_harbor_web_trace
 
-        trial_dir = self.jobs_dir / job_name / trial_name
+        job_dir = self.jobs_dir / job_name
+        trial_dir = job_dir / trial_name
         if not trial_dir.is_dir():
-            raise ValueError("Trial not found: {}/{}".format(job_name, trial_name))
+            if not job_dir.is_dir():
+                with self._guard:
+                    known = job_name in self._launches
+                if not known:
+                    raise ValueError("Job not found: {}".format(job_name))
+            return {"trace": {"events": [], "raw": {}}}
         trace = read_harbor_web_trace(
             find_trial_logs_dir(trial_dir),
             job_name=job_name,
@@ -1756,6 +2569,13 @@ class HarborJobService:
         job = self.get_job(job_name)
         if job is None:
             raise ValueError("Job not found: {}".format(job_name))
+        overlay: dict[str, str] = {}
+        try:
+            from backend.service.modal_host_job import read_live_overlay
+
+            overlay = read_live_overlay(self.jobs_dir / job_name)
+        except Exception:
+            overlay = {}
         live_trials: list[dict[str, Any]] = []
         for trial in job.get("trials", []):
             if not isinstance(trial, dict):
@@ -1768,18 +2588,36 @@ class HarborJobService:
             instruction_path = trial_dir / "instruction.md"
             phase = _trial_live_phase(trial_dir) if trial_dir.is_dir() else None
             completed = bool(trial.get("completed"))
+            succeeded = trial.get("succeeded")
+            error = trial.get("error")
+            overlay_state = overlay.get(trial_name)
+            if overlay_state == "error":
+                completed = True
+                succeeded = False
+                if not error:
+                    error = "failed"
+            elif overlay_state == "done":
+                completed = True
+                if not error:
+                    succeeded = True
             vnc_url = _read_vnc_url(trial_dir) if trial_dir.is_dir() else None
             sandbox_id = _read_sandbox_id(trial_dir) if trial_dir.is_dir() else None
+            stage = _resolve_trial_stage(trial_dir, phase=phase, completed=completed)
+            if not completed:
+                if overlay_state == "running" and (not stage or stage == "queued"):
+                    stage = "agent_running"
+                elif overlay_state == "pending":
+                    stage = "queued"
             live_trials.append(
                 {
                     "trialName": trial_name,
                     "personaId": persona_meta.get("persona_id"),
                     "personaName": persona_meta.get("display_name"),
                     "completed": completed,
-                    "succeeded": trial.get("succeeded"),
-                    "error": trial.get("error"),
+                    "succeeded": succeeded,
+                    "error": error,
                     "phase": phase,
-                    "stage": _resolve_trial_stage(trial_dir, phase=phase, completed=completed),
+                    "stage": stage,
                     "hasInstruction": instruction_path.is_file(),
                     "vncUrl": vnc_url,
                     "sandboxId": sandbox_id,
@@ -1805,14 +2643,25 @@ class HarborJobService:
         trial_dir = job_dir / trial_name
         result_path = trial_dir / "result.json"
         if result_path.is_file():
-            error = _trial_result_error(self._read_json(result_path))
+            error = _trial_result_error(self._read_json(result_path), trial_dir)
             return STATUS_CODE_ERROR if error else STATUS_CODE_DONE
+        overlay_code = None
+        try:
+            from backend.service.modal_host_job import overlay_status_code, read_live_overlay
+
+            overlay_code = overlay_status_code(read_live_overlay(job_dir).get(trial_name))
+        except Exception:
+            overlay_code = None
+        if overlay_code in {STATUS_CODE_DONE, STATUS_CODE_ERROR}:
+            return overlay_code
         if (
             (trial_dir / "config.json").is_file()
             or (trial_dir / "trial.log").is_file()
             or (trial_dir / "agent").is_dir()
         ):
             return STATUS_CODE_RUNNING
+        if overlay_code is not None:
+            return overlay_code
         return STATUS_CODE_PENDING
 
     def _refresh_status_state(self, job_name: str) -> _JobStatusState:
@@ -1846,7 +2695,8 @@ class HarborJobService:
         # Re-check only trials that have not finalized yet.
         for index, name in enumerate(state.trial_names):
             if state.codes[index] >= STATUS_CODE_DONE:
-                continue
+                if (job_dir / name / "result.json").is_file():
+                    continue
             new_code = self._coarse_trial_code(job_dir, name)
             if new_code != state.codes[index]:
                 state.codes[index] = new_code
@@ -1921,6 +2771,93 @@ class HarborJobService:
             # Retry is a convenience; never let metadata persistence break a launch.
             pass
 
+    def _maybe_rollup_job_result(self, job_name: str) -> None:
+        meta = self._read_json(self._launch_meta_path(job_name)) or {}
+        dispatch = str(meta.get("computeDispatch") or "")
+        shards = meta.get("shards") if isinstance(meta.get("shards"), list) else []
+        if dispatch not in {"modal_jobs", "gke_workers"} and not shards:
+            return
+        from backend.service.job_result_rollup import synthesize_job_result
+
+        with self._guard:
+            record = self._launches.get(job_name)
+        started = record.started_at if record is not None else None
+        try:
+            synthesize_job_result(
+                self.jobs_dir / job_name,
+                job_config=meta.get("jobConfig") if isinstance(meta.get("jobConfig"), dict) else None,
+                started_at=started,
+                finished=True,
+            )
+        except Exception:  # noqa: BLE001
+            return
+        if meta.get("retryShards"):
+            meta.pop("retryShards", None)
+            self._persist_launch_meta(job_name, meta)
+
+    def _failed_trial_persona_id(self, trial_dir: Path) -> str:
+        from backend.service.job_result_rollup import trial_persona_id
+
+        return trial_persona_id(trial_dir)
+
+    def _retry_shards_for_failures(
+        self,
+        meta: dict[str, Any],
+        failed_persona_ids: set[str],
+        *,
+        job_name: str,
+    ) -> list[dict[str, Any]]:
+        shards = meta.get("shards") if isinstance(meta.get("shards"), list) else []
+        if not shards or not failed_persona_ids:
+            return []
+        job_config = meta.get("jobConfig") if isinstance(meta.get("jobConfig"), dict) else {}
+        agents = [row for row in (job_config.get("agents") or []) if isinstance(row, dict)]
+        retry_rows: list[dict[str, Any]] = []
+        for shard in shards:
+            if not isinstance(shard, dict):
+                continue
+            shard_ids = {
+                str(pid).strip()
+                for pid in (shard.get("personaIds") or [])
+                if str(pid).strip()
+            }
+            overlap = shard_ids & failed_persona_ids if shard_ids else set(failed_persona_ids)
+            if shard_ids and not overlap:
+                continue
+            retry_cfg = dict(job_config)
+            if agents:
+                from backend.service.cohort_shard_planner import _agent_persona_id
+
+                retry_cfg["agents"] = [
+                    dict(agent)
+                    for index, agent in enumerate(agents)
+                    if _agent_persona_id(agent, index) in overlap
+                ]
+                if not retry_cfg["agents"]:
+                    continue
+            if shard.get("kind") == "harbor":
+                key = str(shard.get("key") or "s0")
+                retry_cfg["job_name"] = job_name
+                retry_cfg["jobs_dir"] = _rel_path(
+                    self.jobs_dir / job_name / "_generated" / "work" / key,
+                    self.repo_root,
+                )
+            index = int(shard.get("index") or 0)
+            retry_path = self.generated_configs_dir / "{}.shard-{:02d}.retry.yaml".format(
+                job_name,
+                index,
+            )
+            retry_path.parent.mkdir(parents=True, exist_ok=True)
+            retry_path.write_text(yaml.safe_dump(retry_cfg, sort_keys=False), encoding="utf-8")
+            retry_rows.append(
+                {
+                    **shard,
+                    "configPath": _rel_path(retry_path, self.repo_root),
+                    "personaIds": sorted(overlap),
+                }
+            )
+        return retry_rows
+
     def failed_trial_count(self, job_name: str) -> int:
         job_dir = self.jobs_dir / job_name
         if not job_dir.is_dir():
@@ -1928,7 +2865,7 @@ class HarborJobService:
         count = 0
         for trial_name in self._list_trial_names(job_name):
             result = self._read_json(job_dir / trial_name / "result.json")
-            if _trial_result_error(result) is not None:
+            if _trial_result_error(result, job_dir / trial_name) is not None:
                 count += 1
         return count
 
@@ -1953,7 +2890,10 @@ class HarborJobService:
         failed_dirs = [
             job_dir / trial_name
             for trial_name in self._list_trial_names(job_name)
-            if _trial_result_error(self._read_json(job_dir / trial_name / "result.json"))
+            if _trial_result_error(
+                self._read_json(job_dir / trial_name / "result.json"),
+                job_dir / trial_name,
+            )
             is not None
         ]
         if not failed_dirs:
@@ -1971,6 +2911,18 @@ class HarborJobService:
                 "Cannot retry: generated config is unavailable for {}".format(job_name)
             )
 
+        failed_persona_ids = {
+            pid
+            for trial_dir in failed_dirs
+            if (pid := self._failed_trial_persona_id(trial_dir))
+        }
+        retry_shards = self._retry_shards_for_failures(
+            meta, failed_persona_ids, job_name=job_name
+        )
+        if retry_shards:
+            meta["retryShards"] = retry_shards
+            self._persist_launch_meta(job_name, meta)
+
         for trial_dir in failed_dirs:
             shutil.rmtree(trial_dir, ignore_errors=True)
         # Reset job-level completion + reporting so status and reporting recompute.
@@ -1980,6 +2932,8 @@ class HarborJobService:
             self._status_states.pop(job_name, None)
 
         plane = str(meta.get("executionPlane") or "harbor")
+        compute_dispatch = meta.get("computeDispatch")
+        retry_extra_env = {str(k): str(v) for k, v in (meta.get("extraLaunchEnv") or {}).items()}
         with self._guard:
             self._launches[job_name] = HarborLaunchRecord(
                 job_name=job_name,
@@ -1987,7 +2941,16 @@ class HarborJobService:
                 config_path=config_rel or None,
                 started_at=_utc_now(),
                 execution_plane=plane,
+                compute_family=str(meta.get("computeFamily") or "local"),
+                compute_environment=(
+                    str(meta["computeEnvironment"])
+                    if meta.get("computeEnvironment")
+                    else None
+                ),
+                compute_dispatch=str(compute_dispatch) if compute_dispatch else None,
             )
+            if retry_extra_env:
+                self._extra_launch_env[job_name] = retry_extra_env
 
         if meta.get("useLocalDistributed"):
             self._executor.submit(
@@ -2015,7 +2978,11 @@ class HarborJobService:
                 meta.get("chatMaxTurns"),
                 meta.get("trialProfile"),
             )
-            if plane == "remote":
+            if compute_dispatch == "modal_jobs":
+                self._executor.submit(self._dispatch_modal_host, *dispatch_kwargs)
+            elif compute_dispatch == "gke_workers":
+                self._executor.submit(self._dispatch_gke_host, *dispatch_kwargs)
+            elif plane == "remote":
                 self._executor.submit(self._dispatch_remote, *dispatch_kwargs)
             else:
                 self._executor.submit(self._run_harbor, *dispatch_kwargs)
@@ -2255,22 +3222,37 @@ class HarborJobService:
         raise FileNotFoundError("instruction not found for trial {}/{}".format(job_name, trial_name))
 
     def trial_live_screenshot(self, job_name: str, trial_name: str) -> bytes:
-        """Proxy the live screenshot from use.computer for an active trial."""
-        import httpx
-
+        """Live frame: use.computer sandbox, else latest flushed trial screenshot."""
         trial_dir = self.jobs_dir / job_name / trial_name
-        sandbox_id = _read_sandbox_id(trial_dir)
-        if not sandbox_id:
-            raise FileNotFoundError("no active sandbox for this trial")
-        api_key = (os.environ.get("USE_COMPUTER_API_KEY") or "").strip()
-        if not api_key:
+        sandbox_id = _read_sandbox_id(trial_dir) if trial_dir.is_dir() else None
+        if sandbox_id:
+            api_key = (os.environ.get("USE_COMPUTER_API_KEY") or "").strip()
+            if api_key:
+                import httpx
+
+                base_url = os.environ.get(
+                    "USE_COMPUTER_BASE_URL", "https://api.use.computer"
+                ).rstrip("/")
+                url = "{}/v1/sandboxes/{}/screenshot".format(base_url, sandbox_id)
+                try:
+                    with httpx.Client(timeout=10.0) as client:
+                        resp = client.get(
+                            url, headers={"Authorization": "Bearer {}".format(api_key)}
+                        )
+                        resp.raise_for_status()
+                        return resp.content
+                except Exception:
+                    pass
+            elif not trial_dir.is_dir():
+                raise RuntimeError("USE_COMPUTER_API_KEY not configured")
+        from backend.service.harbor_web_trace import latest_trial_screenshot_bytes
+
+        blob = latest_trial_screenshot_bytes(trial_dir) if trial_dir.is_dir() else None
+        if blob:
+            return blob
+        if sandbox_id and not (os.environ.get("USE_COMPUTER_API_KEY") or "").strip():
             raise RuntimeError("USE_COMPUTER_API_KEY not configured")
-        base_url = os.environ.get("USE_COMPUTER_BASE_URL", "https://api.use.computer").rstrip("/")
-        url = "{}/v1/sandboxes/{}/screenshot".format(base_url, sandbox_id)
-        with httpx.Client(timeout=10.0) as client:
-            resp = client.get(url, headers={"Authorization": "Bearer {}".format(api_key)})
-            resp.raise_for_status()
-            return resp.content
+        raise FileNotFoundError("no live screenshot for this trial")
 
     def shutdown(self) -> None:
         self._executor.shutdown(wait=False, cancel_futures=True)
@@ -2287,6 +3269,9 @@ def _launch_view(record: HarborLaunchRecord | None) -> dict[str, Any] | None:
         "finishedAt": record.finished_at,
         "exitCode": record.exit_code,
         "executionPlane": record.execution_plane,
+        "computeFamily": record.compute_family,
+        "computeEnvironment": record.compute_environment,
+        "computeDispatch": record.compute_dispatch,
         "remoteRunId": record.remote_run_id,
     }
 

--- a/application/playground/backend/service/harbor_web_trace.py
+++ b/application/playground/backend/service/harbor_web_trace.py
@@ -19,6 +19,23 @@ def _is_safe_relative_path(path: str) -> bool:
     return rel.suffix.lower() in _ALLOWED_SUFFIXES
 
 
+def _rel_screenshot_path(path: str) -> str | None:
+    raw = path.strip().replace("\\", "/")
+    if raw.startswith("file://"):
+        raw = raw[7:]
+    if _is_safe_relative_path(raw):
+        return raw
+    parts = Path(raw).parts
+    if "images" in parts:
+        rel = "/".join(parts[parts.index("images") :])
+        if _is_safe_relative_path(rel):
+            return rel
+    name = Path(raw).name
+    if name and _is_safe_relative_path(name):
+        return name
+    return None
+
+
 def screenshot_file_from_step(step: dict[str, Any]) -> str | None:
     """Return a logs-dir-relative screenshot path for one ATIF trajectory step."""
     observation = step.get("observation")
@@ -38,8 +55,10 @@ def screenshot_file_from_step(step: dict[str, Any]) -> str | None:
                     if not isinstance(source, dict):
                         continue
                     path = source.get("path")
-                    if isinstance(path, str) and _is_safe_relative_path(path.strip()):
-                        return path.strip()
+                    if isinstance(path, str):
+                        rel = _rel_screenshot_path(path)
+                        if rel:
+                            return rel
 
     message = step.get("message")
     if isinstance(message, list):
@@ -50,8 +69,10 @@ def screenshot_file_from_step(step: dict[str, Any]) -> str | None:
             if not isinstance(source, dict):
                 continue
             path = source.get("path")
-            if isinstance(path, str) and _is_safe_relative_path(path.strip()):
-                return path.strip()
+            if isinstance(path, str):
+                rel = _rel_screenshot_path(path)
+                if rel:
+                    return rel
 
     return None
 
@@ -106,6 +127,30 @@ def resolve_trial_screenshot_path(logs_dir: Path, rel_path: str) -> Path:
     if not path.is_file():
         raise FileNotFoundError(rel_path)
     return path
+
+
+def latest_trial_screenshot_bytes(trial_dir: Path) -> bytes | None:
+    """Newest image under the trial logs tree (Harbor modal/gke flush or docker)."""
+    from backend.service.harbor_trial_debrief import find_trial_logs_dir
+
+    logs_dir = find_trial_logs_dir(trial_dir)
+    if logs_dir is None or not logs_dir.is_dir():
+        return None
+    newest: Path | None = None
+    newest_mtime = -1.0
+    for path in logs_dir.rglob("*"):
+        if not path.is_file() or path.suffix.lower() not in _ALLOWED_SUFFIXES:
+            continue
+        try:
+            mtime = path.stat().st_mtime
+        except OSError:
+            continue
+        if mtime >= newest_mtime:
+            newest = path
+            newest_mtime = mtime
+    if newest is None:
+        return None
+    return newest.read_bytes()
 
 
 def read_harbor_web_trace(

--- a/application/playground/backend/service/job_result_rollup.py
+++ b/application/playground/backend/service/job_result_rollup.py
@@ -1,0 +1,111 @@
+"""Write one Harbor-compatible ``jobs/<job>/result.json`` after shard fan-out.
+
+Does not embed per-trial results (that payload does not scale). Counts come
+from trial directories already merged into the canonical job tree.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from backend.service.cohort_shard_planner import _agent_persona_id
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def expected_trial_count(job_config: dict[str, Any] | None) -> int:
+    if not isinstance(job_config, dict):
+        return 0
+    agents = [row for row in (job_config.get("agents") or []) if isinstance(row, dict)]
+    tasks = [row for row in (job_config.get("tasks") or []) if isinstance(row, dict)]
+    attempts = max(1, int(job_config.get("n_attempts") or 1))
+    return max(len(agents), 1) * max(len(tasks), 1) * attempts if agents else 0
+
+
+def trial_persona_id(trial_dir: Path) -> str:
+    meta_path = trial_dir / "persona_meta.json"
+    if meta_path.is_file():
+        try:
+            payload = json.loads(meta_path.read_text(encoding="utf-8"))
+        except Exception:  # noqa: BLE001
+            payload = None
+        if isinstance(payload, dict):
+            pid = str(payload.get("persona_id") or payload.get("personaId") or "").strip()
+            if pid:
+                return pid
+    config_path = trial_dir / "config.json"
+    if config_path.is_file():
+        try:
+            payload = json.loads(config_path.read_text(encoding="utf-8"))
+        except Exception:  # noqa: BLE001
+            payload = None
+        if isinstance(payload, dict):
+            agent = payload.get("agent") if isinstance(payload.get("agent"), dict) else {}
+            return _agent_persona_id(agent, 0)
+    return ""
+
+
+def synthesize_job_result(
+    job_dir: Path,
+    *,
+    job_config: dict[str, Any] | None = None,
+    started_at: str | None = None,
+    finished: bool = True,
+    job_id: str | None = None,
+) -> Path:
+    """Write a compact job-level ``result.json`` from merged trial dirs."""
+    job_dir.mkdir(parents=True, exist_ok=True)
+    trial_dirs = [
+        path
+        for path in sorted(job_dir.iterdir())
+        if path.is_dir() and not path.name.startswith("_")
+    ]
+    completed = 0
+    errored = 0
+    cancelled = 0
+    for trial_dir in trial_dirs:
+        result_path = trial_dir / "result.json"
+        if not result_path.is_file():
+            continue
+        try:
+            payload = json.loads(result_path.read_text(encoding="utf-8"))
+        except Exception:  # noqa: BLE001
+            continue
+        if not isinstance(payload, dict):
+            continue
+        completed += 1
+        exc = payload.get("exception_info")
+        if isinstance(exc, dict) and exc.get("exception_type"):
+            errored += 1
+            if exc.get("exception_type") == "CancelledError":
+                cancelled += 1
+    expected = expected_trial_count(job_config) or completed
+    if finished and expected > completed:
+        errored += expected - completed
+    running = 0 if finished else max(expected - completed, 0)
+    now = _utc_now()
+    result = {
+        "id": job_id or str(uuid.uuid4()),
+        "started_at": started_at or now,
+        "updated_at": now,
+        "finished_at": now if finished else None,
+        "n_total_trials": expected,
+        "stats": {
+            "n_completed_trials": completed,
+            "n_errored_trials": errored,
+            "n_running_trials": running,
+            "n_pending_trials": max(expected - completed - running, 0),
+            "n_cancelled_trials": cancelled,
+            "n_retries": 0,
+            "evals": {},
+        },
+    }
+    path = job_dir / "result.json"
+    path.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+    return path

--- a/application/playground/backend/service/modal_docker_prebuild.py
+++ b/application/playground/backend/service/modal_docker_prebuild.py
@@ -1,8 +1,8 @@
-"""Prebuild and cache Harbor Docker images for Modal docker workers.
+"""Prebuild and cache Harbor Docker images for Modal web/linux sandboxes.
 
 Harbor tags each trial ``hb__{task.short_name}``, so two Playwright tasks with
-the same Dockerfile still rebuild if the daemon is empty. Modal Functions also
-start with an empty Docker graph. Hash the environment context once, persist
+the same Dockerfile still rebuild if the daemon is empty. Each sandbox starts
+with an empty Docker graph. Hash the environment context once, persist
 ``docker save`` tarballs on a Volume, and retag ``hb__{short_name}`` so Harbor
 skips ``compose build``.
 """

--- a/application/playground/backend/service/modal_docker_prebuild.py
+++ b/application/playground/backend/service/modal_docker_prebuild.py
@@ -1,0 +1,370 @@
+"""Prebuild and cache Harbor Docker images for Modal docker workers.
+
+Harbor tags each trial ``hb__{task.short_name}``, so two Playwright tasks with
+the same Dockerfile still rebuild if the daemon is empty. Modal Functions also
+start with an empty Docker graph. Hash the environment context once, persist
+``docker save`` tarballs on a Volume, and retag ``hb__{short_name}`` so Harbor
+skips ``compose build``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import subprocess
+import tomllib
+from pathlib import Path
+from typing import Callable
+
+DOCKER_CACHE_ENV = "MATRIX_DOCKER_IMAGE_CACHE"
+DEFAULT_DOCKER_CACHE_DIR = "/modal-docker-images"
+PREBUILT_IMAGE_PREFIX = "matraix-prebuilt"
+_SKIP_HASH_PARTS = frozenset({".git", "__pycache__", ".pytest_cache", "node_modules"})
+
+
+class DockerPrebuildError(RuntimeError):
+    """Docker was required for a Modal web/linux job but was not usable."""
+
+
+def harbor_environment_type(config_yaml: str) -> str:
+    try:
+        import yaml
+    except ImportError:
+        return ""
+    loaded = yaml.safe_load(config_yaml)
+    if not isinstance(loaded, dict):
+        return ""
+    block = loaded.get("environment")
+    if not isinstance(block, dict):
+        return ""
+    return str(block.get("type") or "").strip().lower()
+
+
+def job_task_dir(config_yaml: str, *, repo_root: Path) -> Path | None:
+    try:
+        import yaml
+    except ImportError:
+        return None
+    loaded = yaml.safe_load(config_yaml)
+    if not isinstance(loaded, dict):
+        return None
+    tasks = loaded.get("tasks")
+    if not isinstance(tasks, list) or not tasks:
+        return None
+    first = tasks[0]
+    rel = ""
+    if isinstance(first, dict):
+        rel = str(first.get("path") or "").strip()
+    elif isinstance(first, str):
+        rel = first.strip()
+    if not rel:
+        return None
+    path = (repo_root / rel).resolve()
+    return path if path.is_dir() else None
+
+
+def docker_context_digest(environment_dir: Path) -> str:
+    """Stable hash of Dockerfile + context (shared images reuse one digest)."""
+    hasher = hashlib.sha256()
+    keep = _dockerignore_keep(environment_dir)
+    files = []
+    for path in sorted(environment_dir.rglob("*")):
+        if not path.is_file():
+            continue
+        if any(part in _SKIP_HASH_PARTS for part in path.parts):
+            continue
+        rel = path.relative_to(environment_dir).as_posix()
+        if keep is not None and rel not in keep:
+            continue
+        files.append(path)
+    if not files:
+        raise DockerPrebuildError(
+            "environment dir {} has no files to hash".format(environment_dir)
+        )
+    for path in files:
+        rel = path.relative_to(environment_dir).as_posix().encode("utf-8")
+        hasher.update(rel)
+        hasher.update(b"\0")
+        hasher.update(path.read_bytes())
+        hasher.update(b"\0")
+    return hasher.hexdigest()[:16]
+
+
+def _dockerignore_keep(environment_dir: Path) -> set[str] | None:
+    """If the ignore file is ``*`` plus ``!`` allow-rules, hash only those files."""
+    path = environment_dir / ".dockerignore"
+    if not path.is_file():
+        return None
+    lines = [
+        line.strip()
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+    if "*" not in lines:
+        return None
+    keep = {".dockerignore"}
+    for line in lines:
+        if line.startswith("!"):
+            keep.add(line[1:].lstrip("/"))
+    return keep
+
+
+def sanitize_docker_image_name(name: str) -> str:
+    cleaned = name.lower()
+    if not re.match(r"^[a-z0-9]", cleaned):
+        cleaned = "0" + cleaned
+    return re.sub(r"[^a-z0-9._-]", "-", cleaned)
+
+
+def harbor_main_image_name(short_name: str) -> str:
+    return sanitize_docker_image_name("hb__{}".format(short_name))
+
+
+def task_short_name(task_dir: Path) -> str:
+    config_path = task_dir / "task.toml"
+    name = task_dir.name
+    if config_path.is_file():
+        try:
+            loaded = tomllib.loads(config_path.read_text(encoding="utf-8"))
+        except (OSError, tomllib.TOMLDecodeError):
+            loaded = {}
+        task = loaded.get("task") if isinstance(loaded, dict) else None
+        raw = (task or {}).get("name") if isinstance(task, dict) else None
+        if isinstance(raw, str) and raw.strip():
+            name = raw.strip()
+    parts = name.split("/")
+    return parts[1] if len(parts) > 1 else parts[0]
+
+
+def prebuilt_image_tag(digest: str) -> str:
+    return "{}:{}".format(PREBUILT_IMAGE_PREFIX, digest)
+
+
+def docker_cache_dir() -> Path:
+    env = (os.environ.get(DOCKER_CACHE_ENV) or "").strip()
+    if env:
+        return Path(env)
+    default = Path(DEFAULT_DOCKER_CACHE_DIR)
+    if default.is_dir():
+        return default
+    return Path("/tmp/matraix-docker-images")
+
+
+def patch_task_toml_docker_image(toml_path: Path, image: str) -> None:
+    """Point Harbor at a prebuilt tag so ``should_use_prebuilt_docker_image`` is true."""
+    text = toml_path.read_text(encoding="utf-8") if toml_path.is_file() else ""
+    line = 'docker_image = "{}"'.format(image)
+    if re.search(r"^docker_image\s*=", text, flags=re.MULTILINE):
+        text = re.sub(
+            r"^docker_image\s*=\s*.*$",
+            line,
+            text,
+            count=1,
+            flags=re.MULTILINE,
+        )
+    elif re.search(r"^\[environment\]\s*$", text, flags=re.MULTILINE):
+        text = re.sub(
+            r"^\[environment\]\s*$",
+            "[environment]\n{}".format(line),
+            text,
+            count=1,
+            flags=re.MULTILINE,
+        )
+    else:
+        text = text.rstrip() + "\n\n[environment]\n{}\n".format(line)
+    toml_path.write_text(text, encoding="utf-8")
+
+
+def ensure_docker_daemon(
+    *,
+    runner: Callable[..., subprocess.CompletedProcess[bytes]] | None = None,
+) -> None:
+    run = runner or _run
+    if shutil_which("docker") is None and runner is None:
+        raise DockerPrebuildError(
+            "docker CLI is missing in the Modal worker image; "
+            "redeploy application/playground/backend/service/modal_host_app.py"
+        )
+    if _docker_info_ok(run):
+        return
+    dockerd = shutil_which("dockerd")
+    if dockerd is None and runner is None:
+        raise DockerPrebuildError(
+            "Docker daemon is not running and dockerd is not installed"
+        )
+    if dockerd is not None:
+        subprocess.Popen(  # noqa: S603
+            [
+                dockerd,
+                "--host=unix:///var/run/docker.sock",
+                "--iptables=false",
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    import time
+
+    for _ in range(30):
+        if _docker_info_ok(run):
+            return
+        time.sleep(1)
+    raise DockerPrebuildError("Docker daemon did not become ready")
+
+
+def prepare_docker_environment_for_job(
+    config_yaml: str,
+    *,
+    repo_root: Path,
+    cache_dir: Path | None = None,
+    docker: "DockerCli | None" = None,
+    start_daemon: bool = True,
+) -> str | None:
+    """Build or restore the task image. Returns the prebuilt tag, or None."""
+    if harbor_environment_type(config_yaml) != "docker":
+        return None
+    task_dir = job_task_dir(config_yaml, repo_root=repo_root)
+    if task_dir is None:
+        return None
+    from backend.service.task_environment import resolve_task_environment_dir
+
+    environment_dir = resolve_task_environment_dir(task_dir)
+    if not environment_dir.is_dir():
+        raise DockerPrebuildError(
+            "task {} has no environment directory".format(task_dir)
+        )
+    dockerfile = environment_dir / "Dockerfile"
+    if not dockerfile.is_file():
+        return None
+    if start_daemon:
+        ensure_docker_daemon()
+    cli = docker or DockerCli()
+    digest = docker_context_digest(environment_dir)
+    cache_tag = prebuilt_image_tag(digest)
+    harbor_tag = harbor_main_image_name(task_short_name(task_dir))
+    cache_root = Path(cache_dir) if cache_dir is not None else docker_cache_dir()
+    cache_root.mkdir(parents=True, exist_ok=True)
+    archive = cache_root / "{}.tar".format(digest)
+    lock_path = cache_root / "{}.lock".format(digest)
+    with _file_lock(lock_path):
+        if cli.image_exists(cache_tag):
+            if not cli.image_exists(harbor_tag):
+                cli.tag(cache_tag, harbor_tag)
+        elif archive.is_file() and archive.stat().st_size > 0:
+            cli.load(archive)
+            if not cli.image_exists(cache_tag):
+                raise DockerPrebuildError(
+                    "docker load of {} did not produce {}".format(archive, cache_tag)
+                )
+            cli.tag(cache_tag, harbor_tag)
+        else:
+            cli.build(environment_dir, cache_tag)
+            cli.tag(cache_tag, harbor_tag)
+            cli.save(cache_tag, archive)
+    toml_path = task_dir / "task.toml"
+    if toml_path.is_file():
+        patch_task_toml_docker_image(toml_path, cache_tag)
+    return cache_tag
+
+
+class DockerCli:
+    """Thin wrapper so tests can stub Harbor image cache operations."""
+
+    def image_exists(self, tag: str) -> bool:
+        completed = _run(
+            ["docker", "image", "inspect", tag],
+            check=False,
+        )
+        return completed.returncode == 0
+
+    def build(self, context: Path, tag: str) -> None:
+        completed = _run(
+            ["docker", "build", "-t", tag, str(context)],
+            check=False,
+        )
+        if completed.returncode != 0:
+            raise DockerPrebuildError(
+                "docker build failed for {}: {}".format(
+                    context, _decode(completed.stderr) or _decode(completed.stdout)
+                )
+            )
+
+    def tag(self, source: str, dest: str) -> None:
+        completed = _run(["docker", "tag", source, dest], check=False)
+        if completed.returncode != 0:
+            raise DockerPrebuildError(
+                "docker tag {} -> {} failed".format(source, dest)
+            )
+
+    def save(self, tag: str, dest: Path) -> None:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        completed = _run(
+            ["docker", "save", "-o", str(dest), tag],
+            check=False,
+        )
+        if completed.returncode != 0:
+            dest.unlink(missing_ok=True)
+            raise DockerPrebuildError("docker save {} failed".format(tag))
+
+    def load(self, archive: Path) -> None:
+        completed = _run(["docker", "load", "-i", str(archive)], check=False)
+        if completed.returncode != 0:
+            raise DockerPrebuildError("docker load {} failed".format(archive))
+
+
+def shutil_which(name: str) -> str | None:
+    import shutil
+
+    return shutil.which(name)
+
+
+def _docker_info_ok(run: Callable[..., subprocess.CompletedProcess[bytes]]) -> bool:
+    completed = run(["docker", "info"], check=False)
+    return completed.returncode == 0
+
+
+def _run(
+    command: list[str],
+    *,
+    check: bool = False,
+) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(  # noqa: S603
+        command,
+        check=check,
+        capture_output=True,
+    )
+
+
+def _decode(blob: bytes | None) -> str:
+    if not blob:
+        return ""
+    return blob.decode("utf-8", errors="replace").strip()
+
+
+def _file_lock(path: Path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle = path.open("a+", encoding="utf-8")
+    try:
+        import fcntl
+
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+    except OSError:
+        pass
+    return _Lock(handle)
+
+
+class _Lock:
+    def __init__(self, handle) -> None:
+        self._handle = handle
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        try:
+            import fcntl
+
+            fcntl.flock(self._handle.fileno(), fcntl.LOCK_UN)
+        except OSError:
+            pass
+        self._handle.close()

--- a/application/playground/backend/service/modal_host_app.py
+++ b/application/playground/backend/service/modal_host_app.py
@@ -1,15 +1,13 @@
-"""Modal app for Harbor jobs (survey/chat host agents + web/linux Docker).
+"""Modal app for Harbor jobs.
 
-Deploy from a MatrAIx checkout:
+Survey and chat use the ``harbor_host_job`` Function. Web and Linux use a
+Sandbox from this app’s Docker image (task images cached on
+``matraix-docker-images``). Deploy once from a MatrAIx checkout:
 
     uv run --extra modal modal deploy application/playground/backend/service/modal_host_app.py
 
 Optional: ``modal secret create matraix-llm ANTHROPIC_API_KEY=...``
 (or set ``MATRIX_MODAL_SECRET``). Orchestrator env keys are also passed per call.
-
-``harbor_host_job`` is the slim survey/chat worker. ``harbor_docker_job`` installs
-Docker, persists task images on the ``matraix-docker-images`` Volume, and runs
-Harbor ``type: docker`` so later dispatches skip ``compose build``.
 """
 
 from __future__ import annotations
@@ -46,6 +44,7 @@ from backend.service.modal_host_job import (  # noqa: E402
     modal_volume_job_name,
     publish_job_to_volume,
 )
+
 
 def _resolve_repo_root() -> str:
     env = (os.environ.get("MATRIX_REPO_ROOT") or "").strip()
@@ -209,23 +208,7 @@ def harbor_host_job(payload: dict) -> dict:
     return _complete_harbor_job(payload)
 
 
-@app.function(
-    image=docker_image,
-    timeout=2 * 60 * 60,
-    cpu=2,
-    memory=8192,
-    volumes={
-        "/modal-jobs": volume,
-        "/modal-docker-images": docker_images_volume,
-    },
-    secrets=_secrets,
-    env={
-        **_WORKER_ENV,
-        "MATRIX_DOCKER_IMAGE_CACHE": "/modal-docker-images",
-    },
-)
-def harbor_docker_job(payload: dict) -> dict:
-    docker_images_volume.reload()
-    result = _complete_harbor_job(payload)
-    docker_images_volume.commit()
-    return result
+@app.function(image=docker_image, timeout=60, cpu=0.125, memory=256)
+def harbor_docker_image() -> str:
+    """Docker image for web/linux Sandboxes."""
+    return "ok"

--- a/application/playground/backend/service/modal_host_app.py
+++ b/application/playground/backend/service/modal_host_app.py
@@ -1,0 +1,231 @@
+"""Modal app for Harbor jobs (survey/chat host agents + web/linux Docker).
+
+Deploy from a MatrAIx checkout:
+
+    uv run --extra modal modal deploy application/playground/backend/service/modal_host_app.py
+
+Optional: ``modal secret create matraix-llm ANTHROPIC_API_KEY=...``
+(or set ``MATRIX_MODAL_SECRET``). Orchestrator env keys are also passed per call.
+
+``harbor_host_job`` is the slim survey/chat worker. ``harbor_docker_job`` installs
+Docker, persists task images on the ``matraix-docker-images`` Volume, and runs
+Harbor ``type: docker`` so later dispatches skip ``compose build``.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import modal
+
+# Modal hydrates this file as /root/modal_host_app.py, so PYTHONPATH from
+# local deploy is gone. Put the baked-in playground (or this checkout) first.
+for _path in (
+    Path("/matraix/application/playground"),
+    Path(__file__).resolve().parent.parent.parent,
+):
+    if _path.is_dir() and (_path / "backend").is_dir():
+        _text = str(_path)
+        if _text not in sys.path:
+            sys.path.insert(0, _text)
+        break
+
+from backend.service.modal_host_job import (  # noqa: E402
+    HARBOR_MODULE_COMMAND,
+    MODAL_DOCKER_IMAGES_VOLUME_NAME,
+    MODAL_HOST_APP_NAME,
+    MODAL_JOBS_VOLUME_NAME,
+    MODAL_REMOTE_REPO,
+    LivePublishState,
+    ModalHostJobRequest,
+    execute_host_harbor_job,
+    modal_volume_job_name,
+    publish_job_to_volume,
+)
+
+def _resolve_repo_root() -> str:
+    env = (os.environ.get("MATRIX_REPO_ROOT") or "").strip()
+    if env and Path(env).is_dir():
+        return env
+    remote = Path(MODAL_REMOTE_REPO)
+    if remote.is_dir():
+        return str(remote)
+    here = Path(__file__).resolve()
+    if len(here.parents) > 4:
+        return str(here.parents[4])
+    return MODAL_REMOTE_REPO
+
+
+_REPO_ROOT = _resolve_repo_root()
+_SECRET_NAME = os.environ.get("MATRIX_MODAL_SECRET") or "matraix-llm"
+_VOLUME_NAME = os.environ.get("MATRIX_MODAL_JOBS_VOLUME") or MODAL_JOBS_VOLUME_NAME
+_DOCKER_VOLUME_NAME = (
+    os.environ.get("MATRIX_MODAL_DOCKER_IMAGES_VOLUME") or MODAL_DOCKER_IMAGES_VOLUME_NAME
+)
+_REPO_IGNORE = [
+    "**/.git/**",
+    "**/node_modules/**",
+    "**/.venv/**",
+    "**/jobs/**",
+    "**/__pycache__/**",
+    "**/.pytest_cache/**",
+    "**/.mypy_cache/**",
+    "**/.env*",
+    "**/docs/**",
+    "**/*.pdf",
+    "**/persona/datasets/generated*/**",
+]
+_PYTHONPATH = (
+    "{root}/application/playground:{root}:{root}/src:"
+    "{root}/environment/runtime:{root}/environment/agents:"
+    "{root}/packages/playground/src"
+).format(root=MODAL_REMOTE_REPO)
+_WORKER_ENV = {
+    "MATRIX_REPO_ROOT": MODAL_REMOTE_REPO,
+    "PYTHONPATH": _PYTHONPATH,
+}
+
+
+def _install_repo(image: modal.Image) -> modal.Image:
+    return (
+        image.add_local_dir(
+            _REPO_ROOT,
+            remote_path=MODAL_REMOTE_REPO,
+            copy=True,
+            ignore=_REPO_IGNORE,
+        ).run_commands(
+            "cd {} && uv pip install --system --compile-bytecode -e '.[modal]'".format(
+                MODAL_REMOTE_REPO
+            )
+        )
+    )
+
+
+image = _install_repo(
+    modal.Image.debian_slim(python_version="3.12")
+    .apt_install("git", "build-essential", "ca-certificates")
+    .pip_install("uv")
+)
+
+docker_image = _install_repo(
+    modal.Image.debian_slim(python_version="3.12")
+    .apt_install(
+        "git",
+        "build-essential",
+        "ca-certificates",
+        "curl",
+        "docker.io",
+        "iptables",
+        "fuse-overlayfs",
+    )
+    .pip_install("uv")
+    .run_commands(
+        "mkdir -p /usr/libexec/docker/cli-plugins",
+        "curl -fsSL "
+        "https://github.com/docker/compose/releases/download/v2.29.7/"
+        "docker-compose-linux-x86_64 "
+        "-o /usr/libexec/docker/cli-plugins/docker-compose",
+        "chmod +x /usr/libexec/docker/cli-plugins/docker-compose",
+    )
+)
+
+volume = modal.Volume.from_name(_VOLUME_NAME, create_if_missing=True)
+docker_images_volume = modal.Volume.from_name(_DOCKER_VOLUME_NAME, create_if_missing=True)
+_secrets: list[modal.Secret] = []
+try:
+    _secrets.append(modal.Secret.from_name(_SECRET_NAME))
+except Exception:
+    pass
+
+app = modal.App(MODAL_HOST_APP_NAME, image=image)
+
+
+def _run_command(command: list[str], *, cwd: str, env: dict[str, str]) -> int:
+    completed = subprocess.run(command, cwd=cwd, env=env, check=False)
+    return int(completed.returncode)
+
+
+def _complete_harbor_job(payload: dict) -> dict:
+    shard_key = str(payload.get("shardKey") or "").strip()
+    request = ModalHostJobRequest(
+        job_name=str(payload["jobName"]),
+        config_yaml=str(payload["configYaml"]),
+        repo_root=MODAL_REMOTE_REPO,
+        jobs_dir="jobs",
+        env=dict(payload.get("env") or {}),
+        harbor_command=HARBOR_MODULE_COMMAND,
+        secret_env=dict(payload.get("secretEnv") or {}),
+        shard_key=shard_key,
+    )
+    volume_name = modal_volume_job_name(request.job_name, shard_key)
+    volume_root = Path("/modal-jobs")
+    live = LivePublishState()
+
+    def _live_publish(job_dir: Path) -> None:
+        if live.tick(
+            job_dir,
+            volume_root=volume_root,
+            job_name=volume_name,
+            status_key=volume_name,
+        ):
+            volume.commit()
+
+    result = execute_host_harbor_job(
+        request,
+        command_runner=_run_command,
+        work_root=Path(MODAL_REMOTE_REPO),
+        progress=_live_publish,
+    )
+    job_dir = Path(MODAL_REMOTE_REPO) / "jobs" / request.job_name
+    volume_path = None
+    if job_dir.is_dir():
+        publish_job_to_volume(job_dir, volume_root=volume_root, job_name=volume_name)
+        volume.commit()
+        volume_path = volume_name
+    artifact_b64 = None
+    if result.artifact_tar:
+        artifact_b64 = base64.b64encode(result.artifact_tar).decode("ascii")
+    return {
+        "exitCode": result.exit_code,
+        "error": result.error,
+        "artifactTarB64": artifact_b64,
+        "volumePath": volume_path,
+    }
+
+
+@app.function(
+    timeout=60 * 60,
+    cpu=1.0,
+    memory=4096,
+    volumes={"/modal-jobs": volume},
+    secrets=_secrets,
+    env=_WORKER_ENV,
+)
+def harbor_host_job(payload: dict) -> dict:
+    return _complete_harbor_job(payload)
+
+
+@app.function(
+    image=docker_image,
+    timeout=2 * 60 * 60,
+    cpu=2,
+    memory=8192,
+    volumes={
+        "/modal-jobs": volume,
+        "/modal-docker-images": docker_images_volume,
+    },
+    secrets=_secrets,
+    env={
+        **_WORKER_ENV,
+        "MATRIX_DOCKER_IMAGE_CACHE": "/modal-docker-images",
+    },
+)
+def harbor_docker_job(payload: dict) -> dict:
+    docker_images_volume.reload()
+    result = _complete_harbor_job(payload)
+    docker_images_volume.commit()
+    return result

--- a/application/playground/backend/service/modal_host_job.py
+++ b/application/playground/backend/service/modal_host_job.py
@@ -1,9 +1,9 @@
-"""Schedule Harbor jobs as Modal Jobs.
+"""Schedule Harbor jobs on Modal.
 
-Survey/chat keep Harbor ``environment.type: host``. Web/linux keep ``type: docker``
-inside a Docker-capable worker; task images are prebuilt onto a Volume so later
-dispatches skip ``docker compose build``. Artifacts merge into the same
-``jobs/<job_name>/`` tree as a local run (``compute.json`` stays orchestrator-owned).
+Survey and chat run as the ``harbor_host_job`` Function. Web and Linux run as a
+Docker-capable Sandbox. Task images are cached on a Volume so later jobs skip
+``docker compose build``. Artifacts merge into the same ``jobs/<job_name>/`` tree
+as a local run (``compute.json`` stays orchestrator-owned).
 """
 
 from __future__ import annotations
@@ -22,8 +22,8 @@ from typing import Any, Callable, Protocol
 
 MODAL_HOST_APP_NAME = "matraix-host-jobs"
 MODAL_HOST_FUNCTION_NAME = "harbor_host_job"
-MODAL_DOCKER_FUNCTION_NAME = "harbor_docker_job"
 MODAL_JOBS_VOLUME_NAME = "matraix-jobs"
+SANDBOX_CALL_PREFIX = "sandbox:"
 MODAL_DOCKER_IMAGES_VOLUME_NAME = "matraix-docker-images"
 MODAL_REMOTE_REPO = "/matraix"
 HARBOR_MODULE_COMMAND = ("python", "-m", "harbor.cli.main", "run")
@@ -45,11 +45,18 @@ _TEXT_REWRITE_SUFFIXES = frozenset({
 })
 _SECRET_ENV_KEYS = (
     "ANTHROPIC_API_KEY",
+    "CLAUDE_API_KEY",
     "OPENAI_API_KEY",
     "DASHSCOPE_API_KEY",
+    "DASHSCOPE_API_BASE",
     "OPENROUTER_API_KEY",
     "GOOGLE_API_KEY",
     "GEMINI_API_KEY",
+    "XAI_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "ZAI_API_KEY",
+    "LLM_API_KEY",
+    "USE_COMPUTER_API_KEY",
     "TOGETHER_API_KEY",
     "FIREWORKS_API_KEY",
     "AZURE_API_KEY",
@@ -65,7 +72,7 @@ _MAX_INLINE_TAR_BYTES = 40 * 1024 * 1024
 
 
 class ModalHostJobError(RuntimeError):
-    """Modal Jobs could not be scheduled or completed."""
+    """Modal could not schedule or complete the job."""
 
 
 @dataclass(frozen=True)
@@ -304,8 +311,13 @@ def rewrite_job_artifact_paths(
             path.write_text(updated, encoding="utf-8")
 
 
-def prepare_modal_job_config(config_yaml: str, *, job_name: str) -> str:
-    """Force Harbor to write ``jobs/<job_name>/`` under the Modal repo root."""
+def prepare_modal_job_config(
+    config_yaml: str,
+    *,
+    job_name: str,
+    jobs_dir: str = "jobs",
+) -> str:
+    """Force Harbor to write ``<jobs_dir>/<job_name>/`` under the remote repo root."""
     try:
         import yaml
     except ImportError:
@@ -314,16 +326,34 @@ def prepare_modal_job_config(config_yaml: str, *, job_name: str) -> str:
     if not isinstance(loaded, dict):
         return config_yaml
     loaded["job_name"] = job_name
-    loaded["jobs_dir"] = "jobs"
+    loaded["jobs_dir"] = jobs_dir or "jobs"
     return yaml.safe_dump(loaded, sort_keys=False)
 
 
 def modal_function_name_for_config(config_yaml: str) -> str:
+    del config_yaml
+    return MODAL_HOST_FUNCTION_NAME
+
+
+def modal_uses_docker_sandbox(config_yaml: str) -> bool:
     from backend.service.modal_docker_prebuild import harbor_environment_type
 
-    if harbor_environment_type(config_yaml) == "docker":
-        return MODAL_DOCKER_FUNCTION_NAME
-    return MODAL_HOST_FUNCTION_NAME
+    return harbor_environment_type(config_yaml) == "docker"
+
+
+def encode_modal_sandbox_call_id(object_id: str) -> str:
+    return SANDBOX_CALL_PREFIX + object_id
+
+
+def is_modal_sandbox_call_id(call_id: str) -> bool:
+    return (call_id or "").startswith(SANDBOX_CALL_PREFIX)
+
+
+def modal_sandbox_object_id(call_id: str) -> str:
+    raw = (call_id or "").strip()
+    if raw.startswith(SANDBOX_CALL_PREFIX):
+        return raw[len(SANDBOX_CALL_PREFIX) :]
+    return raw
 
 
 def execute_host_harbor_job(
@@ -418,6 +448,21 @@ def write_live_status_file(status: dict[str, str], dest: Path) -> bool:
         return False
     path.write_text(encoded, encoding="utf-8")
     return True
+
+
+def apply_worker_live_status(dest: Path, raw: bytes | str) -> dict[str, str]:
+    """Merge a worker ``live_status.json`` blob into the orchestrator overlay."""
+    text = raw.decode("utf-8", errors="replace") if isinstance(raw, bytes) else raw
+    try:
+        loaded = json.loads(text)
+    except Exception:
+        return {}
+    if not isinstance(loaded, dict):
+        return {}
+    status = {str(key): str(value) for key, value in loaded.items() if str(key)}
+    if status:
+        apply_live_overlay(dest, status)
+    return status
 
 
 def apply_live_overlay(dest: Path, status: dict[str, str]) -> Path:
@@ -804,7 +849,7 @@ def wait_modal_call_with_live_pull(
     dest: Path | None,
     poll_sec: float = 5.0,
 ) -> Any:
-    """Block on ``FunctionCall.get`` while applying live status and flushed artifacts."""
+    """Block on the Function while applying live status and flushed artifacts."""
     while True:
         try:
             return call.get(timeout=poll_sec)
@@ -877,7 +922,7 @@ class SdkModalHostJobRunner:
             call = spawn(payload)
         except Exception as exc:  # noqa: BLE001
             raise ModalHostJobError(
-                "Modal Jobs function {}.{} is not reachable. "
+                "Modal function {}.{} is not reachable. "
                 "Deploy application/playground/backend/service/modal_host_app.py "
                 "({}).".format(MODAL_HOST_APP_NAME, modal_function_name_for_config(request.config_yaml), exc)
             ) from exc
@@ -919,7 +964,7 @@ class SdkModalHostJobRunner:
             )
         except Exception as exc:  # noqa: BLE001
             raise ModalHostJobError(
-                "Modal Jobs function {}.{} is not reachable. "
+                "Modal function {}.{} is not reachable. "
                 "Deploy application/playground/backend/service/modal_host_app.py "
                 "({}).".format(
                     MODAL_HOST_APP_NAME,
@@ -936,7 +981,7 @@ class SdkModalHostJobRunner:
     def _function_and_payload(self, request: ModalHostJobRequest) -> tuple[Any, dict[str, Any]]:
         if not modal_credentials_configured():
             raise ModalHostJobError(
-                "computeFamily=modal (Modal Jobs) requires Modal credentials "
+                "computeFamily=modal requires Modal credentials "
                 "(MODAL_TOKEN_ID and MODAL_TOKEN_SECRET, or ~/.modal.toml)"
             )
         try:
@@ -958,7 +1003,7 @@ class SdkModalHostJobRunner:
             fn = modal.Function.from_name(MODAL_HOST_APP_NAME, function_name)
         except Exception as exc:  # noqa: BLE001
             raise ModalHostJobError(
-                "Modal Jobs function {}.{} is not reachable. "
+                "Modal function {}.{} is not reachable. "
                 "Deploy application/playground/backend/service/modal_host_app.py "
                 "({}).".format(MODAL_HOST_APP_NAME, function_name, exc)
             ) from exc
@@ -980,7 +1025,7 @@ class SdkModalHostJobRunner:
 
     def _result_from_raw(self, raw: Any) -> ModalHostJobResult:
         if not isinstance(raw, dict):
-            raise ModalHostJobError("Modal Jobs returned an unexpected payload")
+            raise ModalHostJobError("Modal returned an unexpected payload")
         return ModalHostJobResult(
             exit_code=int(raw.get("exitCode") if raw.get("exitCode") is not None else 1),
             artifact_tar=_decode_artifact(raw),
@@ -1016,7 +1061,7 @@ def materialize_modal_artifacts(
             import modal
         except ImportError as exc:
             raise ModalHostJobError(
-                "Modal Jobs wrote a volume path but the Modal SDK is not installed"
+                "Modal wrote a volume path but the Modal SDK is not installed"
             ) from exc
         volume = modal.Volume.from_name(
             os.environ.get("MATRIX_MODAL_JOBS_VOLUME") or MODAL_JOBS_VOLUME_NAME
@@ -1024,13 +1069,40 @@ def materialize_modal_artifacts(
         download_volume_job(volume, job_name=result.volume_path, dest=dest)
     else:
         raise ModalHostJobError(
-            "Modal Jobs finished without returning jobs/{}/ artifacts".format(job_name)
+            "Modal finished without returning jobs/{}/ artifacts".format(job_name)
         )
     return dest
 
 
+class SdkModalDispatchRunner:
+    """Survey/chat Function, or web/linux Sandbox."""
+
+    def spawn(self, request: ModalHostJobRequest) -> tuple[str, Any]:
+        return self._runner(request).spawn(request)
+
+    def wait(
+        self,
+        request: ModalHostJobRequest,
+        *,
+        call: Any | None = None,
+        call_id: str = "",
+    ) -> ModalHostJobResult:
+        return self._runner(request, call_id).wait(request, call=call, call_id=call_id)
+
+    def run(self, request: ModalHostJobRequest) -> ModalHostJobResult:
+        call_id, handle = self.spawn(request)
+        return self.wait(request, call=handle, call_id=call_id)
+
+    def _runner(self, request: ModalHostJobRequest, call_id: str = "") -> Any:
+        if is_modal_sandbox_call_id(call_id) or modal_uses_docker_sandbox(request.config_yaml):
+            from backend.service.modal_sandbox_job import SdkModalSandboxJobRunner
+
+            return SdkModalSandboxJobRunner()
+        return SdkModalHostJobRunner()
+
+
 def default_modal_host_job_runner() -> ModalHostJobRunner:
-    return SdkModalHostJobRunner()
+    return SdkModalDispatchRunner()
 
 
 def write_compute_json(job_dir: Path, plan: Any) -> Path:

--- a/application/playground/backend/service/modal_host_job.py
+++ b/application/playground/backend/service/modal_host_job.py
@@ -1,0 +1,1041 @@
+"""Schedule Harbor jobs as Modal Jobs.
+
+Survey/chat keep Harbor ``environment.type: host``. Web/linux keep ``type: docker``
+inside a Docker-capable worker; task images are prebuilt onto a Volume so later
+dispatches skip ``docker compose build``. Artifacts merge into the same
+``jobs/<job_name>/`` tree as a local run (``compute.json`` stays orchestrator-owned).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import shutil
+import tarfile
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Protocol
+
+MODAL_HOST_APP_NAME = "matraix-host-jobs"
+MODAL_HOST_FUNCTION_NAME = "harbor_host_job"
+MODAL_DOCKER_FUNCTION_NAME = "harbor_docker_job"
+MODAL_JOBS_VOLUME_NAME = "matraix-jobs"
+MODAL_DOCKER_IMAGES_VOLUME_NAME = "matraix-docker-images"
+MODAL_REMOTE_REPO = "/matraix"
+HARBOR_MODULE_COMMAND = ("python", "-m", "harbor.cli.main", "run")
+_PRESERVE_ON_MERGE = frozenset({"compute.json"})
+_SKIP_ON_MERGE = frozenset({"result.json", "lock.json", "config.json"})
+_LIVE_STATUS_FILENAME = "live_status.json"
+LIVE_OVERLAY_FILENAME = "live_overlay.json"
+CLOUD_RUN_FILENAME = "cloud_run.json"
+MODAL_LIVE_STATUS_DICT = "matraix-live-status"
+_LIVE_MARKER_NAMES = ("config.json", "trial.log", "persona_meta.json")
+_TEXT_REWRITE_SUFFIXES = frozenset({
+    ".json",
+    ".yaml",
+    ".yml",
+    ".txt",
+    ".log",
+    ".md",
+    ".csv",
+})
+_SECRET_ENV_KEYS = (
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "DASHSCOPE_API_KEY",
+    "OPENROUTER_API_KEY",
+    "GOOGLE_API_KEY",
+    "GEMINI_API_KEY",
+    "TOGETHER_API_KEY",
+    "FIREWORKS_API_KEY",
+    "AZURE_API_KEY",
+    "AZURE_API_BASE",
+    "CHATBOT_API_URL",
+    "CHATBOT_MCP_URL",
+    "CHATBOT_UPSTREAM_FINANCE",
+    "CHATBOT_UPSTREAM_MEDICAL",
+    "FINANCE_CHATBOT_URL",
+    "MEDICAL_CHATBOT_URL",
+)
+_MAX_INLINE_TAR_BYTES = 40 * 1024 * 1024
+
+
+class ModalHostJobError(RuntimeError):
+    """Modal Jobs could not be scheduled or completed."""
+
+
+@dataclass(frozen=True)
+class ModalHostJobRequest:
+    job_name: str
+    config_yaml: str
+    repo_root: str
+    jobs_dir: str
+    env: dict[str, str]
+    harbor_command: tuple[str, ...] = HARBOR_MODULE_COMMAND
+    secret_env: dict[str, str] = field(default_factory=dict)
+    shard_key: str = ""
+    live_jobs_dir: str = ""
+
+
+@dataclass(frozen=True)
+class ModalHostJobResult:
+    exit_code: int
+    artifact_tar: bytes | None = None
+    error: str | None = None
+    volume_path: str | None = None
+
+
+class ModalHostJobRunner(Protocol):
+    def run(self, request: ModalHostJobRequest) -> ModalHostJobResult: ...
+
+
+def modal_credentials_configured() -> bool:
+    token_id = (os.environ.get("MODAL_TOKEN_ID") or "").strip()
+    token_secret = (os.environ.get("MODAL_TOKEN_SECRET") or "").strip()
+    if token_id and token_secret:
+        return True
+    return (Path.home() / ".modal.toml").is_file()
+
+
+def collect_orchestrator_secret_env() -> dict[str, str]:
+    payload = {
+        key: value
+        for key in _SECRET_ENV_KEYS
+        if (value := (os.environ.get(key) or "").strip())
+    }
+    from backend.service.chatbot_reachability import rewrite_chatbot_urls_for_cloud
+
+    return rewrite_chatbot_urls_for_cloud(payload)
+
+
+def modal_volume_job_name(job_name: str, shard_key: str = "") -> str:
+    shard = (shard_key or "").strip()
+    if shard:
+        return "{}/{}".format(job_name, shard)
+    return job_name
+
+
+def _live_interval_sec(env_name: str, default: float = 5.0) -> float:
+    raw = (os.environ.get(env_name) or "").strip()
+    try:
+        value = float(raw) if raw else default
+    except ValueError:
+        value = default
+    if value <= 0:
+        return default
+    return max(value, 0.5)
+
+
+def artifact_flush_trials() -> int:
+    raw = (os.environ.get("MATRIX_MODAL_ARTIFACT_FLUSH_TRIALS") or "").strip()
+    try:
+        value = int(raw) if raw else 25
+    except ValueError:
+        value = 25
+    return max(1, value)
+
+
+def artifact_flush_sec() -> float:
+    return _live_interval_sec("MATRIX_MODAL_ARTIFACT_FLUSH_SEC", 30.0)
+
+
+def modal_pythonpath(repo_root: Path) -> str:
+    entries = [
+        str(repo_root),
+        str(repo_root / "src"),
+        str(repo_root / "environment" / "runtime"),
+        str(repo_root / "environment" / "agents"),
+        str(repo_root / "packages" / "playground" / "src"),
+        str(repo_root / "application" / "playground"),
+    ]
+    return ":".join(entries)
+
+
+def pack_job_dir(job_dir: Path) -> bytes:
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
+        if job_dir.is_dir():
+            archive.add(job_dir, arcname=job_dir.name)
+    return buffer.getvalue()
+
+
+def unpack_job_dir(artifact_tar: bytes, *, jobs_dir: Path, job_name: str) -> Path:
+    return merge_job_artifacts(artifact_tar, jobs_dir=jobs_dir, job_name=job_name)
+
+
+def merge_job_artifacts(
+    artifact_tar: bytes,
+    *,
+    jobs_dir: Path,
+    job_name: str,
+    remote_repo: str = MODAL_REMOTE_REPO,
+) -> Path:
+    """Merge a packed Modal job tree into ``jobs/<job_name>/`` without clobbering meta."""
+    jobs_dir.mkdir(parents=True, exist_ok=True)
+    dest = jobs_dir / job_name
+    dest.mkdir(parents=True, exist_ok=True)
+    staging = jobs_dir / ".modal-unpack-{}-{}".format(job_name, uuid.uuid4().hex[:8])
+    if staging.exists():
+        shutil.rmtree(staging)
+    staging.mkdir(parents=True)
+    buffer = io.BytesIO(artifact_tar)
+    with tarfile.open(fileobj=buffer, mode="r:gz") as archive:
+        try:
+            archive.extractall(staging, filter="data")
+        except TypeError:
+            archive.extractall(staging)
+    extracted = staging / job_name
+    if not extracted.is_dir():
+        children = [path for path in staging.iterdir() if path.is_dir()]
+        extracted = children[0] if len(children) == 1 else staging
+    _copy_tree_preserving(extracted, dest)
+    shutil.rmtree(staging, ignore_errors=True)
+    rewrite_job_artifact_paths(
+        dest,
+        remote_repo=remote_repo,
+        local_job_dir=dest,
+        job_name=job_name,
+    )
+    return dest
+
+
+def merge_job_dir(src: Path, dest: Path) -> Path:
+    """Copy a worker/staging job tree into the canonical ``jobs/<name>/``."""
+    dest.mkdir(parents=True, exist_ok=True)
+    if src.is_dir():
+        _copy_tree_preserving(src, dest)
+    return dest
+
+
+def _copy_tree_preserving(src: Path, dest: Path) -> None:
+    for path in src.rglob("*"):
+        rel = path.relative_to(src)
+        target = dest / rel
+        if path.is_dir():
+            target.mkdir(parents=True, exist_ok=True)
+            continue
+        if len(rel.parts) == 1 and rel.parts[0] in _SKIP_ON_MERGE:
+            continue
+        if rel.parts and rel.parts[0] in _PRESERVE_ON_MERGE and target.is_file():
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(path, target)
+
+
+def _iter_trial_dirs(job_dir: Path) -> list[Path]:
+    if not job_dir.is_dir():
+        return []
+    return sorted(
+        path
+        for path in job_dir.iterdir()
+        if path.is_dir() and not path.name.startswith("_")
+    )
+
+
+def _trial_live_state(trial_dir: Path) -> str:
+    if not trial_dir.is_dir():
+        return "pending"
+    result_path = trial_dir / "result.json"
+    if result_path.is_file():
+        try:
+            payload = json.loads(result_path.read_text(encoding="utf-8"))
+        except Exception:
+            payload = None
+        if isinstance(payload, dict) and (payload.get("exception_info") or payload.get("error")):
+            return "error"
+        return "done"
+    if any((trial_dir / name).is_file() for name in _LIVE_MARKER_NAMES) or (
+        trial_dir / "agent"
+    ).is_dir():
+        return "running"
+    return "pending"
+
+
+def _copy_trial_tree(src: Path, dest: Path) -> None:
+    dest.mkdir(parents=True, exist_ok=True)
+    for path in src.rglob("*"):
+        rel = path.relative_to(src)
+        target = dest / rel
+        if path.is_dir():
+            target.mkdir(parents=True, exist_ok=True)
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(path, target)
+
+
+def _copy_trial_markers(src: Path, dest: Path) -> None:
+    dest.mkdir(parents=True, exist_ok=True)
+    for name in _LIVE_MARKER_NAMES:
+        file = src / name
+        if file.is_file():
+            shutil.copy2(file, dest / name)
+
+
+def rewrite_job_artifact_paths(
+    job_dir: Path,
+    *,
+    remote_repo: str,
+    local_job_dir: Path,
+    job_name: str,
+) -> None:
+    """Rewrite Modal absolute paths so Playground can read the local tree."""
+    local = str(local_job_dir.resolve())
+    remote_job = "{}/jobs/{}".format(remote_repo.rstrip("/"), job_name)
+    replacements = (
+        (remote_job, local),
+        ("file://{}".format(remote_job), "file://{}".format(local)),
+        ("{}/jobs".format(remote_repo.rstrip("/")), str(local_job_dir.parent.resolve())),
+    )
+    for path in job_dir.rglob("*"):
+        if not path.is_file() or path.suffix.lower() not in _TEXT_REWRITE_SUFFIXES:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        updated = text
+        for old, new in replacements:
+            updated = updated.replace(old, new)
+        if updated != text:
+            path.write_text(updated, encoding="utf-8")
+
+
+def prepare_modal_job_config(config_yaml: str, *, job_name: str) -> str:
+    """Force Harbor to write ``jobs/<job_name>/`` under the Modal repo root."""
+    try:
+        import yaml
+    except ImportError:
+        return config_yaml
+    loaded = yaml.safe_load(config_yaml)
+    if not isinstance(loaded, dict):
+        return config_yaml
+    loaded["job_name"] = job_name
+    loaded["jobs_dir"] = "jobs"
+    return yaml.safe_dump(loaded, sort_keys=False)
+
+
+def modal_function_name_for_config(config_yaml: str) -> str:
+    from backend.service.modal_docker_prebuild import harbor_environment_type
+
+    if harbor_environment_type(config_yaml) == "docker":
+        return MODAL_DOCKER_FUNCTION_NAME
+    return MODAL_HOST_FUNCTION_NAME
+
+
+def execute_host_harbor_job(
+    request: ModalHostJobRequest,
+    *,
+    command_runner: Callable[..., int],
+    work_root: Path | None = None,
+    progress: Callable[[Path], None] | None = None,
+) -> ModalHostJobResult:
+    """Run Harbor and return a tarball of ``jobs/<job>``."""
+    root = Path(work_root or request.repo_root)
+    config_yaml = prepare_modal_job_config(request.config_yaml, job_name=request.job_name)
+    from backend.service.modal_docker_prebuild import (
+        DockerPrebuildError,
+        prepare_docker_environment_for_job,
+    )
+
+    try:
+        prepare_docker_environment_for_job(config_yaml, repo_root=root)
+    except DockerPrebuildError as exc:
+        return ModalHostJobResult(exit_code=1, error=str(exc))
+    config_path = root / "configs" / "jobs" / "modal-host-incoming" / "{}.yaml".format(
+        request.job_name
+    )
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(config_yaml, encoding="utf-8")
+    command = list(HARBOR_MODULE_COMMAND) + ["--yes", "-c", str(config_path)]
+    env = dict(os.environ)
+    env.update(request.env)
+    env.update(request.secret_env)
+    env["PYTHONPATH"] = modal_pythonpath(root)
+    env["MATRIX_REPO_ROOT"] = str(root)
+    job_dir = root / "jobs" / request.job_name
+    stop = threading.Event()
+    interval = _live_interval_sec("MATRIX_MODAL_LIVE_PUSH_SEC")
+
+    def _watch() -> None:
+        while not stop.wait(interval):
+            _call_progress(progress, job_dir)
+
+    watcher: threading.Thread | None = None
+    if progress is not None:
+        watcher = threading.Thread(target=_watch, name="modal-live-push", daemon=True)
+        watcher.start()
+    exit_code = 1
+    error_exc: str | None = None
+    try:
+        exit_code = int(command_runner(command, cwd=str(root), env=env))
+    except Exception as exc:  # noqa: BLE001
+        error_exc = str(exc)
+        exit_code = 1
+    finally:
+        stop.set()
+        if watcher is not None:
+            watcher.join(timeout=interval + 2)
+        _call_progress(progress, job_dir)
+    if error_exc:
+        return ModalHostJobResult(exit_code=1, error=error_exc)
+    artifact = pack_job_dir(job_dir) if job_dir.is_dir() else None
+    if artifact and len(artifact) > _MAX_INLINE_TAR_BYTES:
+        artifact = None
+    error = None if exit_code == 0 else "harbor run exited with code {}".format(exit_code)
+    if exit_code == 0 and not job_dir.is_dir():
+        error = "harbor run succeeded but wrote no jobs/{} tree".format(request.job_name)
+        exit_code = 1
+    return ModalHostJobResult(
+        exit_code=exit_code,
+        artifact_tar=artifact,
+        error=error,
+        volume_path=request.job_name if job_dir.is_dir() else None,
+    )
+
+
+def _call_progress(progress: Callable[[Path], None] | None, job_dir: Path) -> None:
+    if progress is None or not job_dir.is_dir():
+        return
+    try:
+        progress(job_dir)
+    except Exception:
+        pass
+
+
+def collect_live_status(job_dir: Path) -> dict[str, str]:
+    return {trial.name: _trial_live_state(trial) for trial in _iter_trial_dirs(job_dir)}
+
+
+def write_live_status_file(status: dict[str, str], dest: Path) -> bool:
+    dest.mkdir(parents=True, exist_ok=True)
+    encoded = json.dumps(status, sort_keys=True) + "\n"
+    path = dest / _LIVE_STATUS_FILENAME
+    if path.is_file() and path.read_text(encoding="utf-8") == encoded:
+        return False
+    path.write_text(encoded, encoding="utf-8")
+    return True
+
+
+def apply_live_overlay(dest: Path, status: dict[str, str]) -> Path:
+    """Merge shard live status into ``jobs/<job>/_generated/live_overlay.json``."""
+    generated = dest / "_generated"
+    generated.mkdir(parents=True, exist_ok=True)
+    path = generated / LIVE_OVERLAY_FILENAME
+    existing: dict[str, str] = {}
+    if path.is_file():
+        try:
+            loaded = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(loaded, dict):
+                existing = {str(key): str(value) for key, value in loaded.items()}
+        except Exception:
+            existing = {}
+    merged = dict(existing)
+    merged.update(status)
+    encoded = json.dumps(merged, sort_keys=True) + "\n"
+    if not path.is_file() or path.read_text(encoding="utf-8") != encoded:
+        path.write_text(encoded, encoding="utf-8")
+    return path
+
+
+def read_live_overlay(job_dir: Path) -> dict[str, str]:
+    path = job_dir / "_generated" / LIVE_OVERLAY_FILENAME
+    if not path.is_file():
+        return {}
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    if not isinstance(loaded, dict):
+        return {}
+    return {str(key): str(value) for key, value in loaded.items()}
+
+
+def overlay_status_code(state: str | None) -> int | None:
+    if state == "error":
+        return 3
+    if state == "done":
+        return 2
+    if state == "running":
+        return 1
+    if state == "pending":
+        return 0
+    return None
+
+
+def put_live_status_dict(key: str, status: dict[str, str]) -> bool:
+    try:
+        import modal
+
+        store = modal.Dict.from_name(MODAL_LIVE_STATUS_DICT, create_if_missing=True)
+        store[key] = status
+        return True
+    except Exception:
+        return False
+
+
+def get_live_status_dict(key: str) -> dict[str, str] | None:
+    try:
+        import modal
+
+        store = modal.Dict.from_name(MODAL_LIVE_STATUS_DICT)
+        loaded = store[key]
+    except Exception:
+        return None
+    if not isinstance(loaded, dict):
+        return None
+    return {str(name): str(state) for name, state in loaded.items()}
+
+
+def cloud_run_path(job_dir: Path) -> Path:
+    return job_dir / "_generated" / CLOUD_RUN_FILENAME
+
+
+def load_cloud_run(job_dir: Path) -> dict[str, Any] | None:
+    path = cloud_run_path(job_dir)
+    if not path.is_file():
+        return None
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    return loaded if isinstance(loaded, dict) else None
+
+
+def save_cloud_run(job_dir: Path, payload: dict[str, Any]) -> Path:
+    path = cloud_run_path(job_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def publish_job_to_volume(job_dir: Path, *, volume_root: Path, job_name: str) -> Path:
+    dest = volume_root / job_name
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if dest.exists():
+        shutil.rmtree(dest)
+    shutil.copytree(job_dir, dest)
+    return dest
+
+
+def publish_live_status(job_dir: Path, *, volume_root: Path, job_name: str) -> bool:
+    dest = volume_root / job_name
+    return write_live_status_file(collect_live_status(job_dir), dest)
+
+
+def publish_artifact_flush(job_dir: Path, *, volume_root: Path, job_name: str) -> list[str]:
+    """Copy newly finished trial trees onto the volume. Skip already-copied dones."""
+    dest = volume_root / job_name
+    dest.mkdir(parents=True, exist_ok=True)
+    copied: list[str] = []
+    for trial in _iter_trial_dirs(job_dir):
+        state = _trial_live_state(trial)
+        if state not in {"done", "error"}:
+            continue
+        remote = dest / trial.name
+        if _trial_live_state(remote) in {"done", "error"}:
+            continue
+        _copy_trial_tree(trial, remote)
+        copied.append(trial.name)
+    publish_live_status(job_dir, volume_root=volume_root, job_name=job_name)
+    return copied
+
+
+def publish_live_trial_deltas(job_dir: Path, *, volume_root: Path, job_name: str) -> int:
+    """Status file plus any newly finished trial trees (used by tests / final flush)."""
+    dest = volume_root / job_name
+    dest.mkdir(parents=True, exist_ok=True)
+    copied = publish_artifact_flush(job_dir, volume_root=volume_root, job_name=job_name)
+    return (1 if publish_live_status(job_dir, volume_root=volume_root, job_name=job_name) else 0) + len(
+        copied
+    )
+
+
+class LivePublishState:
+    """Worker-side heartbeat: tiny status every tick, full trees on a slower flush."""
+
+    def __init__(self) -> None:
+        self.flushed_done: set[str] = set()
+        self.last_flush_mono: float = 0.0
+
+    def tick(
+        self,
+        job_dir: Path,
+        *,
+        volume_root: Path,
+        job_name: str,
+        status_key: str = "",
+        force: bool = False,
+    ) -> bool:
+        """Return True when the Modal Volume should ``commit()`` (artifact flush or Dict miss)."""
+        status = collect_live_status(job_dir)
+        wrote_dict = False
+        if status_key:
+            wrote_dict = put_live_status_dict(status_key, status)
+        status_changed = write_live_status_file(status, volume_root / job_name)
+        done_names = {name for name, state in status.items() if state in {"done", "error"}}
+        new_done = done_names - self.flushed_done
+        now = time.monotonic()
+        if self.last_flush_mono <= 0:
+            self.last_flush_mono = now
+        due = force or (
+            bool(new_done)
+            and (
+                len(new_done) >= artifact_flush_trials()
+                or (now - self.last_flush_mono) >= artifact_flush_sec()
+            )
+        )
+        if due and new_done:
+            copied = publish_artifact_flush(job_dir, volume_root=volume_root, job_name=job_name)
+            self.flushed_done.update(copied or new_done)
+            self.last_flush_mono = now
+            return True
+        if force:
+            publish_live_status(job_dir, volume_root=volume_root, job_name=job_name)
+            return True
+        return bool(status_changed and not wrote_dict)
+
+
+def sync_job_dir_to_volume(job_dir: Path, *, volume_root: Path, job_name: str) -> Path:
+    dest = volume_root / job_name
+    dest.mkdir(parents=True, exist_ok=True)
+    publish_live_status(job_dir, volume_root=volume_root, job_name=job_name)
+    publish_artifact_flush(job_dir, volume_root=volume_root, job_name=job_name)
+    return dest
+
+
+def download_volume_job(
+    volume: Any,
+    *,
+    job_name: str,
+    dest: Path,
+    incremental: bool = False,
+) -> Path:
+    dest.mkdir(parents=True, exist_ok=True)
+    try:
+        volume.reload()
+    except Exception:
+        pass
+    generated = dest / "_generated"
+    generated.mkdir(parents=True, exist_ok=True)
+    staging = generated / "live_pull_{}".format(uuid.uuid4().hex[:12])
+    staging.mkdir(parents=True, exist_ok=True)
+    local_job_name = job_name.split("/", 1)[0]
+    try:
+        if incremental:
+            _download_live_trial_deltas(volume, job_name, dest, staging)
+        else:
+            _download_volume_prefix(volume, job_name, staging)
+            if any(staging.iterdir()):
+                _copy_tree_preserving(staging, dest)
+            rewrite_job_artifact_paths(
+                dest,
+                remote_repo=MODAL_REMOTE_REPO,
+                local_job_dir=dest,
+                job_name=local_job_name,
+            )
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+    return dest
+
+
+def _download_live_trial_deltas(
+    volume: Any,
+    job_name: str,
+    dest: Path,
+    staging: Path,
+) -> None:
+    status = _read_volume_live_status(volume, job_name)
+    if status is not None:
+        names = [name for name, state in status.items() if state in {"running", "done"}]
+    else:
+        names = _list_volume_trial_names(volume, job_name)
+    parent_job = job_name.split("/", 1)[0]
+    for name in names:
+        local = dest / name
+        local_state = _trial_live_state(local)
+        if local_state == "done":
+            continue
+        remote_state = status.get(name) if status is not None else None
+        if remote_state == "running" or (
+            local_state == "running" and remote_state != "done" and remote_state != "error"
+        ):
+            if remote_state in {None, "running", "pending"} and not _volume_trial_has_result(
+                volume, job_name, name
+            ):
+                continue
+        if remote_state == "pending":
+            continue
+        trial_staging = staging / name
+        _download_volume_prefix(
+            volume,
+            "{}/{}".format(job_name.rstrip("/"), name),
+            trial_staging,
+        )
+        if not trial_staging.is_dir() or not any(trial_staging.iterdir()):
+            continue
+        _copy_trial_tree(trial_staging, local)
+        rewrite_job_artifact_paths(
+            local,
+            remote_repo=MODAL_REMOTE_REPO,
+            local_job_dir=dest,
+            job_name=parent_job,
+        )
+
+
+def _read_volume_live_status(volume: Any, job_name: str) -> dict[str, str] | None:
+    path = "{}/{}".format(job_name.rstrip("/"), _LIVE_STATUS_FILENAME)
+    try:
+        raw = b"".join(volume.read_file(path))
+        loaded = json.loads(raw.decode("utf-8"))
+    except Exception:
+        return None
+    if not isinstance(loaded, dict):
+        return None
+    return {str(key): str(value) for key, value in loaded.items()}
+
+
+def _list_volume_trial_names(volume: Any, job_name: str) -> list[str]:
+    try:
+        entries = list(volume.listdir(job_name.strip("/") or "/"))
+    except Exception:
+        return []
+    names: list[str] = []
+    for entry in entries:
+        name = getattr(entry, "path", None) or getattr(entry, "filename", "") or str(entry)
+        leaf = Path(str(name).lstrip("/")).name
+        is_dir = bool(getattr(entry, "is_dir", False)) or str(
+            getattr(entry, "type", "")
+        ).lower() in {"dir", "directory"}
+        if not is_dir or not leaf or leaf.startswith("_"):
+            continue
+        names.append(leaf)
+    return names
+
+
+def _volume_trial_has_result(volume: Any, job_name: str, trial_name: str) -> bool:
+    prefix = "{}/{}".format(job_name.rstrip("/"), trial_name)
+    try:
+        entries = list(volume.listdir(prefix))
+    except Exception:
+        return False
+    for entry in entries:
+        name = getattr(entry, "path", None) or getattr(entry, "filename", "") or str(entry)
+        if Path(str(name).lstrip("/")).name == "result.json":
+            return True
+    return False
+
+
+def _download_volume_prefix(volume: Any, prefix: str, dest: Path) -> None:
+    remote = prefix.strip("/") or "/"
+    try:
+        entries = list(volume.listdir(remote))
+    except Exception:
+        entries = []
+    if not entries:
+        try:
+            data = b"".join(volume.read_file(remote))
+        except Exception:
+            return
+        dest.write_bytes(data)
+        return
+    for entry in entries:
+        name = getattr(entry, "path", None) or getattr(entry, "filename", "") or str(entry)
+        name = str(name).lstrip("/")
+        leaf = Path(name).name
+        target = dest / leaf
+        is_dir = bool(getattr(entry, "is_dir", False)) or str(
+            getattr(entry, "type", "")
+        ).lower() in {"dir", "directory"}
+        if is_dir:
+            target.mkdir(parents=True, exist_ok=True)
+            _download_volume_prefix(volume, name, target)
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            target.write_bytes(b"".join(volume.read_file(name)))
+        except Exception:
+            continue
+
+
+def _is_modal_wait_timeout(exc: BaseException) -> bool:
+    if isinstance(exc, TimeoutError):
+        return True
+    return type(exc).__name__ in {"TimeoutError", "FunctionTimeoutError"}
+
+
+def pull_live_progress(
+    *,
+    volume: Any | None,
+    volume_job_name: str,
+    dest: Path,
+) -> None:
+    """Apply shard status overlay, then pull any flushed trial trees."""
+    dest.mkdir(parents=True, exist_ok=True)
+    status = get_live_status_dict(volume_job_name)
+    if status is None and volume is not None:
+        try:
+            volume.reload()
+        except Exception:
+            pass
+        status = _read_volume_live_status(volume, volume_job_name)
+    if status:
+        apply_live_overlay(dest, status)
+    if volume is not None:
+        try:
+            download_volume_job(
+                volume,
+                job_name=volume_job_name,
+                dest=dest,
+                incremental=True,
+            )
+        except Exception:
+            pass
+
+
+def wait_modal_call_with_live_pull(
+    call: Any,
+    *,
+    volume: Any | None,
+    volume_job_name: str,
+    dest: Path | None,
+    poll_sec: float = 5.0,
+) -> Any:
+    """Block on ``FunctionCall.get`` while applying live status and flushed artifacts."""
+    while True:
+        try:
+            return call.get(timeout=poll_sec)
+        except Exception as exc:
+            if not _is_modal_wait_timeout(exc):
+                raise
+            if dest is not None:
+                try:
+                    pull_live_progress(
+                        volume=volume,
+                        volume_job_name=volume_job_name,
+                        dest=dest,
+                    )
+                except Exception:
+                    pass
+
+
+def invoke_modal_host_function(
+    fn: Any,
+    payload: dict[str, Any],
+    *,
+    request: ModalHostJobRequest,
+    volume: Any | None = None,
+) -> Any:
+    """Spawn the Modal function when live pull is enabled; otherwise ``.remote()``."""
+    dest: Path | None = None
+    live_root = (request.live_jobs_dir or "").strip()
+    if live_root:
+        dest = Path(live_root) / request.job_name
+        dest.mkdir(parents=True, exist_ok=True)
+    spawn = getattr(fn, "spawn", None)
+    if dest is not None and callable(spawn):
+        call = spawn(payload)
+        return wait_modal_call_with_live_pull(
+            call,
+            volume=volume,
+            volume_job_name=modal_volume_job_name(request.job_name, request.shard_key),
+            dest=dest,
+            poll_sec=_live_interval_sec("MATRIX_MODAL_LIVE_PULL_SEC"),
+        )
+    return fn.remote(payload)
+
+
+def modal_function_call_id(call: Any) -> str:
+    return str(
+        getattr(call, "object_id", None)
+        or getattr(call, "call_id", None)
+        or ""
+    )
+
+
+def modal_function_call_from_id(call_id: str) -> Any:
+    import modal
+
+    factory = getattr(modal.FunctionCall, "from_id", None)
+    if not callable(factory):
+        raise ModalHostJobError("Modal FunctionCall.from_id is not available")
+    return factory(call_id)
+
+
+class SdkModalHostJobRunner:
+    """Call a deployed Modal function on ``matraix-host-jobs``."""
+
+    def spawn(self, request: ModalHostJobRequest) -> tuple[str, Any]:
+        fn, payload = self._function_and_payload(request)
+        spawn = getattr(fn, "spawn", None)
+        if not callable(spawn):
+            raise ModalHostJobError("Modal function does not support spawn()")
+        try:
+            call = spawn(payload)
+        except Exception as exc:  # noqa: BLE001
+            raise ModalHostJobError(
+                "Modal Jobs function {}.{} is not reachable. "
+                "Deploy application/playground/backend/service/modal_host_app.py "
+                "({}).".format(MODAL_HOST_APP_NAME, modal_function_name_for_config(request.config_yaml), exc)
+            ) from exc
+        return modal_function_call_id(call), call
+
+    def wait(
+        self,
+        request: ModalHostJobRequest,
+        *,
+        call: Any | None = None,
+        call_id: str = "",
+    ) -> ModalHostJobResult:
+        resolved = call
+        if resolved is None and (call_id or "").strip():
+            try:
+                resolved = modal_function_call_from_id(call_id.strip())
+            except Exception as exc:  # noqa: BLE001
+                raise ModalHostJobError(
+                    "Modal FunctionCall {} is not reachable ({})".format(call_id, exc)
+                ) from exc
+        if resolved is None:
+            fn, payload = self._function_and_payload(request)
+            raw = invoke_modal_host_function(
+                fn, payload, request=request, volume=self._volume(request)
+            )
+            return self._result_from_raw(raw)
+        dest = None
+        live_root = (request.live_jobs_dir or "").strip()
+        if live_root:
+            dest = Path(live_root) / request.job_name
+            dest.mkdir(parents=True, exist_ok=True)
+        try:
+            raw = wait_modal_call_with_live_pull(
+                resolved,
+                volume=self._volume(request),
+                volume_job_name=modal_volume_job_name(request.job_name, request.shard_key),
+                dest=dest,
+                poll_sec=_live_interval_sec("MATRIX_MODAL_LIVE_PULL_SEC"),
+            )
+        except Exception as exc:  # noqa: BLE001
+            raise ModalHostJobError(
+                "Modal Jobs function {}.{} is not reachable. "
+                "Deploy application/playground/backend/service/modal_host_app.py "
+                "({}).".format(
+                    MODAL_HOST_APP_NAME,
+                    modal_function_name_for_config(request.config_yaml),
+                    exc,
+                )
+            ) from exc
+        return self._result_from_raw(raw)
+
+    def run(self, request: ModalHostJobRequest) -> ModalHostJobResult:
+        call_id, call = self.spawn(request)
+        return self.wait(request, call=call, call_id=call_id)
+
+    def _function_and_payload(self, request: ModalHostJobRequest) -> tuple[Any, dict[str, Any]]:
+        if not modal_credentials_configured():
+            raise ModalHostJobError(
+                "computeFamily=modal (Modal Jobs) requires Modal credentials "
+                "(MODAL_TOKEN_ID and MODAL_TOKEN_SECRET, or ~/.modal.toml)"
+            )
+        try:
+            import modal
+        except ImportError as exc:
+            raise ModalHostJobError(
+                "computeFamily=modal requires the Modal SDK (pip install 'matraix[modal]')"
+            ) from exc
+        payload = {
+            "jobName": request.job_name,
+            "configYaml": request.config_yaml,
+            "jobsDir": "jobs",
+            "env": request.env,
+            "secretEnv": request.secret_env or collect_orchestrator_secret_env(),
+            "shardKey": request.shard_key,
+        }
+        function_name = modal_function_name_for_config(request.config_yaml)
+        try:
+            fn = modal.Function.from_name(MODAL_HOST_APP_NAME, function_name)
+        except Exception as exc:  # noqa: BLE001
+            raise ModalHostJobError(
+                "Modal Jobs function {}.{} is not reachable. "
+                "Deploy application/playground/backend/service/modal_host_app.py "
+                "({}).".format(MODAL_HOST_APP_NAME, function_name, exc)
+            ) from exc
+        return fn, payload
+
+    def _volume(self, request: ModalHostJobRequest) -> Any | None:
+        if not (request.live_jobs_dir or "").strip():
+            return None
+        try:
+            import modal
+        except ImportError:
+            return None
+        try:
+            return modal.Volume.from_name(
+                os.environ.get("MATRIX_MODAL_JOBS_VOLUME") or MODAL_JOBS_VOLUME_NAME
+            )
+        except Exception:
+            return None
+
+    def _result_from_raw(self, raw: Any) -> ModalHostJobResult:
+        if not isinstance(raw, dict):
+            raise ModalHostJobError("Modal Jobs returned an unexpected payload")
+        return ModalHostJobResult(
+            exit_code=int(raw.get("exitCode") if raw.get("exitCode") is not None else 1),
+            artifact_tar=_decode_artifact(raw),
+            error=str(raw["error"]) if raw.get("error") else None,
+            volume_path=str(raw["volumePath"]) if raw.get("volumePath") else None,
+        )
+
+
+def _decode_artifact(raw: dict[str, Any]) -> bytes | None:
+    artifact = raw.get("artifactTar")
+    if isinstance(artifact, (bytes, bytearray)):
+        return bytes(artifact)
+    encoded = raw.get("artifactTarB64")
+    if isinstance(encoded, str) and encoded:
+        import base64
+
+        return base64.b64decode(encoded)
+    return None
+
+
+def materialize_modal_artifacts(
+    result: ModalHostJobResult,
+    *,
+    jobs_dir: Path,
+    job_name: str,
+) -> Path:
+    dest = jobs_dir / job_name
+    dest.mkdir(parents=True, exist_ok=True)
+    if result.artifact_tar:
+        merge_job_artifacts(result.artifact_tar, jobs_dir=jobs_dir, job_name=job_name)
+    elif result.volume_path:
+        try:
+            import modal
+        except ImportError as exc:
+            raise ModalHostJobError(
+                "Modal Jobs wrote a volume path but the Modal SDK is not installed"
+            ) from exc
+        volume = modal.Volume.from_name(
+            os.environ.get("MATRIX_MODAL_JOBS_VOLUME") or MODAL_JOBS_VOLUME_NAME
+        )
+        download_volume_job(volume, job_name=result.volume_path, dest=dest)
+    else:
+        raise ModalHostJobError(
+            "Modal Jobs finished without returning jobs/{}/ artifacts".format(job_name)
+        )
+    return dest
+
+
+def default_modal_host_job_runner() -> ModalHostJobRunner:
+    return SdkModalHostJobRunner()
+
+
+def write_compute_json(job_dir: Path, plan: Any) -> Path:
+    job_dir.mkdir(parents=True, exist_ok=True)
+    path = job_dir / "compute.json"
+    payload = plan.to_public_dict() if hasattr(plan, "to_public_dict") else dict(plan)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return path

--- a/application/playground/backend/service/modal_sandbox_job.py
+++ b/application/playground/backend/service/modal_sandbox_job.py
@@ -1,0 +1,517 @@
+"""Run web/linux Harbor jobs in a Modal Sandbox with Docker.
+
+Playground starts the sandbox, persists its id in ``cloud_run.json``, and
+reattaches after an API restart. Artifacts land on the jobs Volume so a
+finished sandbox can still be pulled after it exits.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+from backend.service.modal_host_job import (
+    MODAL_DOCKER_IMAGES_VOLUME_NAME,
+    MODAL_HOST_APP_NAME,
+    MODAL_JOBS_VOLUME_NAME,
+    MODAL_REMOTE_REPO,
+    ModalHostJobError,
+    ModalHostJobRequest,
+    ModalHostJobResult,
+    apply_worker_live_status,
+    collect_live_status,
+    collect_orchestrator_secret_env,
+    execute_host_harbor_job,
+    LivePublishState,
+    modal_credentials_configured,
+    modal_sandbox_object_id,
+    modal_volume_job_name,
+    pull_live_progress,
+    publish_job_to_volume,
+    encode_modal_sandbox_call_id,
+)
+
+SANDBOX_LIVE_PATH = "/tmp/matraix-live.json"
+SANDBOX_RESULT_FILENAME = "_sandbox_result.json"
+SANDBOX_PAYLOAD_ENV = "MATRIX_SANDBOX_PAYLOAD"
+_SANDBOX_TIMEOUT_SEC = 2 * 60 * 60
+_LIVE_PATH = Path(SANDBOX_LIVE_PATH)
+
+
+def sandbox_jobs_volume_root() -> Path:
+    return Path("/modal-jobs")
+
+
+def sandbox_payload_remote_path(job_name: str, shard_key: str = "") -> str:
+    return "_payloads/{}.json".format(modal_volume_job_name(job_name, shard_key))
+
+
+def write_sandbox_live_status(job_dir: Path, dest: Path | None = None) -> dict[str, str]:
+    status = collect_live_status(job_dir) if job_dir.is_dir() else {}
+    target = dest if dest is not None else _LIVE_PATH
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(status, sort_keys=True) + "\n", encoding="utf-8")
+    return status
+
+
+def load_sandbox_payload(path: Path | None = None) -> dict[str, Any]:
+    raw_path = path or Path(
+        (os.environ.get(SANDBOX_PAYLOAD_ENV) or "").strip() or "/modal-jobs/_payloads/job.json"
+    )
+    last_error = "payload not found"
+    for _ in range(20):
+        try:
+            loaded = json.loads(raw_path.read_text(encoding="utf-8"))
+        except Exception as exc:  # noqa: BLE001
+            last_error = str(exc)
+            time.sleep(0.5)
+            continue
+        if isinstance(loaded, dict):
+            return loaded
+        last_error = "payload is not a JSON object"
+        break
+    raise ModalHostJobError(
+        "sandbox worker could not read {} ({})".format(raw_path, last_error)
+    )
+
+
+def run_sandbox_worker(payload: dict[str, Any] | None = None) -> int:
+    """Harbor + image cache inside the sandbox. Called as ``python -m``."""
+    from backend.service.modal_docker_prebuild import ensure_docker_daemon
+
+    ensure_docker_daemon()
+    loaded = payload if payload is not None else load_sandbox_payload()
+    request = ModalHostJobRequest(
+        job_name=str(loaded.get("jobName") or ""),
+        config_yaml=str(loaded.get("configYaml") or ""),
+        repo_root=MODAL_REMOTE_REPO,
+        jobs_dir="jobs",
+        env=dict(loaded.get("env") or {}),
+        secret_env={},
+        shard_key=str(loaded.get("shardKey") or "").strip(),
+    )
+    volume_name = modal_volume_job_name(request.job_name, request.shard_key)
+    volume_root = sandbox_jobs_volume_root()
+    live = LivePublishState()
+    jobs_volume = _mounted_volume(MODAL_JOBS_VOLUME_NAME, "MATRIX_MODAL_JOBS_VOLUME")
+    docker_volume = _mounted_volume(
+        MODAL_DOCKER_IMAGES_VOLUME_NAME, "MATRIX_MODAL_DOCKER_IMAGES_VOLUME"
+    )
+    if docker_volume is not None:
+        try:
+            docker_volume.reload()
+        except Exception:
+            pass
+
+    def _live_publish(job_dir: Path) -> None:
+        write_sandbox_live_status(job_dir)
+        if live.tick(
+            job_dir,
+            volume_root=volume_root,
+            job_name=volume_name,
+            status_key=volume_name,
+        ):
+            _commit_volume(jobs_volume)
+
+    result = execute_host_harbor_job(
+        request,
+        command_runner=_run_command,
+        work_root=Path(MODAL_REMOTE_REPO),
+        progress=_live_publish,
+    )
+    job_dir = Path(MODAL_REMOTE_REPO) / "jobs" / request.job_name
+    write_sandbox_live_status(job_dir)
+    volume_path = None
+    if job_dir.is_dir():
+        publish_job_to_volume(job_dir, volume_root=volume_root, job_name=volume_name)
+        volume_path = volume_name
+    _write_sandbox_result(volume_root / volume_name, result, volume_path)
+    live.tick(
+        job_dir,
+        volume_root=volume_root,
+        job_name=volume_name,
+        status_key=volume_name,
+        force=True,
+    )
+    _commit_volume(jobs_volume)
+    _commit_volume(docker_volume)
+    if result.error and result.exit_code == 0:
+        return 1
+    return int(result.exit_code)
+
+
+def wait_sandbox_with_live_pull(
+    sandbox: Any,
+    *,
+    request: ModalHostJobRequest,
+    volume: Any | None,
+    poll_sec: float = 5.0,
+) -> int:
+    dest = _live_dest(request)
+    volume_job_name = modal_volume_job_name(request.job_name, request.shard_key)
+    while True:
+        code = sandbox_returncode(sandbox)
+        if dest is not None:
+            pull_sandbox_live(
+                sandbox,
+                dest=dest,
+                volume=volume,
+                volume_job_name=volume_job_name,
+            )
+        if code is not None:
+            return int(code)
+        time.sleep(poll_sec if poll_sec > 0 else 0.5)
+
+
+def pull_sandbox_live(
+    sandbox: Any,
+    *,
+    dest: Path,
+    volume: Any | None,
+    volume_job_name: str,
+) -> None:
+    raw = sandbox_exec_bytes(sandbox, "cat", SANDBOX_LIVE_PATH)
+    if raw:
+        apply_worker_live_status(dest, raw)
+    pull_live_progress(volume=volume, volume_job_name=volume_job_name, dest=dest)
+
+
+def sandbox_returncode(sandbox: Any) -> int | None:
+    poll = getattr(sandbox, "poll", None)
+    if callable(poll):
+        try:
+            code = poll()
+        except Exception:
+            code = None
+        if code is not None:
+            return int(code)
+    code = getattr(sandbox, "returncode", None)
+    if code is None:
+        return None
+    return int(code)
+
+
+def sandbox_exec_bytes(sandbox: Any, *command: str) -> bytes:
+    execute = getattr(sandbox, "exec", None)
+    if not callable(execute):
+        return b""
+    try:
+        proc = execute(*command)
+    except Exception:
+        return b""
+    wait = getattr(proc, "wait", None)
+    if callable(wait):
+        try:
+            wait()
+        except Exception:
+            return b""
+    stdout = getattr(proc, "stdout", None)
+    if stdout is None:
+        return b""
+    read = getattr(stdout, "read", None)
+    if callable(read):
+        try:
+            data = read()
+        except Exception:
+            return b""
+        if isinstance(data, (bytes, bytearray)):
+            return bytes(data)
+        return str(data or "").encode("utf-8")
+    if isinstance(stdout, (bytes, bytearray)):
+        return bytes(stdout)
+    return str(stdout).encode("utf-8")
+
+
+def read_sandbox_result(volume: Any, volume_job_name: str) -> dict[str, Any] | None:
+    path = "{}/{}".format(volume_job_name.rstrip("/"), SANDBOX_RESULT_FILENAME)
+    try:
+        volume.reload()
+    except Exception:
+        pass
+    try:
+        raw = b"".join(volume.read_file(path))
+        loaded = json.loads(raw.decode("utf-8"))
+    except Exception:
+        return None
+    return loaded if isinstance(loaded, dict) else None
+
+
+class SdkModalSandboxJobRunner:
+    """Create a Docker-capable Modal Sandbox and wait until Harbor finishes."""
+
+    def spawn(self, request: ModalHostJobRequest) -> tuple[str, Any]:
+        runtime = self._runtime(request)
+        payload_path = sandbox_payload_remote_path(request.job_name, request.shard_key)
+        self._upload_payload(runtime["jobs_volume"], payload_path, request)
+        env = dict(runtime["worker_env"])
+        env["MATRIX_DOCKER_IMAGE_CACHE"] = "/modal-docker-images"
+        env[SANDBOX_PAYLOAD_ENV] = "/modal-jobs/{}".format(payload_path)
+        env.update(request.env)
+        env.update(request.secret_env or collect_orchestrator_secret_env())
+        try:
+            sandbox = runtime["modal"].Sandbox.create(
+                "bash",
+                "-lc",
+                "cd {} && python -m backend.service.modal_sandbox_job".format(
+                    MODAL_REMOTE_REPO
+                ),
+                app=runtime["app"],
+                image=runtime["image"],
+                timeout=_SANDBOX_TIMEOUT_SEC,
+                cpu=2,
+                memory=8192,
+                volumes={
+                    "/modal-jobs": runtime["jobs_volume"],
+                    "/modal-docker-images": runtime["docker_volume"],
+                },
+                secrets=runtime["secrets"],
+                env=env,
+                experimental_options={"enable_docker": True},
+            )
+        except Exception as exc:  # noqa: BLE001
+            raise ModalHostJobError(
+                "Modal Sandbox for {} could not be created. "
+                "Deploy application/playground/backend/service/modal_host_app.py "
+                "({}).".format(MODAL_HOST_APP_NAME, exc)
+            ) from exc
+        object_id = str(
+            getattr(sandbox, "object_id", None) or getattr(sandbox, "sandbox_id", None) or ""
+        )
+        if not object_id:
+            raise ModalHostJobError("Modal Sandbox did not return an id")
+        return encode_modal_sandbox_call_id(object_id), sandbox
+
+    def wait(
+        self,
+        request: ModalHostJobRequest,
+        *,
+        call: Any | None = None,
+        call_id: str = "",
+    ) -> ModalHostJobResult:
+        sandbox = call
+        object_id = modal_sandbox_object_id(call_id)
+        if sandbox is None and object_id:
+            try:
+                sandbox = self._runtime(request)["modal"].Sandbox.from_id(object_id)
+            except Exception as exc:  # noqa: BLE001
+                sandbox = None
+                from_id_error = exc
+            else:
+                from_id_error = None
+        else:
+            from_id_error = None
+        volume = self._jobs_volume()
+        volume_job_name = modal_volume_job_name(request.job_name, request.shard_key)
+        dest = _live_dest(request)
+        exit_code: int | None = None
+        if sandbox is not None:
+            try:
+                exit_code = wait_sandbox_with_live_pull(
+                    sandbox,
+                    request=request,
+                    volume=volume,
+                    poll_sec=_poll_sec(),
+                )
+            except Exception as exc:  # noqa: BLE001
+                raise ModalHostJobError(
+                    "Modal Sandbox {} is not reachable ({})".format(
+                        object_id or call_id, exc
+                    )
+                ) from exc
+        elif from_id_error is not None and volume is None:
+            raise ModalHostJobError(
+                "Modal Sandbox {} is not reachable ({})".format(object_id, from_id_error)
+            ) from from_id_error
+        if dest is not None:
+            pull_live_progress(
+                volume=volume,
+                volume_job_name=volume_job_name,
+                dest=dest,
+            )
+        stored = read_sandbox_result(volume, volume_job_name) if volume is not None else None
+        if exit_code is None and stored and stored.get("exitCode") is not None:
+            exit_code = int(stored["exitCode"])
+        if exit_code is None:
+            exit_code = 1
+        error = None
+        if stored and stored.get("error"):
+            error = str(stored["error"])
+        elif exit_code != 0:
+            error = "Modal Sandbox exited with code {}".format(exit_code)
+        volume_path = None
+        if stored and stored.get("volumePath"):
+            volume_path = str(stored["volumePath"])
+        elif volume is not None:
+            volume_path = volume_job_name
+        return ModalHostJobResult(
+            exit_code=exit_code,
+            error=error,
+            volume_path=volume_path,
+        )
+
+    def run(self, request: ModalHostJobRequest) -> ModalHostJobResult:
+        call_id, sandbox = self.spawn(request)
+        return self.wait(request, call=sandbox, call_id=call_id)
+
+    def _runtime(self, request: ModalHostJobRequest) -> dict[str, Any]:
+        del request
+        if not modal_credentials_configured():
+            raise ModalHostJobError(
+                "computeFamily=modal requires Modal credentials "
+                "(MODAL_TOKEN_ID and MODAL_TOKEN_SECRET, or ~/.modal.toml)"
+            )
+        try:
+            import modal
+        except ImportError as exc:
+            raise ModalHostJobError(
+                "computeFamily=modal requires the Modal SDK (pip install 'matraix[modal]')"
+            ) from exc
+        try:
+            from backend.service import modal_host_app as host_app
+        except Exception as exc:  # noqa: BLE001
+            raise ModalHostJobError(
+                "Modal sandbox image is not available ({})".format(exc)
+            ) from exc
+        try:
+            app = modal.App.lookup(MODAL_HOST_APP_NAME, create_if_missing=True)
+        except Exception as exc:  # noqa: BLE001
+            raise ModalHostJobError(
+                "Modal app {} is not reachable. "
+                "Deploy application/playground/backend/service/modal_host_app.py "
+                "({}).".format(MODAL_HOST_APP_NAME, exc)
+            ) from exc
+        return {
+            "modal": modal,
+            "app": app,
+            "image": host_app.docker_image,
+            "jobs_volume": host_app.volume,
+            "docker_volume": host_app.docker_images_volume,
+            "secrets": list(getattr(host_app, "_secrets", None) or []),
+            "worker_env": dict(getattr(host_app, "_WORKER_ENV", None) or {}),
+        }
+
+    def _upload_payload(self, volume: Any, remote_path: str, request: ModalHostJobRequest) -> None:
+        payload = {
+            "jobName": request.job_name,
+            "configYaml": request.config_yaml,
+            "env": request.env,
+            "shardKey": request.shard_key,
+        }
+        encoded = json.dumps(payload).encode("utf-8")
+        handle = tempfile.NamedTemporaryFile(delete=False, suffix=".json")
+        try:
+            handle.write(encoded)
+            handle.close()
+            with volume.batch_upload() as batch:
+                batch.put_file(handle.name, remote_path)
+        except Exception as exc:  # noqa: BLE001
+            raise ModalHostJobError(
+                "could not upload sandbox payload ({})".format(exc)
+            ) from exc
+        finally:
+            try:
+                os.unlink(handle.name)
+            except OSError:
+                pass
+
+    def _jobs_volume(self) -> Any | None:
+        try:
+            import modal
+        except ImportError:
+            return None
+        try:
+            return modal.Volume.from_name(
+                os.environ.get("MATRIX_MODAL_JOBS_VOLUME") or MODAL_JOBS_VOLUME_NAME
+            )
+        except Exception:
+            return None
+
+
+def _live_dest(request: ModalHostJobRequest) -> Path | None:
+    root = (request.live_jobs_dir or "").strip()
+    if not root:
+        return None
+    dest = Path(root) / request.job_name
+    dest.mkdir(parents=True, exist_ok=True)
+    return dest
+
+
+def _poll_sec() -> float:
+    raw = (os.environ.get("MATRIX_MODAL_LIVE_PULL_SEC") or "").strip()
+    try:
+        value = float(raw) if raw else 5.0
+    except ValueError:
+        value = 5.0
+    if value <= 0:
+        return 5.0
+    return max(value, 0.5)
+
+
+def _run_command(command: list[str], *, cwd: str, env: dict[str, str]) -> int:
+    completed = subprocess.run(command, cwd=cwd, env=env, check=False)
+    return int(completed.returncode)
+
+
+def _mounted_volume(default_name: str, env_name: str) -> Any | None:
+    try:
+        import modal
+    except ImportError:
+        return None
+    try:
+        return modal.Volume.from_name(os.environ.get(env_name) or default_name)
+    except Exception:
+        return None
+
+
+def _commit_volume(volume: Any | None) -> None:
+    if volume is None:
+        return
+    try:
+        volume.commit()
+    except Exception:
+        pass
+
+
+def _write_sandbox_result(
+    dest: Path,
+    result: ModalHostJobResult,
+    volume_path: str | None,
+) -> None:
+    dest.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "exitCode": int(result.exit_code),
+        "error": result.error,
+        "volumePath": volume_path,
+    }
+    (dest / SANDBOX_RESULT_FILENAME).write_text(
+        json.dumps(payload) + "\n", encoding="utf-8"
+    )
+
+
+def main() -> int:
+    try:
+        return run_sandbox_worker()
+    except Exception as exc:  # noqa: BLE001
+        volume_name = (os.environ.get("MATRIX_SANDBOX_VOLUME_NAME") or "").strip()
+        if volume_name:
+            try:
+                _write_sandbox_result(
+                    Path("/modal-jobs") / volume_name,
+                    ModalHostJobResult(exit_code=1, error=str(exc)),
+                    volume_name,
+                )
+                _commit_volume(
+                    _mounted_volume(MODAL_JOBS_VOLUME_NAME, "MATRIX_MODAL_JOBS_VOLUME")
+                )
+            except Exception:
+                pass
+        raise
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/application/playground/backend/tests/test_chatbot_reachability.py
+++ b/application/playground/backend/tests/test_chatbot_reachability.py
@@ -1,0 +1,111 @@
+"""Tests for chatbot URLs that Modal / GKE workers can reach."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from backend.service.chatbot_dev_tunnel import (
+    CHATBOT_TUNNEL_ENV,
+    ensure_dev_chatbot_tunnel,
+    loopback_origin,
+)
+from backend.service.chatbot_reachability import (
+    CHATBOT_PUBLIC_URL_ENV,
+    is_loopback_chatbot_url,
+    require_cloud_reachable_chatbot_url,
+    rewrite_chatbot_urls_for_cloud,
+)
+
+
+def test_is_loopback_chatbot_url() -> None:
+    assert is_loopback_chatbot_url("http://127.0.0.1:8905")
+    assert is_loopback_chatbot_url("http://localhost:8000/v1")
+    assert is_loopback_chatbot_url("http://host.docker.internal:8905")
+    assert not is_loopback_chatbot_url("https://chat.example.com")
+    assert not is_loopback_chatbot_url("http://10.0.0.8:8905")
+
+
+def test_loopback_origin_maps_unspecified_to_localhost() -> None:
+    assert loopback_origin("http://0.0.0.0:8905/v1") == "http://127.0.0.1:8905"
+    assert loopback_origin("http://127.0.0.1:8905") == "http://127.0.0.1:8905"
+
+
+def test_rewrite_replaces_loopback_with_public_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(CHATBOT_PUBLIC_URL_ENV, "https://abc.ngrok-free.app")
+    rewritten = rewrite_chatbot_urls_for_cloud(
+        {"CHATBOT_API_URL": "http://127.0.0.1:8905"}
+    )
+    assert rewritten["CHATBOT_API_URL"] == "https://abc.ngrok-free.app"
+
+
+def test_require_cloud_reachable_rejects_localhost_when_tunnel_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(CHATBOT_PUBLIC_URL_ENV, raising=False)
+    monkeypatch.setenv(CHATBOT_TUNNEL_ENV, "0")
+    monkeypatch.setenv("CHATBOT_API_URL", "http://127.0.0.1:8905")
+    with pytest.raises(ValueError, match="localhost is not visible|needs a chatbot URL"):
+        require_cloud_reachable_chatbot_url()
+
+
+def test_require_cloud_reachable_accepts_public(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(CHATBOT_PUBLIC_URL_ENV, raising=False)
+    monkeypatch.setenv("CHATBOT_API_URL", "https://chat.prod.example")
+    require_cloud_reachable_chatbot_url()
+
+
+def test_ensure_dev_chatbot_tunnel_sets_public_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    from backend.service import chatbot_dev_tunnel as tunnel
+
+    tunnel._tunnels.clear()
+    monkeypatch.delenv(CHATBOT_PUBLIC_URL_ENV, raising=False)
+    monkeypatch.setenv(CHATBOT_TUNNEL_ENV, "auto")
+    monkeypatch.setenv("CHATBOT_API_URL", "http://127.0.0.1:8905")
+
+    class _FakeProc:
+        def poll(self) -> None:
+            return None
+
+        def terminate(self) -> None:
+            return None
+
+    def _fake_start(origin: str, **kwargs: object) -> tuple[str, _FakeProc]:
+        assert origin == "http://127.0.0.1:8905"
+        return "https://demo.trycloudflare.com", _FakeProc()
+
+    monkeypatch.setattr(tunnel, "_start_tunnel", _fake_start)
+    url = ensure_dev_chatbot_tunnel()
+    assert url == "https://demo.trycloudflare.com"
+    assert os.environ[CHATBOT_PUBLIC_URL_ENV] == url
+    require_cloud_reachable_chatbot_url()
+    tunnel._tunnels.clear()
+
+
+def test_require_seeds_sidecar_url_then_tunnels(monkeypatch: pytest.MonkeyPatch) -> None:
+    from backend.service import chatbot_dev_tunnel as tunnel
+    from backend.service.chatbot_sidecar_service import ensure_sidecar_url_env
+
+    tunnel._tunnels.clear()
+    monkeypatch.delenv(CHATBOT_PUBLIC_URL_ENV, raising=False)
+    monkeypatch.delenv("CHATBOT_API_URL", raising=False)
+    monkeypatch.setenv(CHATBOT_TUNNEL_ENV, "auto")
+    ensure_sidecar_url_env("meal_planning_nutrition")
+    assert os.environ["CHATBOT_API_URL"] == "http://127.0.0.1:8905"
+
+    class _FakeProc:
+        def poll(self) -> None:
+            return None
+
+        def terminate(self) -> None:
+            return None
+
+    def _fake_start(origin: str, **kwargs: object) -> tuple[str, _FakeProc]:
+        assert origin == "http://127.0.0.1:8905"
+        return "https://demo.trycloudflare.com", _FakeProc()
+
+    monkeypatch.setattr(tunnel, "_start_tunnel", _fake_start)
+    require_cloud_reachable_chatbot_url()
+    assert os.environ[CHATBOT_PUBLIC_URL_ENV] == "https://demo.trycloudflare.com"
+    tunnel._tunnels.clear()

--- a/application/playground/backend/tests/test_chatbot_reachability.py
+++ b/application/playground/backend/tests/test_chatbot_reachability.py
@@ -50,6 +50,16 @@ def test_require_cloud_reachable_rejects_localhost_when_tunnel_off(
         require_cloud_reachable_chatbot_url()
 
 
+def test_require_cloud_reachable_defaults_to_no_tunnel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(CHATBOT_PUBLIC_URL_ENV, raising=False)
+    monkeypatch.delenv(CHATBOT_TUNNEL_ENV, raising=False)
+    monkeypatch.setenv("CHATBOT_API_URL", "http://127.0.0.1:8905")
+    with pytest.raises(ValueError, match="needs a chatbot URL"):
+        require_cloud_reachable_chatbot_url()
+
+
 def test_require_cloud_reachable_accepts_public(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv(CHATBOT_PUBLIC_URL_ENV, raising=False)
     monkeypatch.setenv("CHATBOT_API_URL", "https://chat.prod.example")

--- a/application/playground/backend/tests/test_chatbot_sidecar_service.py
+++ b/application/playground/backend/tests/test_chatbot_sidecar_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -16,6 +17,24 @@ def test_resolve_health_url_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     assert svc.resolve_health_url("acme_support_api") == "http://127.0.0.1:8904"
     assert svc.resolve_health_url("acme_support_mcp") == "http://127.0.0.1:8903"
     assert svc.resolve_health_url("meal_planning_nutrition") == "http://127.0.0.1:8905"
+
+
+def test_ensure_sidecar_url_env_seeds_meal_planning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("CHATBOT_API_URL", raising=False)
+    url = svc.ensure_sidecar_url_env("meal_planning_nutrition")
+    assert url == "http://127.0.0.1:8905"
+    assert os.environ["CHATBOT_API_URL"] == url
+
+
+def test_ensure_sidecar_url_env_keeps_existing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CHATBOT_API_URL", "https://chat.prod.example")
+    url = svc.ensure_sidecar_url_env("meal_planning_nutrition")
+    assert url == "https://chat.prod.example"
+    assert os.environ["CHATBOT_API_URL"] == url
 
 
 def test_sidecar_host_ports_are_unique() -> None:

--- a/application/playground/backend/tests/test_cohort_shard_planner.py
+++ b/application/playground/backend/tests/test_cohort_shard_planner.py
@@ -1,0 +1,177 @@
+"""Tests for cohort shard planner."""
+
+from __future__ import annotations
+
+from backend.service.cohort_shard_planner import (
+    plan_cohort_shards,
+    plan_job_config_shards,
+    plan_job_shards,
+    plan_pool_shards_from_manifest,
+    plan_shard_layout,
+    should_fanout_cloud_shards,
+    should_fanout_harbor_shards,
+)
+
+
+def test_plan_cohort_shards_splits_evenly():
+    ids = [f"{i:04d}" for i in range(1, 11)]
+    shards = plan_cohort_shards(ids, shard_size=4)
+    assert len(shards) == 3
+    assert shards[0].persona_ids == ("0001", "0002", "0003", "0004")
+    assert shards[0].shard_count == 3
+    assert shards[2].persona_ids == ("0009", "0010")
+    assert shards[2].limit == 2
+    # Shards are internal slices under one run’s plan.
+    assert [s.shard_index for s in shards] == [0, 1, 2]
+
+
+def test_plan_cohort_shards_empty():
+    assert plan_cohort_shards([], shard_size=100) == []
+
+
+def test_plan_pool_shards_from_manifest():
+    rows = [{"persona_id": "a"}, {"personaId": "b"}, {"other": 1}]
+    shards = plan_pool_shards_from_manifest(rows, shard_size=1)
+    assert [s.persona_ids for s in shards] == [("a",), ("b",)]
+
+
+def test_plan_job_config_shards_keeps_job_name():
+    config = {
+        "job_name": "batch-one",
+        "jobs_dir": "jobs",
+        "agents": [
+            {"name": "persona-json-survey", "kwargs": {"persona_path": "persona/p/persona_0001.yaml"}},
+            {"name": "persona-json-survey", "kwargs": {"persona_path": "persona/p/persona_0002.yaml"}},
+            {"name": "persona-json-survey", "kwargs": {"persona_path": "persona/p/persona_0003.yaml"}},
+        ],
+    }
+    planned = plan_job_config_shards(config, shard_size=2)
+    assert len(planned) == 2
+    assert planned[0][0].key == "s0"
+    assert planned[0][1]["job_name"] == "batch-one"
+    assert planned[1][1]["job_name"] == "batch-one"
+    assert len(planned[0][1]["agents"]) == 2
+    assert len(planned[1][1]["agents"]) == 1
+    assert should_fanout_cloud_shards("modal_jobs", 2)
+    assert not should_fanout_cloud_shards("modal_jobs", 1)
+    assert not should_fanout_cloud_shards(None, 5)
+    assert should_fanout_harbor_shards(
+        family="modal", environment="modal", dispatch=None, shard_count=2
+    )
+    assert should_fanout_harbor_shards(
+        family="gcp", environment="gke", dispatch=None, shard_count=3
+    )
+    assert not should_fanout_harbor_shards(
+        family="modal", environment="host", dispatch="modal_jobs", shard_count=4
+    )
+    assert not should_fanout_harbor_shards(
+        family="modal", environment="docker", dispatch="modal_jobs", shard_count=4
+    )
+    assert not should_fanout_harbor_shards(
+        family="local", environment="docker", dispatch=None, shard_count=20
+    )
+
+
+def test_shard_size_default_is_100(monkeypatch) -> None:
+    monkeypatch.delenv("MATRIX_SHARD_SIZE", raising=False)
+    from backend.service.cohort_shard_planner import (
+        DEFAULT_SHARD_SIZE,
+        shard_size_from_env,
+    )
+
+    assert DEFAULT_SHARD_SIZE == 100
+    assert shard_size_from_env() == 100
+
+
+def test_layout_small_parallel_stays_on_one_worker() -> None:
+    layout = plan_shard_layout(n=100, parallel=2, pack=32, max_workers=8)
+    assert layout.worker_count == 1
+    assert layout.effective_parallel == 2
+    assert layout.per_shard_concurrent == (2,)
+
+
+def test_layout_fills_pack_then_adds_workers() -> None:
+    layout = plan_shard_layout(n=100, parallel=64, pack=32, max_workers=8)
+    assert layout.requested_parallel == 64
+    assert layout.worker_count == 2
+    assert layout.per_shard_concurrent == (32, 32)
+    assert layout.effective_parallel == 64
+
+
+def test_layout_cluster_caps_parallel() -> None:
+    layout = plan_shard_layout(n=10000, parallel=500, pack=32, max_workers=8)
+    assert layout.worker_count == 8
+    assert layout.effective_parallel == 256
+    assert layout.per_shard_concurrent == (32,) * 8
+
+
+def test_layout_web_pack_one() -> None:
+    layout = plan_shard_layout(n=100, parallel=8, pack=1, max_workers=8)
+    assert layout.worker_count == 8
+    assert layout.effective_parallel == 8
+    assert layout.per_shard_concurrent == (1,) * 8
+
+
+def test_layout_remainder_goes_to_later_workers() -> None:
+    layout = plan_shard_layout(n=100, parallel=50, pack=32, max_workers=8)
+    assert layout.worker_count == 2
+    assert layout.per_shard_concurrent == (32, 18)
+    assert layout.effective_parallel == 50
+
+
+def test_layout_max_parallel_env_cap() -> None:
+    layout = plan_shard_layout(
+        n=1000, parallel=500, pack=32, max_workers=8, max_parallel=64
+    )
+    assert layout.requested_parallel == 500
+    assert layout.effective_parallel == 64
+    assert layout.worker_count == 2
+    assert layout.per_shard_concurrent == (32, 32)
+
+
+def test_demand_shards_keep_parent_parallel() -> None:
+    agents = [
+        {"name": "persona-json-survey", "kwargs": {"persona_path": f"persona/p/persona_{i:04d}.yaml"}}
+        for i in range(1, 5)
+    ]
+    config = {
+        "job_name": "batch-one",
+        "n_concurrent_trials": 2,
+        "agents": agents,
+    }
+    planned = plan_job_shards(config, trial_profile="json_survey", pack=32, max_workers=8)
+    assert planned.layout.worker_count == 1
+    assert len(planned.shards) == 1
+    assert planned.shards[0][1]["n_concurrent_trials"] == 2
+    assert config["n_concurrent_trials"] == 2
+
+
+def test_demand_shards_split_when_parallel_exceeds_pack() -> None:
+    agents = [
+        {"name": "persona-json-survey", "kwargs": {"persona_path": f"persona/p/persona_{i:04d}.yaml"}}
+        for i in range(1, 101)
+    ]
+    config = {
+        "job_name": "batch-one",
+        "n_concurrent_trials": 64,
+        "agents": agents,
+    }
+    planned = plan_job_shards(config, trial_profile="json_survey", pack=32, max_workers=8)
+    assert len(planned.shards) == 2
+    assert planned.shards[0][1]["n_concurrent_trials"] == 32
+    assert planned.shards[1][1]["n_concurrent_trials"] == 32
+    assert config["n_concurrent_trials"] == 64
+    assert len(planned.shards[0][1]["agents"]) == 50
+    assert len(planned.shards[1][1]["agents"]) == 50
+
+
+def test_demand_shards_do_not_split_on_shard_size_env(monkeypatch) -> None:
+    monkeypatch.setenv("MATRIX_SHARD_SIZE", "2")
+    agents = [
+        {"name": "persona-json-survey", "kwargs": {"persona_path": f"persona/p/persona_{i:04d}.yaml"}}
+        for i in range(1, 5)
+    ]
+    config = {"job_name": "batch-one", "n_concurrent_trials": 2, "agents": agents}
+    planned = plan_job_shards(config, trial_profile="json_survey", pack=32, max_workers=8)
+    assert len(planned.shards) == 1
+    assert planned.shards[0][1]["n_concurrent_trials"] == 2

--- a/application/playground/backend/tests/test_config.py
+++ b/application/playground/backend/tests/test_config.py
@@ -163,6 +163,8 @@ def test_options_environment_block(config_manager):
         "promptOwnership",
         "executionPlane",
         "remoteRunnerConfigured",
+        "computeFamily",
+        "computeFamilies",
     }
     assert env["runtime"] == "In-process Harbor runner"
     assert env["personaAgent"] == "Playground simulated user"

--- a/application/playground/backend/tests/test_gke_host_job.py
+++ b/application/playground/backend/tests/test_gke_host_job.py
@@ -1,0 +1,107 @@
+"""Tests for GKE host-worker helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from backend.service.gke_host_job import (
+    GKE_REMOTE_REPO,
+    GkeHostJobError,
+    GkeHostJobRequest,
+    build_gke_job_manifest,
+    gke_host_worker_script,
+    gke_job_name,
+    materialize_gke_artifacts,
+)
+from backend.service.modal_host_job import ModalHostJobResult, pack_job_dir
+
+
+def test_gke_job_name_is_dns_safe() -> None:
+    assert gke_job_name("pg-Example_Survey 1") == "matraix-host-pg-example-survey-1"
+    assert gke_job_name("pg-Example_Survey 1", "s1").endswith("-s1")
+    assert gke_job_name("pg-Example_Survey 1", "s0") != gke_job_name("pg-Example_Survey 1", "s1")
+
+
+def test_gke_host_worker_script_packs_job_tree() -> None:
+    script = gke_host_worker_script("demo-job")
+    assert "python -m harbor.cli.main run --yes -c /config/job.yaml" in script
+    assert "/tmp/matraix-exit" in script
+    assert "tar czf /tmp/matraix-job.tgz" in script
+    assert "python -c" in script
+    assert "/tmp/matraix-live.json" in script
+    assert "demo-job" in script
+
+
+def test_build_gke_job_manifest_uses_host_image_and_configmap() -> None:
+    request = GkeHostJobRequest(
+        job_name="demo-job",
+        config_yaml="job_name: demo-job\n",
+        env={"MATRIX_SURVEY_TASK_PATH": "application/tasks/example"},
+        secret_env={"ANTHROPIC_API_KEY": "sk-test"},
+    )
+    manifest = build_gke_job_manifest(
+        request,
+        image="us-central1-docker.pkg.dev/p/r/host:latest",
+        namespace="matraix",
+        pvc_name="jobs-pvc",
+    )
+    assert manifest["kind"] == "Job"
+    assert manifest["metadata"]["name"] == "matraix-host-demo-job"
+    assert manifest["metadata"]["namespace"] == "matraix"
+    container = manifest["spec"]["template"]["spec"]["containers"][0]
+    assert container["image"].endswith("host:latest")
+    assert container["command"] == ["/bin/sh", "-c"]
+    assert container["resources"]["requests"] == {"cpu": "1", "memory": "4Gi"}
+    env_names = {item["name"]: item["value"] for item in container["env"]}
+    assert env_names["ANTHROPIC_API_KEY"] == "sk-test"
+    assert env_names["MATRIX_REPO_ROOT"] == GKE_REMOTE_REPO
+    volumes = {item["name"]: item for item in manifest["spec"]["template"]["spec"]["volumes"]}
+    assert "configMap" in volumes["config"]
+    assert volumes["jobs"]["persistentVolumeClaim"]["claimName"] == "jobs-pvc"
+
+
+def test_materialize_gke_artifacts_preserves_compute_json(tmp_path: Path) -> None:
+    dest_jobs = tmp_path / "jobs"
+    dest = dest_jobs / "demo"
+    dest.mkdir(parents=True)
+    (dest / "compute.json").write_text(
+        '{"family": "gcp", "environment": "host", "dispatch": "gke_workers"}\n',
+        encoding="utf-8",
+    )
+    src = tmp_path / "remote" / "demo"
+    trial = src / "survey__abc"
+    trial.mkdir(parents=True)
+    (trial / "result.json").write_text(
+        '{"trial_uri": "file:///matraix/jobs/demo/survey__abc"}',
+        encoding="utf-8",
+    )
+    (src / "compute.json").write_text('{"family": "wrong"}\n', encoding="utf-8")
+    result = ModalHostJobResult(exit_code=0, artifact_tar=pack_job_dir(src))
+    merged = materialize_gke_artifacts(result, jobs_dir=dest_jobs, job_name="demo")
+    assert '"dispatch": "gke_workers"' in (merged / "compute.json").read_text(encoding="utf-8")
+    text = (merged / "survey__abc" / "result.json").read_text(encoding="utf-8")
+    assert "/matraix/jobs/demo" not in text
+    assert str(merged.resolve()) in text
+
+
+def test_materialize_gke_artifacts_requires_tree(tmp_path: Path) -> None:
+    with pytest.raises(GkeHostJobError, match="without returning"):
+        materialize_gke_artifacts(
+            ModalHostJobResult(exit_code=0),
+            jobs_dir=tmp_path / "jobs",
+            job_name="missing",
+        )
+
+
+def test_apply_gke_live_status_writes_overlay(tmp_path: Path) -> None:
+    from backend.service.gke_host_job import apply_gke_live_status
+    from backend.service.modal_host_job import read_live_overlay
+
+    dest = tmp_path / "jobs" / "demo"
+    dest.mkdir(parents=True)
+    status = apply_gke_live_status(dest, b'{"survey__a": "running", "survey__b": "done"}\n')
+    assert status == {"survey__a": "running", "survey__b": "done"}
+    assert read_live_overlay(dest)["survey__a"] == "running"
+    assert read_live_overlay(dest)["survey__b"] == "done"

--- a/application/playground/backend/tests/test_gke_host_job.py
+++ b/application/playground/backend/tests/test_gke_host_job.py
@@ -11,52 +11,86 @@ from backend.service.gke_host_job import (
     GkeHostJobError,
     GkeHostJobRequest,
     build_gke_job_manifest,
+    encode_gke_job_config,
     gke_host_worker_script,
     gke_job_name,
+    gke_jobs_dir,
     materialize_gke_artifacts,
 )
 from backend.service.modal_host_job import ModalHostJobResult, pack_job_dir
 
 
-def test_gke_job_name_is_dns_safe() -> None:
-    assert gke_job_name("pg-Example_Survey 1") == "matraix-host-pg-example-survey-1"
+def test_gke_job_name_is_dns_safe_and_unique() -> None:
+    name = gke_job_name("pg-Example_Survey 1")
+    assert name.startswith("matraix-h-")
+    assert name == name.lower()
+    assert len(name) <= 63
     assert gke_job_name("pg-Example_Survey 1", "s1").endswith("-s1")
-    assert gke_job_name("pg-Example_Survey 1", "s0") != gke_job_name("pg-Example_Survey 1", "s1")
+    assert gke_job_name("pg-Example_Survey 1", "s0") != gke_job_name(
+        "pg-Example_Survey 1", "s1"
+    )
+    long_a = gke_job_name("pg-example-survey-product-feedback-aaaaaaaa")
+    long_b = gke_job_name("pg-example-survey-product-feedback-bbbbbbbb")
+    assert long_a != long_b
+    assert len(long_a) <= 63
+    assert len(long_b) <= 63
+
+
+def test_gke_jobs_dir_isolates_shards() -> None:
+    assert gke_jobs_dir("") == "jobs"
+    assert gke_jobs_dir("s0") == "jobs/s0"
+
+
+def test_encode_gke_job_config_gzips_when_large(monkeypatch: pytest.MonkeyPatch) -> None:
+    from backend.service import gke_host_job as module
+
+    monkeypatch.setattr(module, "_CONFIGMAP_MAX_BYTES", 80)
+    small = encode_gke_job_config("job_name: demo\n")
+    assert "job.yaml" in small
+    huge = encode_gke_job_config("persona: " + "x" * 4000)
+    assert "job.yaml.gz.b64" in huge
+    assert "job.yaml" not in huge
 
 
 def test_gke_host_worker_script_packs_job_tree() -> None:
-    script = gke_host_worker_script("demo-job")
-    assert "python -m harbor.cli.main run --yes -c /config/job.yaml" in script
+    script = gke_host_worker_script("demo-job", jobs_dir="jobs/s0")
+    assert "python -m harbor.cli.main run --yes -c \"$CONFIG\"" in script
     assert "/tmp/matraix-exit" in script
     assert "tar czf /tmp/matraix-job.tgz" in script
+    assert "jobs/s0" in script
     assert "python -c" in script
     assert "/tmp/matraix-live.json" in script
     assert "demo-job" in script
 
 
-def test_build_gke_job_manifest_uses_host_image_and_configmap() -> None:
+def test_build_gke_job_manifest_uses_secret_ref_not_plaintext_key() -> None:
     request = GkeHostJobRequest(
         job_name="demo-job",
         config_yaml="job_name: demo-job\n",
         env={"MATRIX_SURVEY_TASK_PATH": "application/tasks/example"},
         secret_env={"ANTHROPIC_API_KEY": "sk-test"},
+        shard_key="s1",
     )
+    kube_name = gke_job_name("demo-job", "s1")
     manifest = build_gke_job_manifest(
         request,
         image="us-central1-docker.pkg.dev/p/r/host:latest",
         namespace="matraix",
         pvc_name="jobs-pvc",
+        secret_name=kube_name + "-sec",
     )
     assert manifest["kind"] == "Job"
-    assert manifest["metadata"]["name"] == "matraix-host-demo-job"
+    assert manifest["metadata"]["name"] == kube_name
     assert manifest["metadata"]["namespace"] == "matraix"
     container = manifest["spec"]["template"]["spec"]["containers"][0]
     assert container["image"].endswith("host:latest")
     assert container["command"] == ["/bin/sh", "-c"]
     assert container["resources"]["requests"] == {"cpu": "1", "memory": "4Gi"}
     env_names = {item["name"]: item["value"] for item in container["env"]}
-    assert env_names["ANTHROPIC_API_KEY"] == "sk-test"
+    assert "ANTHROPIC_API_KEY" not in env_names
     assert env_names["MATRIX_REPO_ROOT"] == GKE_REMOTE_REPO
+    assert env_names["MATRIX_GKE_JOBS_DIR"] == "jobs/s1"
+    assert container["envFrom"] == [{"secretRef": {"name": kube_name + "-sec"}}]
     volumes = {item["name"]: item for item in manifest["spec"]["template"]["spec"]["volumes"]}
     assert "configMap" in volumes["config"]
     assert volumes["jobs"]["persistentVolumeClaim"]["claimName"] == "jobs-pvc"

--- a/application/playground/backend/tests/test_harbor_job_service.py
+++ b/application/playground/backend/tests/test_harbor_job_service.py
@@ -859,6 +859,93 @@ def test_get_job_status_incremental(tmp_path):
     assert full["statuses"] == [2, 3, 0]
 
 
+def test_get_job_status_uses_live_overlay_without_trial_trees(tmp_path):
+    from backend.service.harbor_job_service import STATUS_CODE_DONE, STATUS_CODE_RUNNING
+    from backend.service.modal_host_job import apply_live_overlay
+
+    jobs_dir = tmp_path / "jobs"
+    job_dir = jobs_dir / "pg-batch"
+    job_dir.mkdir(parents=True)
+    apply_live_overlay(job_dir, {"survey__a": "done", "survey__b": "running"})
+
+    service = HarborJobService(
+        repo_root=tmp_path,
+        jobs_dir=jobs_dir,
+        generated_configs_dir=tmp_path / "generated",
+    )
+    snapshot = service.get_job_status("pg-batch", since=0)
+    assert snapshot["trialNames"] == ["survey__a", "survey__b"]
+    assert snapshot["statuses"][0] == STATUS_CODE_DONE
+    assert snapshot["statuses"][1] == STATUS_CODE_RUNNING
+    assert snapshot["counts"]["done"] == 1
+    assert snapshot["counts"]["running"] == 1
+
+
+def test_get_job_live_uses_live_overlay_without_trial_trees(tmp_path):
+    from backend.service.modal_host_job import apply_live_overlay
+
+    jobs_dir = tmp_path / "jobs"
+    job_dir = jobs_dir / "pg-batch"
+    job_dir.mkdir(parents=True)
+    apply_live_overlay(job_dir, {"survey__a": "done", "survey__b": "running"})
+
+    service = HarborJobService(
+        repo_root=tmp_path,
+        jobs_dir=jobs_dir,
+        generated_configs_dir=tmp_path / "generated",
+    )
+    live = service.get_job_live("pg-batch")
+    by_name = {row["trialName"]: row for row in live["trials"]}
+    assert by_name["survey__a"]["completed"] is True
+    assert by_name["survey__a"]["succeeded"] is True
+    assert by_name["survey__b"]["completed"] is False
+    assert by_name["survey__b"]["stage"] == "agent_running"
+    assert live["completedTrials"] == 1
+
+
+def test_get_trial_events_empty_before_trial_tree(tmp_path):
+    jobs_dir = tmp_path / "jobs"
+    job_dir = jobs_dir / "pg-batch"
+    job_dir.mkdir(parents=True)
+
+    service = HarborJobService(
+        repo_root=tmp_path,
+        jobs_dir=jobs_dir,
+        generated_configs_dir=tmp_path / "generated",
+    )
+    payload = service.get_trial_events("pg-batch", "survey__a")
+    assert payload == {"events": [], "offset": 0}
+
+
+def test_get_trial_web_trace_empty_before_trial_tree(tmp_path):
+    jobs_dir = tmp_path / "jobs"
+    job_dir = jobs_dir / "pg-web"
+    job_dir.mkdir(parents=True)
+
+    service = HarborJobService(
+        repo_root=tmp_path,
+        jobs_dir=jobs_dir,
+        generated_configs_dir=tmp_path / "generated",
+    )
+    payload = service.get_trial_web_trace("pg-web", "web__a")
+    assert payload == {"trace": {"events": [], "raw": {}}}
+
+
+def test_trial_live_screenshot_falls_back_to_disk(tmp_path):
+    jobs_dir = tmp_path / "jobs"
+    trial = jobs_dir / "pg-web" / "web__a"
+    images = trial / "agent" / "images"
+    images.mkdir(parents=True)
+    (images / "step_001.png").write_bytes(b"png-bytes")
+
+    service = HarborJobService(
+        repo_root=tmp_path,
+        jobs_dir=jobs_dir,
+        generated_configs_dir=tmp_path / "generated",
+    )
+    assert service.trial_live_screenshot("pg-web", "web__a") == b"png-bytes"
+
+
 def test_get_job_status_running_marker(tmp_path):
     jobs_dir = tmp_path / "jobs"
     job_dir = jobs_dir / "pg-batch"
@@ -1143,6 +1230,156 @@ def test_list_jobs_external_run_uses_freshness(tmp_path):
     rows = {row["jobName"]: row for row in service.list_jobs()}
     assert rows["job-external-live"]["status"] == "running"
     assert rows["job-external-dead"]["status"] == "failed"
+    service.shutdown()
+
+
+def test_list_jobs_external_run_uses_live_overlay_freshness(tmp_path):
+    import os
+    from datetime import datetime, timezone
+
+    jobs_dir = tmp_path / "jobs"
+    jobs_dir.mkdir()
+    now = datetime.now(timezone.utc).timestamp()
+    stale = now - EXTERNAL_RUN_STALE_AFTER_SEC - 120
+
+    job_dir = jobs_dir / "job-modal-overlay"
+    generated = job_dir / "_generated"
+    generated.mkdir(parents=True)
+    (job_dir / "trial-a").mkdir()
+    (job_dir / "result.json").write_text(
+        json.dumps(
+            {
+                "updated_at": datetime.fromtimestamp(stale, tz=timezone.utc).strftime(
+                    "%Y-%m-%dT%H:%M:%SZ"
+                ),
+                "stats": {"n_running_trials": 1, "n_pending_trials": 0},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (generated / "live_overlay.json").write_text("{}", encoding="utf-8")
+    for path in (job_dir, job_dir / "result.json", job_dir / "trial-a"):
+        os.utime(path, (stale, stale))
+
+    service = HarborJobService(
+        repo_root=tmp_path,
+        jobs_dir=jobs_dir,
+        generated_configs_dir=tmp_path / "configs",
+    )
+    rows = {row["jobName"]: row for row in service.list_jobs()}
+    assert rows["job-modal-overlay"]["status"] == "running"
+    service.shutdown()
+
+
+def test_list_jobs_counts_overlay_and_expected_agents(tmp_path):
+    from backend.service.modal_host_job import apply_live_overlay
+
+    jobs_dir = tmp_path / "jobs"
+    job_dir = jobs_dir / "pg-live"
+    job_dir.mkdir(parents=True)
+    (job_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "agents": [
+                    {"kwargs": {"persona_path": "pool/persona_a.yaml"}},
+                    {"kwargs": {"persona_path": "pool/persona_b.yaml"}},
+                    {"kwargs": {"persona_path": "pool/persona_c.yaml"}},
+                    {"kwargs": {"persona_path": "pool/persona_d.yaml"}},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    apply_live_overlay(job_dir, {"survey__a": "done", "survey__b": "running"})
+
+    service = HarborJobService(
+        repo_root=tmp_path,
+        jobs_dir=jobs_dir,
+        generated_configs_dir=tmp_path / "configs",
+    )
+    service._launches["pg-live"] = HarborLaunchRecord(
+        job_name="pg-live",
+        status="running",
+    )
+    rows = {row["jobName"]: row for row in service.list_jobs()}
+    assert rows["pg-live"]["trialCount"] == 4
+    assert rows["pg-live"]["completedTrials"] == 1
+    assert rows["pg-live"]["status"] == "running"
+    service.shutdown()
+
+
+def test_list_jobs_discounts_missing_reward_when_artifacts_exist(tmp_path):
+    import json
+
+    jobs_dir = tmp_path / "jobs"
+    jobs_dir.mkdir()
+
+    exp_job = jobs_dir / "exp-survey-onboarding-framing-1e9fd26e-c0"
+    trial = exp_job / "survey-onboarding-framing__persona-a"
+    (trial / "verifier").mkdir(parents=True)
+    (trial / "result.json").write_text(
+        json.dumps(
+            {
+                "exception_info": {
+                    "exception_type": "RewardFileNotFoundError",
+                    "exception_message": "Reward file not found",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (trial / "verifier" / "structured_output.json").write_text("{}", encoding="utf-8")
+    (exp_job / "result.json").write_text(
+        json.dumps(
+            {
+                "finished_at": "2026-08-25T12:00:00Z",
+                "n_total_trials": 1,
+                "stats": {"n_completed_trials": 1, "n_errored_trials": 1},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    pg_job = jobs_dir / "pg-survey-onboarding-framing-aa11bb22"
+    pg_trial = pg_job / "trial-a"
+    pg_trial.mkdir(parents=True)
+    (pg_trial / "result.json").write_text(
+        json.dumps(
+            {
+                "exception_info": {
+                    "exception_type": "RuntimeError",
+                    "exception_message": "auth failed",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (pg_job / "result.json").write_text(
+        json.dumps(
+            {
+                "finished_at": "2026-08-25T12:05:00Z",
+                "n_total_trials": 1,
+                "stats": {"n_completed_trials": 1, "n_errored_trials": 1},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    service = HarborJobService(
+        repo_root=tmp_path,
+        jobs_dir=jobs_dir,
+        generated_configs_dir=tmp_path / "configs",
+    )
+    rows = {row["jobName"]: row for row in service.list_jobs()}
+    assert rows[exp_job.name]["source"] == "experiment"
+    assert rows[exp_job.name]["status"] == "success"
+    assert rows[exp_job.name]["failedTrials"] == 0
+    assert rows[pg_job.name]["source"] == "playground"
+    assert rows[pg_job.name]["status"] == "failed"
+    detail = service.get_job(exp_job.name)
+    assert detail is not None
+    assert detail["trials"][0]["succeeded"] is True
+    assert detail["trials"][0]["error"] is None
     service.shutdown()
 
 

--- a/application/playground/backend/tests/test_harbor_jobs_api.py
+++ b/application/playground/backend/tests/test_harbor_jobs_api.py
@@ -86,8 +86,10 @@ class _FakeHarborJobService:
         return job_name
 
     def get_trial_events(self, job_name: str, trial_name: str, *, after: int = 0) -> dict[str, Any]:
-        if (job_name, trial_name) != ("demo-job", "trial-0"):
-            raise ValueError("Trial not found")
+        if job_name != "demo-job":
+            raise ValueError("Job not found")
+        if trial_name != "trial-0":
+            return {"events": [], "offset": after}
         events = [
             {"type": "phase", "phase": "persona_kickoff"},
             {"type": "turn", "turn": {"turnIndex": 1, "userMessage": "hi", "assistantMessage": "hello"}},
@@ -233,6 +235,12 @@ def test_get_harbor_trial_events(client, fake_harbor_jobs):
 
 def test_get_harbor_trial_events_missing(client, fake_harbor_jobs):
     resp = client.get("/api/harbor/jobs/demo-job/trials/missing/events")
+    assert resp.status_code == 200
+    assert resp.json() == {"events": [], "offset": 0}
+
+
+def test_get_harbor_trial_events_missing_job(client, fake_harbor_jobs):
+    resp = client.get("/api/harbor/jobs/missing-job/trials/trial-0/events")
     assert resp.status_code == 404
 
 

--- a/application/playground/backend/tests/test_harbor_web_trace.py
+++ b/application/playground/backend/tests/test_harbor_web_trace.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from backend.service.harbor_web_trace import (
     attach_harbor_trace_screenshot_urls,
+    latest_trial_screenshot_bytes,
     read_harbor_web_trace,
     resolve_trial_screenshot_path,
     screenshot_file_from_step,
@@ -112,3 +113,32 @@ def test_read_harbor_web_trace_from_cocoa_trial(tmp_path: Path) -> None:
     assert agent_event["screenshotUrl"].endswith("images/step_001.png")
     path = resolve_trial_screenshot_path(logs_dir, "images/step_001.png")
     assert path.is_file()
+
+
+def test_screenshot_file_from_step_normalizes_absolute_images_path() -> None:
+    step = {
+        "source": "agent",
+        "message": [
+            {
+                "type": "image",
+                "source": {"path": "/sandbox/logs/images/step_009.png"},
+            }
+        ],
+    }
+    assert screenshot_file_from_step(step) == "images/step_009.png"
+
+
+def test_latest_trial_screenshot_bytes(tmp_path: Path) -> None:
+    trial = tmp_path / "trial"
+    images = trial / "agent" / "images"
+    images.mkdir(parents=True)
+    older = images / "step_001.png"
+    newer = images / "step_002.png"
+    older.write_bytes(b"old")
+    newer.write_bytes(b"new")
+    older.touch()
+    import time
+
+    time.sleep(0.02)
+    newer.write_bytes(b"new")
+    assert latest_trial_screenshot_bytes(trial) == b"new"

--- a/application/playground/backend/tests/test_job_result_rollup.py
+++ b/application/playground/backend/tests/test_job_result_rollup.py
@@ -1,0 +1,37 @@
+"""Tests for sharded job-level result.json rollup."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from backend.service.job_result_rollup import expected_trial_count, synthesize_job_result
+
+
+def test_expected_trial_count() -> None:
+    assert expected_trial_count({"agents": [{}, {}, {}], "tasks": [{}], "n_attempts": 1}) == 3
+
+
+def test_synthesize_job_result_counts_trials(tmp_path: Path) -> None:
+    job_dir = tmp_path / "jobs" / "demo"
+    ok = job_dir / "t_ok"
+    bad = job_dir / "t_bad"
+    ok.mkdir(parents=True)
+    bad.mkdir(parents=True)
+    (ok / "result.json").write_text("{}\n", encoding="utf-8")
+    (bad / "result.json").write_text(
+        '{"exception_info": {"exception_type": "TimeoutError"}}\n',
+        encoding="utf-8",
+    )
+    (job_dir / "_generated").mkdir()
+    path = synthesize_job_result(
+        job_dir,
+        job_config={"agents": [{}, {}, {}, {}], "tasks": [{}]},
+        started_at="2026-01-01T00:00:00Z",
+        finished=True,
+    )
+    payload = __import__("json").loads(path.read_text(encoding="utf-8"))
+    assert payload["n_total_trials"] == 4
+    assert payload["stats"]["n_completed_trials"] == 2
+    assert payload["stats"]["n_errored_trials"] == 3
+    assert payload["finished_at"]
+    assert "trial_results" not in payload

--- a/application/playground/backend/tests/test_modal_compute_launch.py
+++ b/application/playground/backend/tests/test_modal_compute_launch.py
@@ -1,0 +1,705 @@
+"""Tests for Modal compute-family Harbor launches."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from backend.service.harbor_job_service import HarborJobService
+
+
+def test_launch_modal_family_survey_uses_modal_jobs(tmp_path, monkeypatch) -> None:
+    repo = tmp_path
+    jobs_dir = repo / "jobs"
+    jobs_dir.mkdir()
+    (repo / "persona" / "datasets" / "matraix-persona-dev-sample").mkdir(parents=True)
+    (repo / "persona" / "datasets" / "matraix-persona-dev-sample" / "persona_0001.yaml").write_text(
+        "persona_id: '0001'\nversion: '1.0'\nsource: Nemotron\ndimensions: {}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("playground.harbor.playground._repo_root", lambda: repo)
+
+    class _FakeModalRunner:
+        def __init__(self) -> None:
+            self.calls: list[object] = []
+
+        def run(self, request):
+            from backend.service.modal_host_job import ModalHostJobResult, pack_job_dir
+
+            self.calls.append(request)
+            trial = jobs_dir / request.job_name / "survey__trial"
+            trial.mkdir(parents=True)
+            (trial / "result.json").write_text("{}", encoding="utf-8")
+            return ModalHostJobResult(exit_code=0, artifact_tar=pack_job_dir(jobs_dir / request.job_name))
+
+    fake = _FakeModalRunner()
+    service = HarborJobService(
+        repo_root=repo,
+        jobs_dir=jobs_dir,
+        generated_configs_dir=repo / "configs" / "jobs" / "application-task-job-recipe",
+        command_runner=lambda *args, **kwargs: 0,
+        harbor_command=("echo", "harbor"),
+        modal_host_job_runner=fake,
+    )
+    job_name = service.launch(
+        task_path="application/tasks/example-survey_product-feedback",
+        persona_ids=["0001"],
+        persona_pool="persona/datasets/matraix-persona-dev-sample",
+        job_name="modal-survey",
+        compute_family="modal",
+        execution_plane="harbor",
+    )
+    service._executor.shutdown(wait=True)
+    launch = service._launches[job_name]
+    assert launch.compute_family == "modal"
+    assert launch.compute_environment == "host"
+    assert launch.compute_dispatch == "modal_jobs"
+    assert fake.calls
+    assert fake.calls[0].live_jobs_dir == str(jobs_dir.resolve())
+    config_text = (repo / "configs" / "jobs" / "application-task-job-recipe" / "modal-survey.yaml").read_text(
+        encoding="utf-8"
+    )
+    assert "type: host" in config_text
+    assert "dispatch=modal_jobs" in config_text
+    compute = (jobs_dir / job_name / "compute.json").read_text(encoding="utf-8")
+    assert '"dispatch": "modal_jobs"' in compute
+    assert '"family": "modal"' in compute
+    assert (jobs_dir / job_name / "survey__trial" / "result.json").is_file()
+
+
+def test_launch_modal_family_survey_fans_out_shards(tmp_path, monkeypatch) -> None:
+    repo = tmp_path
+    jobs_dir = repo / "jobs"
+    jobs_dir.mkdir()
+    pool = repo / "persona" / "datasets" / "matraix-persona-dev-sample"
+    pool.mkdir(parents=True)
+    for index in range(1, 5):
+        pid = f"{index:04d}"
+        (pool / f"persona_{pid}.yaml").write_text(
+            f"persona_id: '{pid}'\nversion: '1.0'\nsource: Nemotron\ndimensions: {{}}\n",
+            encoding="utf-8",
+        )
+    monkeypatch.setattr("playground.harbor.playground._repo_root", lambda: repo)
+    monkeypatch.setenv("MATRIX_HOST_PACK_CONCURRENCY", "1")
+    monkeypatch.setenv("MATRIX_SHARD_CONCURRENCY", "2")
+
+    class _FakeModalRunner:
+        def __init__(self) -> None:
+            self.calls: list[object] = []
+
+        def run(self, request):
+            from backend.service.modal_host_job import ModalHostJobResult, pack_job_dir
+
+            self.calls.append(request)
+            isolated = repo / "worker" / (request.shard_key or "s0") / request.job_name
+            trial = isolated / "survey__{}".format(request.shard_key or "s0")
+            trial.mkdir(parents=True)
+            (trial / "result.json").write_text("{}", encoding="utf-8")
+            (isolated / "result.json").write_text('{"shard": true}\n', encoding="utf-8")
+            return ModalHostJobResult(exit_code=0, artifact_tar=pack_job_dir(isolated))
+
+    fake = _FakeModalRunner()
+    service = HarborJobService(
+        repo_root=repo,
+        jobs_dir=jobs_dir,
+        generated_configs_dir=repo / "configs" / "jobs" / "application-task-job-recipe",
+        command_runner=lambda *args, **kwargs: 0,
+        harbor_command=("echo", "harbor"),
+        modal_host_job_runner=fake,
+    )
+    job_name = service.launch(
+        task_path="application/tasks/example-survey_product-feedback",
+        persona_ids=["0001", "0002", "0003", "0004"],
+        persona_pool="persona/datasets/matraix-persona-dev-sample",
+        job_name="modal-sharded",
+        compute_family="modal",
+        execution_plane="harbor",
+    )
+    service._executor.shutdown(wait=True)
+    launch = service._launches[job_name]
+    assert launch.status == "completed"
+    assert launch.compute_dispatch == "modal_jobs"
+    assert len(fake.calls) == 2
+    assert {call.job_name for call in fake.calls} == {"modal-sharded"}
+    assert {call.shard_key for call in fake.calls} == {"s0", "s1"}
+    job_dir = jobs_dir / job_name
+    assert (job_dir / "compute.json").is_file()
+    assert (job_dir / "survey__s0" / "result.json").is_file()
+    assert (job_dir / "survey__s1" / "result.json").is_file()
+    rolled = json.loads((job_dir / "result.json").read_text(encoding="utf-8"))
+    assert rolled["n_total_trials"] == 4
+    assert rolled["stats"]["n_completed_trials"] == 2
+    assert rolled.get("finished_at")
+    assert (job_dir / "_generated" / "shards.json").is_file()
+    parent = (repo / "configs" / "jobs" / "application-task-job-recipe" / "modal-sharded.yaml").read_text(
+        encoding="utf-8"
+    )
+    shard0 = (
+        repo / "configs" / "jobs" / "application-task-job-recipe" / "modal-sharded.shard-00.yaml"
+    ).read_text(encoding="utf-8")
+    assert parent.count("persona_path:") == 4
+    assert shard0.count("persona_path:") == 2
+    assert "job_name: modal-sharded" in shard0
+    assert "n_concurrent_trials: 2" in parent
+    assert "n_concurrent_trials: 1" in shard0
+
+
+def test_retry_failed_only_rediscovers_failed_shards(tmp_path, monkeypatch) -> None:
+    import time
+
+    repo = tmp_path
+    jobs_dir = repo / "jobs"
+    jobs_dir.mkdir()
+    pool = repo / "persona" / "datasets" / "matraix-persona-dev-sample"
+    pool.mkdir(parents=True)
+    for index in range(1, 5):
+        pid = f"{index:04d}"
+        (pool / f"persona_{pid}.yaml").write_text(
+            f"persona_id: '{pid}'\nversion: '1.0'\nsource: Nemotron\ndimensions: {{}}\n",
+            encoding="utf-8",
+        )
+    monkeypatch.setattr("playground.harbor.playground._repo_root", lambda: repo)
+    monkeypatch.setenv("MATRIX_HOST_PACK_CONCURRENCY", "1")
+
+    class _FakeModalRunner:
+        def __init__(self) -> None:
+            self.calls: list[object] = []
+
+        def run(self, request):
+            import shutil
+
+            import yaml
+
+            from backend.service.modal_host_job import ModalHostJobResult, pack_job_dir
+
+            self.calls.append(request)
+            loaded = yaml.safe_load(request.config_yaml) or {}
+            agents = [row for row in (loaded.get("agents") or []) if isinstance(row, dict)]
+            isolated = repo / "worker" / (request.shard_key or "s0") / request.job_name
+            if isolated.exists():
+                shutil.rmtree(isolated)
+            fail_ids = {"0003", "0004"} if len(self.calls) <= 2 else set()
+            for agent in agents:
+                path = str((agent.get("kwargs") or {}).get("persona_path") or "")
+                pid = Path(path).stem.replace("persona_", "") or "x"
+                trial = isolated / "survey__{}".format(pid)
+                trial.mkdir(parents=True)
+                (trial / "persona_meta.json").write_text(
+                    json.dumps({"persona_id": pid}) + "\n",
+                    encoding="utf-8",
+                )
+                payload = (
+                    {"exception_info": {"exception_type": "TimeoutError"}}
+                    if pid in fail_ids
+                    else {}
+                )
+                (trial / "result.json").write_text(json.dumps(payload) + "\n", encoding="utf-8")
+            return ModalHostJobResult(exit_code=0, artifact_tar=pack_job_dir(isolated))
+
+    fake = _FakeModalRunner()
+    service = HarborJobService(
+        repo_root=repo,
+        jobs_dir=jobs_dir,
+        generated_configs_dir=repo / "configs" / "jobs" / "application-task-job-recipe",
+        command_runner=lambda *args, **kwargs: 0,
+        harbor_command=("echo", "harbor"),
+        modal_host_job_runner=fake,
+    )
+
+    def _wait() -> None:
+        for _ in range(100):
+            status = service._launches[job_name].status
+            if status in {"completed", "failed"}:
+                return
+            time.sleep(0.02)
+        raise AssertionError("launch did not finish")
+
+    job_name = service.launch(
+        task_path="application/tasks/example-survey_product-feedback",
+        persona_ids=["0001", "0002", "0003", "0004"],
+        persona_pool="persona/datasets/matraix-persona-dev-sample",
+        job_name="modal-retry",
+        compute_family="modal",
+        execution_plane="harbor",
+    )
+    _wait()
+    first_calls = len(fake.calls)
+    assert first_calls == 2
+    retried = service.retry_failed(job_name)
+    assert retried["retried"] == 2
+    _wait()
+    service._executor.shutdown(wait=True)
+    assert len(fake.calls) == first_calls + 1
+    assert fake.calls[-1].shard_key == "s1"
+    assert fake.calls[-1].config_yaml.count("persona_path:") == 2
+
+
+def test_launch_modal_family_web_writes_harbor_docker(tmp_path, monkeypatch) -> None:
+    repo = tmp_path
+    jobs_dir = repo / "jobs"
+    jobs_dir.mkdir()
+    (repo / "persona" / "datasets" / "matraix-persona-dev-sample").mkdir(parents=True)
+    (repo / "persona" / "datasets" / "matraix-persona-dev-sample" / "persona_0001.yaml").write_text(
+        "persona_id: '0001'\nversion: '1.0'\nsource: Nemotron\ndimensions: {}\n",
+        encoding="utf-8",
+    )
+    task = repo / "application" / "tasks" / "example-web_bookshop"
+    task.mkdir(parents=True)
+    (task / "task.toml").write_text(
+        '[task]\nname = "web-demo"\n[metadata]\ntype = "web"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("playground.harbor.playground._repo_root", lambda: repo)
+
+    class _FakeModalRunner:
+        def __init__(self) -> None:
+            self.calls: list[object] = []
+
+        def run(self, request):
+            from backend.service.modal_host_job import ModalHostJobResult, pack_job_dir
+
+            self.calls.append(request)
+            trial = jobs_dir / request.job_name / "web__trial"
+            trial.mkdir(parents=True)
+            (trial / "result.json").write_text("{}", encoding="utf-8")
+            return ModalHostJobResult(
+                exit_code=0, artifact_tar=pack_job_dir(jobs_dir / request.job_name)
+            )
+
+    fake = _FakeModalRunner()
+    service = HarborJobService(
+        repo_root=repo,
+        jobs_dir=jobs_dir,
+        generated_configs_dir=repo / "configs" / "jobs" / "application-task-job-recipe",
+        command_runner=lambda *args, **kwargs: 0,
+        harbor_command=("echo", "harbor"),
+        modal_host_job_runner=fake,
+    )
+    job_name = service.launch(
+        task_path="application/tasks/example-web_bookshop",
+        persona_ids=["0001"],
+        persona_pool="persona/datasets/matraix-persona-dev-sample",
+        agent_name="persona-computer-1",
+        job_name="modal-web",
+        compute_family="modal",
+        execution_plane="harbor",
+    )
+    service._executor.shutdown(wait=True)
+    launch = service._launches[job_name]
+    assert launch.compute_family == "modal"
+    assert launch.compute_environment == "docker"
+    assert launch.compute_dispatch == "modal_jobs"
+    assert fake.calls
+    config_text = (repo / "configs" / "jobs" / "application-task-job-recipe" / "modal-web.yaml").read_text(
+        encoding="utf-8"
+    )
+    assert "type: docker" in config_text
+    assert "dispatch=modal_jobs" in config_text
+    compute = (jobs_dir / job_name / "compute.json").read_text(encoding="utf-8")
+    assert '"dispatch": "modal_jobs"' in compute
+    assert '"environment": "docker"' in compute
+
+
+def test_launch_modal_family_web_fans_out_modal_jobs(tmp_path, monkeypatch) -> None:
+    repo = tmp_path
+    jobs_dir = repo / "jobs"
+    jobs_dir.mkdir()
+    pool = repo / "persona" / "datasets" / "matraix-persona-dev-sample"
+    pool.mkdir(parents=True)
+    for index in range(1, 5):
+        pid = f"{index:04d}"
+        (pool / f"persona_{pid}.yaml").write_text(
+            f"persona_id: '{pid}'\nversion: '1.0'\nsource: Nemotron\ndimensions: {{}}\n",
+            encoding="utf-8",
+        )
+    task = repo / "application" / "tasks" / "example-web_bookshop"
+    task.mkdir(parents=True)
+    (task / "task.toml").write_text(
+        '[task]\nname = "web-demo"\n[metadata]\ntype = "web"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("playground.harbor.playground._repo_root", lambda: repo)
+    monkeypatch.setenv("MATRIX_WEB_PACK_CONCURRENCY", "1")
+    monkeypatch.setenv("MATRIX_SHARD_CONCURRENCY", "2")
+
+    class _FakeModalRunner:
+        def __init__(self) -> None:
+            self.calls: list[object] = []
+
+        def run(self, request):
+            from backend.service.modal_host_job import ModalHostJobResult, pack_job_dir
+
+            self.calls.append(request)
+            isolated = repo / "worker" / (request.shard_key or "s0") / request.job_name
+            trial = isolated / "web__{}".format(request.shard_key or "s0")
+            trial.mkdir(parents=True)
+            (trial / "result.json").write_text("{}\n", encoding="utf-8")
+            (isolated / "result.json").write_text('{"shard": true}\n', encoding="utf-8")
+            return ModalHostJobResult(exit_code=0, artifact_tar=pack_job_dir(isolated))
+
+    fake = _FakeModalRunner()
+    service = HarborJobService(
+        repo_root=repo,
+        jobs_dir=jobs_dir,
+        generated_configs_dir=repo / "configs" / "jobs" / "application-task-job-recipe",
+        command_runner=lambda *args, **kwargs: 0,
+        harbor_command=("echo", "harbor"),
+        modal_host_job_runner=fake,
+    )
+    job_name = service.launch(
+        task_path="application/tasks/example-web_bookshop",
+        persona_ids=["0001", "0002", "0003", "0004"],
+        persona_pool="persona/datasets/matraix-persona-dev-sample",
+        agent_name="persona-computer-1",
+        job_name="modal-web-shards",
+        compute_family="modal",
+        execution_plane="harbor",
+    )
+    service._executor.shutdown(wait=True)
+    launch = service._launches[job_name]
+    assert launch.status == "completed"
+    assert launch.compute_environment == "docker"
+    assert launch.compute_dispatch == "modal_jobs"
+    assert len(fake.calls) == 2
+    job_dir = jobs_dir / job_name
+    assert (job_dir / "compute.json").is_file()
+    assert (job_dir / "web__s0" / "result.json").is_file()
+    assert (job_dir / "web__s1" / "result.json").is_file()
+    rolled = json.loads((job_dir / "result.json").read_text(encoding="utf-8"))
+    assert rolled["n_total_trials"] == 4
+    assert rolled.get("finished_at")
+    shard0 = (
+        repo / "configs" / "jobs" / "application-task-job-recipe" / "modal-web-shards.shard-00.yaml"
+    ).read_text(encoding="utf-8")
+    assert "type: docker" in shard0
+    assert "job_name: modal-web-shards" in shard0
+
+
+def test_launch_modal_survey_requires_credentials(tmp_path, monkeypatch) -> None:
+    repo = tmp_path
+    jobs_dir = repo / "jobs"
+    jobs_dir.mkdir()
+    (repo / "persona" / "datasets" / "matraix-persona-dev-sample").mkdir(parents=True)
+    (repo / "persona" / "datasets" / "matraix-persona-dev-sample" / "persona_0001.yaml").write_text(
+        "persona_id: '0001'\nversion: '1.0'\nsource: Nemotron\ndimensions: {}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("playground.harbor.playground._repo_root", lambda: repo)
+    monkeypatch.delenv("MODAL_TOKEN_ID", raising=False)
+    monkeypatch.delenv("MODAL_TOKEN_SECRET", raising=False)
+    monkeypatch.setattr(
+        "backend.service.modal_host_job.modal_credentials_configured",
+        lambda: False,
+    )
+
+    service = HarborJobService(
+        repo_root=repo,
+        jobs_dir=jobs_dir,
+        generated_configs_dir=repo / "configs" / "jobs" / "application-task-job-recipe",
+        command_runner=lambda *args, **kwargs: 0,
+        harbor_command=("echo", "harbor"),
+    )
+    try:
+        service.launch(
+            task_path="application/tasks/example-survey_product-feedback",
+            persona_ids=["0001"],
+            persona_pool="persona/datasets/matraix-persona-dev-sample",
+            compute_family="modal",
+        )
+        raise AssertionError("expected missing Modal credentials to fail")
+    except ValueError as exc:
+        assert "Modal" in str(exc)
+
+
+def test_launch_gcp_survey_requires_host_workers(tmp_path, monkeypatch) -> None:
+    repo = tmp_path
+    jobs_dir = repo / "jobs"
+    jobs_dir.mkdir()
+    (repo / "persona" / "datasets" / "matraix-persona-dev-sample").mkdir(parents=True)
+    (repo / "persona" / "datasets" / "matraix-persona-dev-sample" / "persona_0001.yaml").write_text(
+        "persona_id: '0001'\nversion: '1.0'\nsource: Nemotron\ndimensions: {}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("playground.harbor.playground._repo_root", lambda: repo)
+    monkeypatch.setattr("matraix.gke_settings.gke_host_workers_ready", lambda: False)
+    service = HarborJobService(
+        repo_root=repo,
+        jobs_dir=jobs_dir,
+        generated_configs_dir=repo / "configs" / "jobs" / "application-task-job-recipe",
+        command_runner=lambda *args, **kwargs: 0,
+        harbor_command=("echo", "harbor"),
+    )
+    with pytest.raises(ValueError, match="MATRIX_GKE_HOST_IMAGE"):
+        service.launch(
+            task_path="application/tasks/example-survey_product-feedback",
+            persona_ids=["0001"],
+            persona_pool="persona/datasets/matraix-persona-dev-sample",
+            compute_family="gcp",
+        )
+
+
+def test_launch_gcp_family_survey_uses_gke_workers(tmp_path, monkeypatch) -> None:
+    repo = tmp_path
+    jobs_dir = repo / "jobs"
+    jobs_dir.mkdir()
+    (repo / "persona" / "datasets" / "matraix-persona-dev-sample").mkdir(parents=True)
+    (repo / "persona" / "datasets" / "matraix-persona-dev-sample" / "persona_0001.yaml").write_text(
+        "persona_id: '0001'\nversion: '1.0'\nsource: Nemotron\ndimensions: {}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("playground.harbor.playground._repo_root", lambda: repo)
+
+    class _FakeGkeRunner:
+        def __init__(self) -> None:
+            self.calls: list[object] = []
+
+        def run(self, request):
+            from backend.service.modal_host_job import ModalHostJobResult, pack_job_dir
+
+            self.calls.append(request)
+            trial = jobs_dir / request.job_name / "survey__trial"
+            trial.mkdir(parents=True)
+            (trial / "result.json").write_text("{}", encoding="utf-8")
+            return ModalHostJobResult(exit_code=0, artifact_tar=pack_job_dir(jobs_dir / request.job_name))
+
+    fake = _FakeGkeRunner()
+    service = HarborJobService(
+        repo_root=repo,
+        jobs_dir=jobs_dir,
+        generated_configs_dir=repo / "configs" / "jobs" / "application-task-job-recipe",
+        command_runner=lambda *args, **kwargs: 0,
+        harbor_command=("echo", "harbor"),
+        gke_host_job_runner=fake,
+    )
+    job_name = service.launch(
+        task_path="application/tasks/example-survey_product-feedback",
+        persona_ids=["0001"],
+        persona_pool="persona/datasets/matraix-persona-dev-sample",
+        job_name="gke-survey",
+        compute_family="gcp",
+        execution_plane="harbor",
+    )
+    service._executor.shutdown(wait=True)
+    launch = service._launches[job_name]
+    assert launch.compute_family == "gcp"
+    assert launch.compute_environment == "host"
+    assert launch.compute_dispatch == "gke_workers"
+    assert fake.calls
+    config_text = (repo / "configs" / "jobs" / "application-task-job-recipe" / "gke-survey.yaml").read_text(
+        encoding="utf-8"
+    )
+    assert "type: host" in config_text
+    assert "dispatch=gke_workers" in config_text
+    compute = (jobs_dir / job_name / "compute.json").read_text(encoding="utf-8")
+    assert '"dispatch": "gke_workers"' in compute
+    assert '"family": "gcp"' in compute
+    assert (jobs_dir / job_name / "survey__trial" / "result.json").is_file()
+
+
+def test_launch_gcp_family_web_writes_harbor_gke(tmp_path, monkeypatch) -> None:
+    repo = tmp_path
+    jobs_dir = repo / "jobs"
+    jobs_dir.mkdir()
+    (repo / "persona" / "datasets" / "matraix-persona-dev-sample").mkdir(parents=True)
+    (repo / "persona" / "datasets" / "matraix-persona-dev-sample" / "persona_0001.yaml").write_text(
+        "persona_id: '0001'\nversion: '1.0'\nsource: Nemotron\ndimensions: {}\n",
+        encoding="utf-8",
+    )
+    task = repo / "application" / "tasks" / "example-web_bookshop"
+    task.mkdir(parents=True)
+    (task / "task.toml").write_text(
+        '[task]\nname = "web-demo"\n[metadata]\ntype = "web"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("playground.harbor.playground._repo_root", lambda: repo)
+    monkeypatch.setenv("MATRIX_GKE_CLUSTER", "demo")
+    monkeypatch.setenv("MATRIX_GKE_REGION", "us-central1")
+    monkeypatch.setenv("MATRIX_GKE_REGISTRY", "matraix")
+    monkeypatch.setenv("GCP_PROJECT", "proj-1")
+
+    service = HarborJobService(
+        repo_root=repo,
+        jobs_dir=jobs_dir,
+        generated_configs_dir=repo / "configs" / "jobs" / "application-task-job-recipe",
+        command_runner=lambda *args, **kwargs: 0,
+        harbor_command=("echo", "harbor"),
+    )
+    job_name = service.launch(
+        task_path="application/tasks/example-web_bookshop",
+        persona_ids=["0001"],
+        persona_pool="persona/datasets/matraix-persona-dev-sample",
+        agent_name="persona-computer-1",
+        job_name="gke-web",
+        compute_family="gcp",
+        execution_plane="harbor",
+    )
+    service._executor.shutdown(wait=True)
+    launch = service._launches[job_name]
+    assert launch.compute_family == "gcp"
+    assert launch.compute_environment == "gke"
+    assert launch.compute_dispatch is None
+    config_text = (repo / "configs" / "jobs" / "application-task-job-recipe" / "gke-web.yaml").read_text(
+        encoding="utf-8"
+    )
+    assert "type: gke" in config_text
+    assert "cluster_name: demo" in config_text
+    assert "registry_name: matraix" in config_text
+    assert '"dispatch"' not in (jobs_dir / job_name / "compute.json").read_text(encoding="utf-8")
+
+
+def test_launch_gcp_web_requires_cluster_settings(tmp_path, monkeypatch) -> None:
+    repo = tmp_path
+    jobs_dir = repo / "jobs"
+    jobs_dir.mkdir()
+    (repo / "persona" / "datasets" / "matraix-persona-dev-sample").mkdir(parents=True)
+    (repo / "persona" / "datasets" / "matraix-persona-dev-sample" / "persona_0001.yaml").write_text(
+        "persona_id: '0001'\nversion: '1.0'\nsource: Nemotron\ndimensions: {}\n",
+        encoding="utf-8",
+    )
+    task = repo / "application" / "tasks" / "example-web_bookshop"
+    task.mkdir(parents=True)
+    (task / "task.toml").write_text(
+        '[task]\nname = "web-demo"\n[metadata]\ntype = "web"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("playground.harbor.playground._repo_root", lambda: repo)
+    for name in (
+        "MATRIX_GKE_CLUSTER",
+        "MATRIX_GKE_REGION",
+        "MATRIX_GKE_REGISTRY",
+        "MATRIX_GKE_REGISTRY_LOCATION",
+        "GCP_PROJECT",
+        "GOOGLE_CLOUD_PROJECT",
+        "MATRIX_GCP_PROJECT",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    service = HarborJobService(
+        repo_root=repo,
+        jobs_dir=jobs_dir,
+        generated_configs_dir=repo / "configs" / "jobs" / "application-task-job-recipe",
+        command_runner=lambda *args, **kwargs: 0,
+        harbor_command=("echo", "harbor"),
+    )
+    with pytest.raises(ValueError, match="GKE"):
+        service.launch(
+            task_path="application/tasks/example-web_bookshop",
+            persona_ids=["0001"],
+            persona_pool="persona/datasets/matraix-persona-dev-sample",
+            agent_name="persona-computer-1",
+            compute_family="gcp",
+        )
+
+
+def test_launch_modal_spawns_all_shards_before_wait(tmp_path, monkeypatch) -> None:
+    repo = tmp_path
+    jobs_dir = repo / "jobs"
+    jobs_dir.mkdir()
+    pool = repo / "persona" / "datasets" / "matraix-persona-dev-sample"
+    pool.mkdir(parents=True)
+    for index in range(1, 5):
+        pid = f"{index:04d}"
+        (pool / f"persona_{pid}.yaml").write_text(
+            f"persona_id: '{pid}'\nversion: '1.0'\nsource: Nemotron\ndimensions: {{}}\n",
+            encoding="utf-8",
+        )
+    monkeypatch.setattr("playground.harbor.playground._repo_root", lambda: repo)
+    monkeypatch.setenv("MATRIX_HOST_PACK_CONCURRENCY", "1")
+
+    class _SpawnRunner:
+        def __init__(self) -> None:
+            self.spawned: list[str] = []
+            self.waited: list[str] = []
+
+        def spawn(self, request):
+            previous = list(self.spawned)
+            self.spawned.append(request.shard_key)
+            from backend.service.modal_host_job import load_cloud_run
+
+            cloud = load_cloud_run(jobs_dir / request.job_name) or {}
+            recorded = {
+                str(row.get("key") or "")
+                for row in cloud.get("shards") or []
+                if isinstance(row, dict)
+            }
+            # Earlier shards must already be recorded before this spawn returns
+            # (save happens after spawn; check previous keys on next call).
+            assert set(previous) <= recorded
+            return "fc-{}".format(request.shard_key), object()
+
+        def wait(self, request, *, call=None, call_id=""):
+            del call
+            self.waited.append(call_id)
+            from backend.service.modal_host_job import ModalHostJobResult, pack_job_dir
+
+            isolated = repo / "worker" / (request.shard_key or "s0") / request.job_name
+            trial = isolated / "survey__{}".format(request.shard_key or "s0")
+            trial.mkdir(parents=True)
+            (trial / "result.json").write_text("{}\n", encoding="utf-8")
+            return ModalHostJobResult(exit_code=0, artifact_tar=pack_job_dir(isolated))
+
+    fake = _SpawnRunner()
+    service = HarborJobService(
+        repo_root=repo,
+        jobs_dir=jobs_dir,
+        generated_configs_dir=repo / "configs" / "jobs" / "application-task-job-recipe",
+        command_runner=lambda *args, **kwargs: 0,
+        harbor_command=("echo", "harbor"),
+        modal_host_job_runner=fake,
+    )
+    job_name = service.launch(
+        task_path="application/tasks/example-survey_product-feedback",
+        persona_ids=["0001", "0002", "0003", "0004"],
+        persona_pool="persona/datasets/matraix-persona-dev-sample",
+        job_name="modal-spawn-all",
+        compute_family="modal",
+        execution_plane="harbor",
+    )
+    service._executor.shutdown(wait=True)
+    assert fake.spawned == ["s0", "s1"]
+    assert set(fake.waited) == {"fc-s0", "fc-s1"}
+    cloud = json.loads(
+        (jobs_dir / job_name / "_generated" / "cloud_run.json").read_text(encoding="utf-8")
+    )
+    assert cloud["status"] == "completed"
+    assert {row["callId"] for row in cloud["shards"]} == {"fc-s0", "fc-s1"}
+    assert (jobs_dir / job_name / "survey__s0" / "result.json").is_file()
+    assert (jobs_dir / job_name / "survey__s1" / "result.json").is_file()
+
+
+def test_launch_modal_chat_rejects_localhost_sidecar(tmp_path, monkeypatch) -> None:
+    repo = tmp_path
+    jobs_dir = repo / "jobs"
+    jobs_dir.mkdir()
+    pool = repo / "persona" / "datasets" / "matraix-persona-dev-sample"
+    pool.mkdir(parents=True)
+    (pool / "persona_0042.yaml").write_text(
+        "persona_id: '0042'\nversion: '1.0'\nsource: Nemotron\ndimensions: {}\n",
+        encoding="utf-8",
+    )
+    task_dir = repo / "application" / "tasks" / "chat_meal-planning-nutrition"
+    task_dir.mkdir(parents=True)
+    (task_dir / "task.toml").write_text("metadata:\n  type: chat\n", encoding="utf-8")
+    monkeypatch.setattr("playground.harbor.playground._repo_root", lambda: repo)
+    monkeypatch.setenv("CHATBOT_API_URL", "http://127.0.0.1:8905")
+    monkeypatch.delenv("MATRIX_CHATBOT_PUBLIC_URL", raising=False)
+    monkeypatch.setenv("MATRIX_CHATBOT_TUNNEL", "0")
+
+    service = HarborJobService(
+        repo_root=repo,
+        jobs_dir=jobs_dir,
+        generated_configs_dir=repo / "configs" / "jobs" / "application-task-job-recipe",
+        command_runner=lambda *args, **kwargs: 0,
+        harbor_command=("echo", "harbor"),
+        modal_host_job_runner=object(),
+    )
+    with pytest.raises(ValueError, match="localhost is not visible|needs a chatbot URL"):
+        service.launch(
+            task_path="application/tasks/chat_meal-planning-nutrition",
+            persona_ids=["0042"],
+            job_name="modal-chat-local",
+            compute_family="modal",
+            execution_plane="harbor",
+        )

--- a/application/playground/backend/tests/test_modal_docker_prebuild.py
+++ b/application/playground/backend/tests/test_modal_docker_prebuild.py
@@ -15,7 +15,6 @@ from backend.service.modal_docker_prebuild import (
     prepare_docker_environment_for_job,
     task_short_name,
 )
-from backend.service.modal_host_job import modal_function_name_for_config
 
 
 class _FakeDocker(DockerCli):
@@ -130,11 +129,14 @@ def test_host_jobs_skip_prebuild(tmp_path: Path) -> None:
     )
 
 
-def test_function_name_follows_environment_type() -> None:
-    assert (
-        modal_function_name_for_config("environment:\n  type: docker\n")
-        == "harbor_docker_job"
+def test_docker_jobs_use_sandbox_not_function() -> None:
+    from backend.service.modal_host_job import (
+        modal_function_name_for_config,
+        modal_uses_docker_sandbox,
     )
+
+    assert modal_uses_docker_sandbox("environment:\n  type: docker\n")
+    assert not modal_uses_docker_sandbox("environment:\n  type: host\n")
     assert (
         modal_function_name_for_config("environment:\n  type: host\n")
         == "harbor_host_job"

--- a/application/playground/backend/tests/test_modal_docker_prebuild.py
+++ b/application/playground/backend/tests/test_modal_docker_prebuild.py
@@ -1,0 +1,154 @@
+"""Tests for Modal Docker image prebuild / Volume cache."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from backend.service.modal_docker_prebuild import (
+    DockerCli,
+    docker_context_digest,
+    harbor_environment_type,
+    harbor_main_image_name,
+    job_task_dir,
+    patch_task_toml_docker_image,
+    prebuilt_image_tag,
+    prepare_docker_environment_for_job,
+    task_short_name,
+)
+from backend.service.modal_host_job import modal_function_name_for_config
+
+
+class _FakeDocker(DockerCli):
+    def __init__(self) -> None:
+        self.images: set[str] = set()
+        self.built: list[tuple[str, str]] = []
+        self.loaded: list[str] = []
+        self.saved: list[tuple[str, str]] = []
+
+    def image_exists(self, tag: str) -> bool:
+        return tag in self.images
+
+    def build(self, context: Path, tag: str) -> None:
+        self.built.append((str(context), tag))
+        self.images.add(tag)
+
+    def tag(self, source: str, dest: str) -> None:
+        if source not in self.images:
+            raise RuntimeError("missing {}".format(source))
+        self.images.add(dest)
+
+    def save(self, tag: str, dest: Path) -> None:
+        dest.write_bytes(b"tar:" + tag.encode("utf-8"))
+        self.saved.append((tag, str(dest)))
+
+    def load(self, archive: Path) -> None:
+        payload = archive.read_bytes().decode("utf-8")
+        tag = payload.split("tar:", 1)[-1]
+        self.images.add(tag)
+        self.loaded.append(str(archive))
+
+
+def _web_repo(tmp_path: Path) -> tuple[Path, Path]:
+    env = tmp_path / "environment" / "task-environments" / "application" / "shared-web-playwright"
+    env.mkdir(parents=True)
+    (env / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
+    task = tmp_path / "application" / "tasks" / "example-web"
+    task.mkdir(parents=True)
+    (task / "task.toml").write_text(
+        '[task]\nname = "application/playwright-quote-choice"\n'
+        '[environment]\ndefinition = "application/shared-web-playwright"\n',
+        encoding="utf-8",
+    )
+    return tmp_path, task
+
+
+def test_digest_ignores_readme_when_dockerignore_allowlists_dockerfile(
+    tmp_path: Path,
+) -> None:
+    env = tmp_path / "env"
+    env.mkdir()
+    (env / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
+    (env / ".dockerignore").write_text("*\n!Dockerfile\n", encoding="utf-8")
+    first = docker_context_digest(env)
+    (env / "README.md").write_text("noise\n", encoding="utf-8")
+    assert docker_context_digest(env) == first
+    (env / "Dockerfile").write_text("FROM debian\n", encoding="utf-8")
+    assert docker_context_digest(env) != first
+
+
+def test_prepare_builds_once_then_loads_from_cache(tmp_path: Path) -> None:
+    repo, task = _web_repo(tmp_path)
+    yaml_text = (
+        "environment:\n  type: docker\n"
+        "tasks:\n  - path: application/tasks/example-web\n"
+    )
+    cache = tmp_path / "cache"
+    docker = _FakeDocker()
+    tag = prepare_docker_environment_for_job(
+        yaml_text,
+        repo_root=repo,
+        cache_dir=cache,
+        docker=docker,
+        start_daemon=False,
+    )
+    assert tag == prebuilt_image_tag(
+        docker_context_digest(
+            repo / "environment" / "task-environments" / "application" / "shared-web-playwright"
+        )
+    )
+    assert docker.built
+    harbor = harbor_main_image_name(task_short_name(task))
+    assert harbor in docker.images
+    assert tag in docker.images
+    toml = (task / "task.toml").read_text(encoding="utf-8")
+    assert 'docker_image = "{}"'.format(tag) in toml
+
+    docker.images.clear()
+    docker.built.clear()
+    again = prepare_docker_environment_for_job(
+        yaml_text,
+        repo_root=repo,
+        cache_dir=cache,
+        docker=docker,
+        start_daemon=False,
+    )
+    assert again == tag
+    assert not docker.built
+    assert docker.loaded
+    assert harbor in docker.images
+
+
+def test_host_jobs_skip_prebuild(tmp_path: Path) -> None:
+    assert harbor_environment_type("environment:\n  type: host\n") == "host"
+    assert (
+        prepare_docker_environment_for_job(
+            "environment:\n  type: host\n",
+            repo_root=tmp_path,
+            start_daemon=False,
+        )
+        is None
+    )
+
+
+def test_function_name_follows_environment_type() -> None:
+    assert (
+        modal_function_name_for_config("environment:\n  type: docker\n")
+        == "harbor_docker_job"
+    )
+    assert (
+        modal_function_name_for_config("environment:\n  type: host\n")
+        == "harbor_host_job"
+    )
+
+
+def test_job_task_dir_and_patch(tmp_path: Path) -> None:
+    repo, task = _web_repo(tmp_path)
+    found = job_task_dir(
+        "tasks:\n  - path: application/tasks/example-web\n",
+        repo_root=repo,
+    )
+    assert found == task
+    patch_task_toml_docker_image(task / "task.toml", "matraix-prebuilt:abc")
+    assert 'docker_image = "matraix-prebuilt:abc"' in (task / "task.toml").read_text(
+        encoding="utf-8"
+    )

--- a/application/playground/backend/tests/test_modal_host_job.py
+++ b/application/playground/backend/tests/test_modal_host_job.py
@@ -1,0 +1,432 @@
+"""Tests for Modal Jobs host-agent helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from backend.service.modal_host_job import (
+    HARBOR_MODULE_COMMAND,
+    ModalHostJobError,
+    ModalHostJobRequest,
+    ModalHostJobResult,
+    apply_live_overlay,
+    download_volume_job,
+    execute_host_harbor_job,
+    invoke_modal_host_function,
+    LivePublishState,
+    materialize_modal_artifacts,
+    merge_job_artifacts,
+    modal_volume_job_name,
+    overlay_status_code,
+    pack_job_dir,
+    prepare_modal_job_config,
+    publish_live_trial_deltas,
+    read_live_overlay,
+    rewrite_job_artifact_paths,
+    sync_job_dir_to_volume,
+    unpack_job_dir,
+    wait_modal_call_with_live_pull,
+)
+
+
+def test_pack_and_unpack_job_dir(tmp_path: Path) -> None:
+    src = tmp_path / "jobs" / "demo"
+    trial = src / "t1"
+    trial.mkdir(parents=True)
+    (trial / "result.json").write_text("{\"ok\": true}", encoding="utf-8")
+    blob = pack_job_dir(src)
+    dest = tmp_path / "out"
+    unpacked = unpack_job_dir(blob, jobs_dir=dest, job_name="demo")
+    assert (unpacked / "t1" / "result.json").read_text(encoding="utf-8") == "{\"ok\": true}"
+
+
+def test_merge_preserves_compute_json_and_rewrites_paths(tmp_path: Path) -> None:
+    dest_jobs = tmp_path / "jobs"
+    dest = dest_jobs / "demo"
+    dest.mkdir(parents=True)
+    (dest / "compute.json").write_text(
+        '{"family": "modal", "environment": "host", "dispatch": "modal_jobs"}\n',
+        encoding="utf-8",
+    )
+    src = tmp_path / "remote" / "demo"
+    trial = src / "survey__abc"
+    (trial / "agent").mkdir(parents=True)
+    (trial / "verifier").mkdir()
+    (trial / "result.json").write_text(
+        '{"trial_uri": "file:///matraix/jobs/demo/survey__abc"}',
+        encoding="utf-8",
+    )
+    (src / "compute.json").write_text('{"family": "wrong"}\n', encoding="utf-8")
+    (src / "job.log").write_text("ok\n", encoding="utf-8")
+    blob = pack_job_dir(src)
+    merged = merge_job_artifacts(blob, jobs_dir=dest_jobs, job_name="demo")
+    assert '"dispatch": "modal_jobs"' in (merged / "compute.json").read_text(encoding="utf-8")
+    result = (merged / "survey__abc" / "result.json").read_text(encoding="utf-8")
+    assert "/matraix/jobs/demo" not in result
+    assert str(merged.resolve()) in result
+    assert (merged / "survey__abc" / "agent").is_dir()
+    assert (merged / "job.log").read_text(encoding="utf-8") == "ok\n"
+
+
+def test_merge_skips_shard_job_result_json(tmp_path: Path) -> None:
+    dest_jobs = tmp_path / "jobs"
+    dest = dest_jobs / "demo"
+    dest.mkdir(parents=True)
+    (dest / "compute.json").write_text('{"family": "modal"}\n', encoding="utf-8")
+    src = tmp_path / "remote" / "demo"
+    src.mkdir(parents=True)
+    (src / "result.json").write_text('{"shardOnly": true}\n', encoding="utf-8")
+    (src / "survey__a" / "result.json").parent.mkdir(parents=True)
+    (src / "survey__a" / "result.json").write_text("{}\n", encoding="utf-8")
+    merged = merge_job_artifacts(pack_job_dir(src), jobs_dir=dest_jobs, job_name="demo")
+    assert not (merged / "result.json").is_file()
+    assert (merged / "survey__a" / "result.json").is_file()
+    assert '"family": "modal"' in (merged / "compute.json").read_text(encoding="utf-8")
+
+
+def test_rewrite_job_artifact_paths(tmp_path: Path) -> None:
+    job_dir = tmp_path / "jobs" / "j1"
+    job_dir.mkdir(parents=True)
+    (job_dir / "note.txt").write_text("root=/matraix/jobs/j1/trial\n", encoding="utf-8")
+    rewrite_job_artifact_paths(
+        job_dir,
+        remote_repo="/matraix",
+        local_job_dir=job_dir,
+        job_name="j1",
+    )
+    assert "/matraix/" not in (job_dir / "note.txt").read_text(encoding="utf-8")
+
+
+def test_prepare_modal_job_config_forces_jobs_dir() -> None:
+    text = prepare_modal_job_config(
+        "job_name: other\njobs_dir: /Users/me/jobs\n",
+        job_name="j1",
+    )
+    assert "job_name: j1" in text
+    assert "jobs_dir: jobs" in text
+
+
+def test_execute_host_harbor_job_uses_module_command(tmp_path: Path) -> None:
+    request = ModalHostJobRequest(
+        job_name="j1",
+        config_yaml="job_name: j1\njobs_dir: /tmp/elsewhere\n",
+        repo_root=str(tmp_path),
+        jobs_dir="jobs",
+        env={},
+        harbor_command=("/Users/me/.venv/bin/harbor", "run"),
+    )
+    seen: dict[str, object] = {}
+
+    def _runner(command, *, cwd, env):
+        seen["command"] = command
+        seen["env"] = env
+        job_dir = Path(cwd) / "jobs" / "j1"
+        (job_dir / "agent").mkdir(parents=True)
+        (job_dir / "result.json").write_text("{}", encoding="utf-8")
+        return 0
+
+    result = execute_host_harbor_job(request, command_runner=_runner, work_root=tmp_path)
+    assert result.exit_code == 0
+    assert result.artifact_tar
+    command = seen["command"]
+    assert command[:4] == list(HARBOR_MODULE_COMMAND)
+    assert "/Users/me/.venv/bin/harbor" not in command
+    env = seen["env"]
+    assert str(tmp_path / "packages" / "playground" / "src") in str(env["PYTHONPATH"])
+
+
+def test_execute_host_harbor_job_calls_progress(tmp_path: Path) -> None:
+    request = ModalHostJobRequest(
+        job_name="j1",
+        config_yaml="job_name: j1\n",
+        repo_root=str(tmp_path),
+        jobs_dir="jobs",
+        env={},
+    )
+    hits: list[str] = []
+
+    def _runner(command, *, cwd, env):
+        del command, env
+        trial = Path(cwd) / "jobs" / "j1" / "survey__a"
+        trial.mkdir(parents=True)
+        (trial / "result.json").write_text("{}\n", encoding="utf-8")
+        return 0
+
+    def _progress(job_dir: Path) -> None:
+        hits.append(job_dir.name)
+        assert (job_dir / "survey__a" / "result.json").is_file()
+
+    result = execute_host_harbor_job(
+        request,
+        command_runner=_runner,
+        work_root=tmp_path,
+        progress=_progress,
+    )
+    assert result.exit_code == 0
+    assert hits
+
+
+def test_sync_job_dir_to_volume_is_incremental(tmp_path: Path) -> None:
+    src = tmp_path / "src" / "j1"
+    (src / "survey__a").mkdir(parents=True)
+    (src / "survey__a" / "result.json").write_text("{}\n", encoding="utf-8")
+    (src / "result.json").write_text('{"job": true}\n', encoding="utf-8")
+    vol = tmp_path / "vol"
+    sync_job_dir_to_volume(src, volume_root=vol, job_name="j1")
+    (vol / "j1" / "survey__a" / "keep.txt").write_text("stay\n", encoding="utf-8")
+    (src / "survey__b").mkdir()
+    (src / "survey__b" / "config.json").write_text("{}\n", encoding="utf-8")
+    dest = sync_job_dir_to_volume(src, volume_root=vol, job_name="j1")
+    assert dest == vol / "j1"
+    assert (dest / "survey__a" / "keep.txt").read_text(encoding="utf-8") == "stay\n"
+    status = json.loads((dest / "live_status.json").read_text(encoding="utf-8"))
+    assert status["survey__b"] == "running"
+    assert not (dest / "survey__b").exists()
+    assert not (dest / "result.json").is_file()
+
+
+def test_live_delta_skips_unchanged_trials(tmp_path: Path) -> None:
+    src = tmp_path / "src" / "j1"
+    trial = src / "survey__a"
+    trial.mkdir(parents=True)
+    (trial / "result.json").write_text("{}\n", encoding="utf-8")
+    (trial / "agent" / "trace.json").parent.mkdir(parents=True)
+    (trial / "agent" / "trace.json").write_text("{}\n", encoding="utf-8")
+    vol = tmp_path / "vol"
+    first = publish_live_trial_deltas(src, volume_root=vol, job_name="j1")
+    (vol / "j1" / "survey__a" / "agent" / "extra.txt").write_text("keep\n", encoding="utf-8")
+    second = publish_live_trial_deltas(src, volume_root=vol, job_name="j1")
+    assert first > 0
+    assert second == 0
+    assert (vol / "j1" / "survey__a" / "agent" / "extra.txt").read_text(encoding="utf-8") == "keep\n"
+
+
+class _MemVolume:
+    def __init__(self, files: dict[str, bytes]) -> None:
+        self.files = {key.strip("/"): value for key, value in files.items()}
+        self.reads: list[str] = []
+
+    def reload(self) -> None:
+        return None
+
+    def listdir(self, prefix: str):
+        remote = prefix.strip("/")
+        found = []
+        seen: set[str] = set()
+        for path in self.files:
+            if remote:
+                if path == remote:
+                    continue
+                if not path.startswith(remote + "/"):
+                    continue
+                rest = path[len(remote) + 1 :]
+            else:
+                rest = path
+            leaf = rest.split("/", 1)[0]
+            child = "{}/{}".format(remote, leaf) if remote else leaf
+            if child in seen:
+                continue
+            seen.add(child)
+            found.append(type("Ent", (), {"path": child, "is_dir": "/" in rest})())
+        return found
+
+    def read_file(self, name: str):
+        key = name.strip("/")
+        self.reads.append(key)
+        yield self.files[key]
+
+
+def test_download_volume_job_merges_without_clobbering_compute_json(tmp_path: Path) -> None:
+    dest = tmp_path / "jobs" / "demo"
+    dest.mkdir(parents=True)
+    (dest / "compute.json").write_text('{"family": "modal"}\n', encoding="utf-8")
+    volume = _MemVolume(
+        {
+            "demo/s0/compute.json": b'{"family": "wrong"}\n',
+            "demo/s0/result.json": b'{"shardOnly": true}\n',
+            "demo/s0/survey__a/result.json": b'{"trial_uri": "file:///matraix/jobs/demo/survey__a"}\n',
+        }
+    )
+    download_volume_job(volume, job_name="demo/s0", dest=dest)
+    assert '"family": "modal"' in (dest / "compute.json").read_text(encoding="utf-8")
+    assert not (dest / "result.json").is_file()
+    result = (dest / "survey__a" / "result.json").read_text(encoding="utf-8")
+    assert "/matraix/jobs/demo" not in result
+    assert str(dest.resolve()) in result
+    leftover = list((dest / "_generated").glob("live_pull_*"))
+    assert leftover == []
+
+
+def test_download_live_skips_already_completed_trials(tmp_path: Path) -> None:
+    dest = tmp_path / "jobs" / "demo"
+    done = dest / "survey__a"
+    done.mkdir(parents=True)
+    (done / "result.json").write_text("{}\n", encoding="utf-8")
+    (dest / "compute.json").write_text('{"family": "modal"}\n', encoding="utf-8")
+    volume = _MemVolume(
+        {
+            "demo/s0/live_status.json": b'{"survey__a": "done", "survey__b": "done"}\n',
+            "demo/s0/survey__a/result.json": b'{"old": true}\n',
+            "demo/s0/survey__a/agent/trace.json": b"big\n",
+            "demo/s0/survey__b/result.json": b"{}\n",
+        }
+    )
+    download_volume_job(volume, job_name="demo/s0", dest=dest, incremental=True)
+    assert (dest / "survey__a" / "result.json").read_text(encoding="utf-8") == "{}\n"
+    assert not (dest / "survey__a" / "agent").exists()
+    assert (dest / "survey__b" / "result.json").is_file()
+    assert "demo/s0/survey__a/agent/trace.json" not in volume.reads
+    assert "demo/s0/survey__b/result.json" in volume.reads
+
+
+def test_wait_modal_call_with_live_pull_merges_before_return(tmp_path: Path) -> None:
+    dest = tmp_path / "jobs" / "demo"
+    dest.mkdir(parents=True)
+    (dest / "compute.json").write_text('{"family": "modal"}\n', encoding="utf-8")
+    volume = _MemVolume(
+        {
+            "demo/s0/survey__a/result.json": b"{}\n",
+        }
+    )
+
+    class _Call:
+        def __init__(self) -> None:
+            self.n = 0
+
+        def get(self, timeout=None):
+            del timeout
+            self.n += 1
+            if self.n < 2:
+                raise TimeoutError()
+            return {"exitCode": 0}
+
+    raw = wait_modal_call_with_live_pull(
+        _Call(),
+        volume=volume,
+        volume_job_name="demo/s0",
+        dest=dest,
+        poll_sec=0.01,
+    )
+    assert raw["exitCode"] == 0
+    assert (dest / "survey__a" / "result.json").is_file()
+    assert '"family": "modal"' in (dest / "compute.json").read_text(encoding="utf-8")
+
+
+def test_invoke_modal_host_function_spawns_when_live_jobs_dir_set(tmp_path: Path) -> None:
+    request = ModalHostJobRequest(
+        job_name="demo",
+        config_yaml="job_name: demo\n",
+        repo_root=str(tmp_path),
+        jobs_dir="jobs",
+        env={},
+        shard_key="s0",
+        live_jobs_dir=str(tmp_path / "jobs"),
+    )
+
+    class _Call:
+        def get(self, timeout=None):
+            del timeout
+            return {"exitCode": 0, "volumePath": "demo/s0"}
+
+    class _Fn:
+        def __init__(self) -> None:
+            self.spawned: list[dict] = []
+            self.remote_calls = 0
+
+        def spawn(self, payload):
+            self.spawned.append(payload)
+            return _Call()
+
+        def remote(self, payload):
+            del payload
+            self.remote_calls += 1
+            raise AssertionError("live pull should spawn, not remote")
+
+    fn = _Fn()
+    raw = invoke_modal_host_function(fn, {"jobName": "demo"}, request=request, volume=None)
+    assert raw["exitCode"] == 0
+    assert fn.spawned
+    assert fn.remote_calls == 0
+    assert modal_volume_job_name("demo", "s0") == "demo/s0"
+
+
+def test_invoke_modal_host_function_uses_remote_without_live_dir(tmp_path: Path) -> None:
+    request = ModalHostJobRequest(
+        job_name="demo",
+        config_yaml="job_name: demo\n",
+        repo_root=str(tmp_path),
+        jobs_dir="jobs",
+        env={},
+    )
+
+    class _Fn:
+        def remote(self, payload):
+            del payload
+            return {"exitCode": 0}
+
+        def spawn(self, payload):
+            del payload
+            raise AssertionError("should not spawn without live_jobs_dir")
+
+    raw = invoke_modal_host_function(_Fn(), {"jobName": "demo"}, request=request)
+    assert raw["exitCode"] == 0
+
+
+def test_live_overlay_merges_shard_status(tmp_path: Path) -> None:
+    dest = tmp_path / "jobs" / "demo"
+    apply_live_overlay(dest, {"survey__a": "running"})
+    apply_live_overlay(dest, {"survey__b": "done"})
+    overlay = read_live_overlay(dest)
+    assert overlay["survey__a"] == "running"
+    assert overlay["survey__b"] == "done"
+    assert overlay_status_code("done") == 2
+    assert overlay_status_code("error") == 3
+
+
+def test_live_publish_state_defers_full_trees_until_flush(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("MATRIX_MODAL_ARTIFACT_FLUSH_TRIALS", "50")
+    monkeypatch.setenv("MATRIX_MODAL_ARTIFACT_FLUSH_SEC", "3600")
+    monkeypatch.setattr(
+        "backend.service.modal_host_job.put_live_status_dict",
+        lambda key, status: True,
+    )
+    src = tmp_path / "src" / "j1"
+    trial = src / "survey__a"
+    trial.mkdir(parents=True)
+    (trial / "config.json").write_text("{}\n", encoding="utf-8")
+    vol = tmp_path / "vol"
+    live = LivePublishState()
+    live.tick(src, volume_root=vol, job_name="j1", status_key="j1")
+    assert (vol / "j1" / "live_status.json").is_file()
+    assert not (vol / "j1" / "survey__a").exists()
+    (trial / "result.json").write_text("{}\n", encoding="utf-8")
+    (trial / "agent" / "trace.json").parent.mkdir(parents=True)
+    (trial / "agent" / "trace.json").write_text("big\n", encoding="utf-8")
+    commit = live.tick(src, volume_root=vol, job_name="j1", status_key="j1")
+    assert commit is False
+    assert not (vol / "j1" / "survey__a" / "agent").exists()
+    live.tick(src, volume_root=vol, job_name="j1", status_key="j1", force=True)
+    assert (vol / "j1" / "survey__a" / "agent" / "trace.json").is_file()
+
+
+def test_materialize_requires_artifacts(tmp_path: Path) -> None:
+    with pytest.raises(ModalHostJobError, match="without returning"):
+        materialize_modal_artifacts(
+            ModalHostJobResult(exit_code=0),
+            jobs_dir=tmp_path / "jobs",
+            job_name="missing",
+        )
+
+
+def test_collect_orchestrator_secret_env_rewrites_loopback_chatbot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CHATBOT_API_URL", "http://127.0.0.1:8905")
+    monkeypatch.setenv("MATRIX_CHATBOT_PUBLIC_URL", "https://tunnel.example")
+    from backend.service.modal_host_job import collect_orchestrator_secret_env
+
+    env = collect_orchestrator_secret_env()
+    assert env["CHATBOT_API_URL"] == "https://tunnel.example"

--- a/application/playground/backend/tests/test_modal_host_job.py
+++ b/application/playground/backend/tests/test_modal_host_job.py
@@ -430,3 +430,28 @@ def test_collect_orchestrator_secret_env_rewrites_loopback_chatbot(
 
     env = collect_orchestrator_secret_env()
     assert env["CHATBOT_API_URL"] == "https://tunnel.example"
+
+
+def test_collect_orchestrator_secret_env_includes_provider_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from backend.service.modal_host_job import collect_orchestrator_secret_env
+
+    monkeypatch.delenv("CHATBOT_API_URL", raising=False)
+    monkeypatch.delenv("MATRIX_CHATBOT_PUBLIC_URL", raising=False)
+    for key, value in (
+        ("XAI_API_KEY", "sk-xai"),
+        ("DEEPSEEK_API_KEY", "sk-ds"),
+        ("ZAI_API_KEY", "sk-zai"),
+        ("LLM_API_KEY", "sk-llm"),
+        ("USE_COMPUTER_API_KEY", "sk-uc"),
+        ("CLAUDE_API_KEY", "sk-claude"),
+    ):
+        monkeypatch.setenv(key, value)
+    env = collect_orchestrator_secret_env()
+    assert env["XAI_API_KEY"] == "sk-xai"
+    assert env["DEEPSEEK_API_KEY"] == "sk-ds"
+    assert env["ZAI_API_KEY"] == "sk-zai"
+    assert env["LLM_API_KEY"] == "sk-llm"
+    assert env["USE_COMPUTER_API_KEY"] == "sk-uc"
+    assert env["CLAUDE_API_KEY"] == "sk-claude"

--- a/application/playground/backend/tests/test_modal_sandbox_job.py
+++ b/application/playground/backend/tests/test_modal_sandbox_job.py
@@ -1,0 +1,191 @@
+"""Tests for Modal Sandbox web/linux workers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from backend.service.modal_host_job import (
+    ModalHostJobRequest,
+    ModalHostJobResult,
+    SdkModalDispatchRunner,
+    encode_modal_sandbox_call_id,
+    is_modal_sandbox_call_id,
+    modal_sandbox_object_id,
+    read_live_overlay,
+)
+from backend.service.modal_sandbox_job import (
+    SANDBOX_RESULT_FILENAME,
+    run_sandbox_worker,
+    sandbox_payload_remote_path,
+    wait_sandbox_with_live_pull,
+    write_sandbox_live_status,
+)
+
+
+def _request(tmp_path: Path, config_yaml: str, live: bool = True) -> ModalHostJobRequest:
+    return ModalHostJobRequest(
+        job_name="demo-job",
+        config_yaml=config_yaml,
+        repo_root=str(tmp_path),
+        jobs_dir="jobs",
+        env={},
+        shard_key="s0",
+        live_jobs_dir=str(tmp_path / "jobs") if live else "",
+    )
+
+
+def test_sandbox_call_id_round_trip() -> None:
+    encoded = encode_modal_sandbox_call_id("sb-abc")
+    assert is_modal_sandbox_call_id(encoded)
+    assert modal_sandbox_object_id(encoded) == "sb-abc"
+    assert not is_modal_sandbox_call_id("fc-123")
+
+
+def test_sandbox_payload_path_uses_shard() -> None:
+    assert sandbox_payload_remote_path("demo-job", "s0") == "_payloads/demo-job/s0.json"
+
+
+def test_write_sandbox_live_status(tmp_path: Path) -> None:
+    job_dir = tmp_path / "jobs" / "demo-job"
+    trial = job_dir / "web__a"
+    trial.mkdir(parents=True)
+    (trial / "config.json").write_text("{}\n", encoding="utf-8")
+    dest = tmp_path / "live.json"
+    status = write_sandbox_live_status(job_dir, dest=dest)
+    assert status["web__a"] == "running"
+    assert json.loads(dest.read_text(encoding="utf-8"))["web__a"] == "running"
+
+
+def test_dispatch_runner_uses_sandbox_for_docker(monkeypatch, tmp_path: Path) -> None:
+    spawned: list[str] = []
+
+    class _FakeSandbox:
+        def spawn(self, request):
+            spawned.append("sandbox")
+            return encode_modal_sandbox_call_id("sb-1"), object()
+
+        def wait(self, request, **kwargs):
+            return ModalHostJobResult(exit_code=0, volume_path="demo-job/s0")
+
+    class _FakeHost:
+        def spawn(self, request):
+            spawned.append("host")
+            return "fc-1", object()
+
+        def wait(self, request, **kwargs):
+            return ModalHostJobResult(exit_code=0)
+
+    monkeypatch.setattr(
+        "backend.service.modal_sandbox_job.SdkModalSandboxJobRunner",
+        _FakeSandbox,
+    )
+    monkeypatch.setattr(
+        "backend.service.modal_host_job.SdkModalHostJobRunner",
+        _FakeHost,
+    )
+    runner = SdkModalDispatchRunner()
+    docker = _request(tmp_path, "environment:\n  type: docker\n")
+    call_id, _ = runner.spawn(docker)
+    assert spawned == ["sandbox"]
+    assert is_modal_sandbox_call_id(call_id)
+    host = _request(tmp_path, "environment:\n  type: host\n")
+    host_id, _ = runner.spawn(host)
+    assert spawned == ["sandbox", "host"]
+    assert host_id == "fc-1"
+
+
+def test_wait_sandbox_applies_live_overlay(tmp_path: Path) -> None:
+    dest = tmp_path / "jobs" / "demo-job"
+    dest.mkdir(parents=True)
+
+    class _Stdout:
+        def __init__(self, payload: bytes) -> None:
+            self._payload = payload
+
+        def read(self) -> bytes:
+            return self._payload
+
+    class _Proc:
+        def __init__(self, payload: bytes) -> None:
+            self.stdout = _Stdout(payload)
+
+        def wait(self) -> int:
+            return 0
+
+    class _Sandbox:
+        def __init__(self) -> None:
+            self._polls = 0
+
+        def poll(self) -> int | None:
+            self._polls += 1
+            if self._polls < 2:
+                return None
+            return 0
+
+        def exec(self, *command: str):
+            del command
+            return _Proc(b'{"web__a": "running"}\n')
+
+    request = _request(tmp_path, "environment:\n  type: docker\n")
+    code = wait_sandbox_with_live_pull(_Sandbox(), request=request, volume=None, poll_sec=0.01)
+    assert code == 0
+    assert read_live_overlay(dest)["web__a"] == "running"
+
+
+def test_run_sandbox_worker_writes_result(tmp_path: Path, monkeypatch) -> None:
+    repo = tmp_path / "matraix"
+    job_dir = repo / "jobs" / "demo-job"
+    trial = job_dir / "web__a"
+    trial.mkdir(parents=True)
+    (trial / "result.json").write_text("{}\n", encoding="utf-8")
+    volume_root = tmp_path / "modal-jobs"
+    live_path = tmp_path / "live.json"
+    monkeypatch.setattr(
+        "backend.service.modal_sandbox_job.MODAL_REMOTE_REPO",
+        str(repo),
+    )
+    monkeypatch.setattr(
+        "backend.service.modal_sandbox_job.sandbox_jobs_volume_root",
+        lambda: volume_root,
+    )
+    monkeypatch.setattr(
+        "backend.service.modal_sandbox_job._LIVE_PATH",
+        live_path,
+    )
+    monkeypatch.setattr(
+        "backend.service.modal_docker_prebuild.ensure_docker_daemon",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "backend.service.modal_docker_prebuild.prepare_docker_environment_for_job",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "backend.service.modal_sandbox_job._mounted_volume",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "backend.service.modal_sandbox_job._commit_volume",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "backend.service.modal_sandbox_job._run_command",
+        lambda command, *, cwd, env: 0,
+    )
+    payload = {
+        "jobName": "demo-job",
+        "configYaml": "environment:\n  type: docker\njob_name: demo-job\n",
+        "env": {},
+        "shardKey": "s0",
+    }
+    code = run_sandbox_worker(payload)
+    assert code == 0
+    stored = json.loads(
+        (volume_root / "demo-job" / "s0" / SANDBOX_RESULT_FILENAME).read_text(
+            encoding="utf-8"
+        )
+    )
+    assert stored["exitCode"] == 0
+    assert (volume_root / "demo-job" / "s0" / "web__a" / "result.json").is_file()
+    assert json.loads(live_path.read_text(encoding="utf-8"))["web__a"] == "done"

--- a/application/playground/frontend/src/components/HarborJobDetail.tsx
+++ b/application/playground/frontend/src/components/HarborJobDetail.tsx
@@ -5803,11 +5803,26 @@ export function HarborJobDetail({ jobName, onBack, onOpenTrial }: HarborJobDetai
     enabled: query.isSuccess && trials.length > 0,
     refetchInterval: (ctx) => {
       const reporting = ctx.state.data?.reporting;
+      const coverage = ctx.state.data?.coverage;
       const pending = trials.some((trial) => !trial.completed);
+      // Modal/GKE merge artifacts a few seconds after Harbor marks trials
+      // complete. Stop only once coverage has artifacts, or the launch has
+      // been finished for two minutes (failed trials never grow artifacts).
+      const artifactsPending =
+        coverage != null &&
+        (coverage.pendingTrials > 0 ||
+          coverage.completedWithoutArtifactTrials > 0 ||
+          coverage.artifactReadyTrials !== coverage.trialCount);
+      const finishedAt = Date.parse(String(launch?.finishedAt ?? ""));
+      const launchRecentlyFinished =
+        launch?.status === "running" ||
+        launch?.status === "queued" ||
+        (Number.isFinite(finishedAt) && Date.now() - finishedAt < 120_000);
       if (
         launch?.status === "running" ||
         launch?.status === "queued" ||
         pending ||
+        (artifactsPending && launchRecentlyFinished) ||
         reporting?.status === "queued" ||
         reporting?.status === "running"
       ) {

--- a/application/playground/frontend/src/components/cockpit/OsAppEvalCockpit.tsx
+++ b/application/playground/frontend/src/components/cockpit/OsAppEvalCockpit.tsx
@@ -655,7 +655,7 @@ function OsAppResults({
   harborJobName,
   harborTrialName,
   vncUrl,
-  sandboxId,
+  sandboxId: _sandboxId,
 }: {
   task: OsAppEvalTask | null;
   osAppResult: OsAppResult | null;
@@ -683,11 +683,11 @@ function OsAppResults({
   }, [recordingUrl]);
 
   const isIos = task?.platform === "ios";
-  const useScreenshot = Boolean(sandboxId && harborJobName && harborTrialName);
   const screenshotUrl =
-    useScreenshot && harborJobName && harborTrialName
+    harborJobName && harborTrialName
       ? harborTrialLiveScreenshotUrl(harborJobName, harborTrialName)
       : null;
+  const useScreenshot = Boolean(screenshotUrl) && !vncUrl;
   const [screenshotSrc, setScreenshotSrc] = useState<string | null>(null);
   const screenshotTimerRef = useRef<number | null>(null);
 
@@ -795,7 +795,7 @@ function OsAppResults({
     if (el) el.scrollTop = el.scrollHeight;
   }, [liveSteps.length]);
 
-  const hasLiveView = useScreenshot ? Boolean(screenshotUrl) : Boolean(vncUrl);
+  const hasLiveView = Boolean(vncUrl) || Boolean(screenshotUrl);
 
   const stepsPanel = (
     <div className="flex h-full min-h-0 flex-col rounded-md border border-outline bg-surface p-2">

--- a/application/playground/frontend/src/components/cockpit/WebEvalCockpit.tsx
+++ b/application/playground/frontend/src/components/cockpit/WebEvalCockpit.tsx
@@ -16,11 +16,11 @@
  * export logic, and every result/trace shape are wired exactly as before. Only
  * the structure and presentation are rebuilt.
  */
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { useI18n } from "@/i18n/I18nProvider";
-import { listWebEvalTasks, api } from "@/lib/api";
+import { listWebEvalTasks, api, harborTrialLiveScreenshotUrl } from "@/lib/api";
 import {
   findPersonaAgent,
   personaModelPipelineLabel,
@@ -489,6 +489,8 @@ export function WebEvalCockpit({
                 error={displayError}
                 persona={persona}
                 onRetry={handleRetry}
+                harborJobName={harborJobName}
+                harborTrialName={harborTrialName}
               />
     </>
   );
@@ -694,6 +696,8 @@ function WebResults({
   error,
   persona,
   onRetry,
+  harborJobName,
+  harborTrialName,
 }: {
   task: WebEvalTask | null;
   webResult: WebResult | null;
@@ -703,10 +707,51 @@ function WebResults({
   error: string | null;
   persona: PlaygroundPersona | null;
   onRetry: () => void;
+  harborJobName: string | null;
+  harborTrialName: string | null;
 }) {
   const { t } = useI18n();
   const running = phase === "launching" || phase === "running";
   const failed = phase === "error" || phase === "timeout";
+  const screenshotUrl =
+    running && harborJobName && harborTrialName
+      ? harborTrialLiveScreenshotUrl(harborJobName, harborTrialName)
+      : null;
+  const [screenshotSrc, setScreenshotSrc] = useState<string | null>(null);
+  const screenshotTimerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!screenshotUrl) {
+      setScreenshotSrc(null);
+      return;
+    }
+    let cancelled = false;
+    const refresh = async () => {
+      try {
+        const resp = await fetch(`${screenshotUrl}?t=${Date.now()}`);
+        if (cancelled || !resp.ok) return;
+        const blob = await resp.blob();
+        if (cancelled) return;
+        const url = URL.createObjectURL(blob);
+        setScreenshotSrc((prev) => {
+          if (prev) URL.revokeObjectURL(prev);
+          return url;
+        });
+      } catch {
+        /* trajectory / screenshot may not have flushed yet */
+      }
+    };
+    void refresh();
+    screenshotTimerRef.current = window.setInterval(() => void refresh(), 1500);
+    return () => {
+      cancelled = true;
+      if (screenshotTimerRef.current !== null) window.clearInterval(screenshotTimerRef.current);
+      setScreenshotSrc((prev) => {
+        if (prev) URL.revokeObjectURL(prev);
+        return null;
+      });
+    };
+  }, [screenshotUrl]);
   const personaTitle = persona
     ? personaDescriptiveTitle(null, persona.blurb, persona.source)
     : t("eval.web.personaFallback");
@@ -741,6 +786,16 @@ function WebResults({
         </div>
       )}
 
+      {running && !webResult && screenshotSrc && !(trace && trace.events.length > 0) && (
+        <div className="overflow-hidden rounded-md border border-outline bg-black">
+          <img
+            src={screenshotSrc}
+            alt={t("eval.web.results.browsing")}
+            className="mx-auto max-h-[28rem] w-full object-contain"
+          />
+        </div>
+      )}
+
       {/* Error */}
       {failed && (
         <ErrorCard
@@ -762,7 +817,7 @@ function WebResults({
       )}
 
       {/* Loading skeleton before any result/trace lands */}
-      {running && !webResult && !trace && (
+      {running && !webResult && !(trace && trace.events.length > 0) && !screenshotSrc && (
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4" aria-hidden>
           {Array.from({ length: 4 }).map((_, i) => (
             <div key={i} className="h-32 animate-rb-pulse rounded-md bg-surface-high" />

--- a/application/playground/frontend/src/components/cockpit/setup/BatchTrialGrid.tsx
+++ b/application/playground/frontend/src/components/cockpit/setup/BatchTrialGrid.tsx
@@ -651,7 +651,7 @@ export function buildBatchGridCells(
     // Status is driven by each cell's OWN matched trial, so it only ever moves
     // forward (queued -> running -> done/error) instead of flickering.
     let status: BatchTrialStatus = "pending";
-    if trial?.completed) {
+    if (trial?.completed) {
       status = trial.succeeded === false || trial.error ? "error" : "done";
     } else if (trial?.stage === "queued") {
       status = "pending";

--- a/application/playground/frontend/src/components/cockpit/setup/BatchTrialGrid.tsx
+++ b/application/playground/frontend/src/components/cockpit/setup/BatchTrialGrid.tsx
@@ -651,8 +651,10 @@ export function buildBatchGridCells(
     // Status is driven by each cell's OWN matched trial, so it only ever moves
     // forward (queued -> running -> done/error) instead of flickering.
     let status: BatchTrialStatus = "pending";
-    if (trial?.completed) {
+    if trial?.completed) {
       status = trial.succeeded === false || trial.error ? "error" : "done";
+    } else if (trial?.stage === "queued") {
+      status = "pending";
     } else if (trial) {
       status = "running";
     }

--- a/application/playground/frontend/src/lib/api.ts
+++ b/application/playground/frontend/src/lib/api.ts
@@ -203,6 +203,7 @@ export const api = {
     nConcurrentTrials?: number;
     mode?: "auto" | "force_docker" | "smoke";
     plane?: "harbor" | "remote";
+    computeFamily?: "local" | "modal" | "gcp";
     jobName?: string | null;
     chatDomain?: string | null;
     chatApplicationId?: string | null;

--- a/application/playground/frontend/src/lib/types.ts
+++ b/application/playground/frontend/src/lib/types.ts
@@ -638,6 +638,9 @@ export interface HarborLaunchView {
   finishedAt?: string | null;
   exitCode?: number | null;
   executionPlane?: string | null;
+  computeFamily?: string | null;
+  computeEnvironment?: string | null;
+  computeDispatch?: string | null;
   remoteRunId?: string | null;
 }
 

--- a/application/playground/frontend/src/lib/useHarborBatchLive.ts
+++ b/application/playground/frontend/src/lib/useHarborBatchLive.ts
@@ -93,7 +93,9 @@ export function useHarborBatchLive(jobName: string | null, options?: { enabled?:
         const trial = activeTrialName
           ? snapshot.trials.find((item) => item.trialName === activeTrialName)
           : undefined;
-        if (trial) {
+        // queued = overlay/persona slot with no trial tree yet. All four task
+        // kinds share this; only chatbot/web/os-app bubbles need events.jsonl.
+        if (trial && trial.stage !== "queued") {
           const offset = offsetsRef.current[trial.trialName] ?? 0;
           try {
             const payload = await api.getHarborTrialEvents(jobName, trial.trialName, offset);

--- a/application/scripts/generate_application_job.py
+++ b/application/scripts/generate_application_job.py
@@ -4,6 +4,10 @@
 Retrieval matches Playground Persona World:
   sources, dimension filters, task persona_strategy.json, cohorts,
   and matraix-persona-1m sampling via PersonaPoolService.
+
+Then run the printed ``matraix run -c`` command. Modal / GKE: pass
+``--compute-family modal|gcp`` here so the sidecar records the family;
+``matraix run`` dispatches through HarborJobService automatically.
 """
 
 from __future__ import annotations
@@ -20,6 +24,7 @@ from matraix.application_job import (
     build_application_job_config,
     collect_run_env_exports,
 )
+from matraix.compute_family import ComputePlan, resolve_compute_plan
 from matraix.persona_job import DEFAULT_DATASET, parse_stratify_field_args
 from matraix.provider_credentials import (
     export_hint_lines,
@@ -41,6 +46,7 @@ from persona_retrieval import (  # noqa: E402
 
 DEFAULT_JOBS_DIR = REPO_ROOT / "configs" / "jobs" / "application-task-job-recipe"
 _EXECUTION_MODES = frozenset({"auto", "force_docker", "smoke"})
+_COMPUTE_FAMILIES = frozenset({"local", "modal", "gcp"})
 _DEFAULT_N_CONCURRENT_TRIALS = 2
 
 
@@ -71,12 +77,37 @@ def _default_job_name(
     return f"{task_slug}{mode_suffix}-n{sample_size}"
 
 
+def format_run_instructions(
+    *,
+    config_display: str,
+    compute_plan: ComputePlan,
+    n_concurrent_trials: int,
+) -> list[str]:
+    """Print the next command so CLI compute matches Playground / the jobs API."""
+    bits = [
+        "family={}".format(compute_plan.family),
+        "environment={}".format(compute_plan.environment),
+    ]
+    if compute_plan.dispatch:
+        bits.append("dispatch={}".format(compute_plan.dispatch))
+    bits.append("n_concurrent_trials={}".format(n_concurrent_trials))
+    lines = ["Compute: {}".format(" ".join(bits)), "Run:"]
+    lines.append("  uv run matraix run -c {}".format(config_display))
+    if compute_plan.needs_playground_dispatch():
+        lines.append(
+            "  # sidecar computeFamily={} — HarborJobService (Playground / Modal / GKE)".format(
+                compute_plan.family
+            )
+        )
+    return lines
+
+
 def _format_run_env_comment(
     exports: list[tuple[str, str]],
     *,
     model_name: str,
     sample_size: int,
-    compute_family: str = "local",
+    compute_plan: ComputePlan,
 ) -> str:
     primary_exports = export_hint_lines(model_name)
     needs_openai_sut = any(name == "MATRIX_CHATBOT_TASK_PATH" for name, _ in exports)
@@ -88,10 +119,10 @@ def _format_run_env_comment(
     for name, value in exports:
         lines.append(f"#   export {name}={value}")
     lines.append("#   uv run matraix run -c <this-file>")
-    if compute_family and compute_family != "local":
+    if compute_plan.needs_playground_dispatch():
         lines.append(
             "#   sidecar computeFamily={} — matraix run uses HarborJobService".format(
-                compute_family
+                compute_plan.family
             )
         )
     lines.append("#")
@@ -242,12 +273,12 @@ def main() -> None:
     )
     parser.add_argument(
         "--compute-family",
-        default="local",
-        metavar="FAMILY",
+        choices=sorted(_COMPUTE_FAMILIES),
+        default=None,
         help=(
-            "Execution family written into the sidecar (same field as Playground "
-            "computeFamily). Default: local. matraix run -c wraps Harbor for local "
-            "and uses HarborJobService for any other value."
+            "Where trials run (same as Playground computeFamily). Written into "
+            "the sidecar so `matraix run -c` can dispatch Modal / GKE. "
+            "Default: MATRIX_COMPUTE_FAMILY or local."
         ),
     )
     parser.add_argument(
@@ -305,7 +336,6 @@ def main() -> None:
         parser.error("use either --strategy or --no-strategy, not both")
     if args.n_concurrent_trials < 1:
         parser.error("--n-concurrent-trials must be >= 1")
-    compute_family = (args.compute_family or "local").strip().lower() or "local"
 
     try:
         plan = build_retrieval_plan(
@@ -350,6 +380,14 @@ def main() -> None:
     )
     job_name = args.job_name or job_slug
 
+    compute_plan = resolve_compute_plan(
+        execution_mode=execution_mode,
+        trial_profile=trial_profile,
+        cua_backend=args.cua_backend,
+        compute_family=args.compute_family,
+    )
+    n_concurrent_trials = int(args.n_concurrent_trials)
+
     spec: dict[str, object] = {
         "name": job_slug,
         "stratify_fields": [],  # already resolved to concrete ids
@@ -359,6 +397,7 @@ def main() -> None:
         "task": args.task,
         "execution_mode": execution_mode,
         "trial_profile": trial_profile,
+        "compute_family": compute_plan.family,
         "agent": {
             "name": agent_name,
             "model_name": args.model_name,
@@ -367,12 +406,27 @@ def main() -> None:
             "job_name": job_name,
             "jobs_dir": "jobs",
             "n_attempts": 1,
-            "n_concurrent_trials": int(args.n_concurrent_trials),
+            "n_concurrent_trials": n_concurrent_trials,
             "timeout_multiplier": 1.0,
         },
     }
     if args.cua_backend:
         spec["cua_backend"] = args.cua_backend
+
+    run_env_exports = collect_run_env_exports(
+        trial_profile=trial_profile,
+        task_path=args.task,
+        repo_root=REPO_ROOT,
+    )
+
+    print(
+        f"Matched {retrieved.matched_count} personas; selected {retrieved.sample_size}"
+    )
+    print(f"Pool: {retrieved.persona_pool}")
+    if retrieved.strategy_path:
+        print(f"Strategy: {retrieved.strategy_path}")
+    print(f"Execution mode: {execution_mode} | trial profile: {trial_profile}")
+    print(f"Agent: {agent_name}")
 
     if execution_mode == "force_docker" and not args.cua_backend:
         spec["job"]["environment"] = {"type": "docker", "delete": True}
@@ -381,7 +435,9 @@ def main() -> None:
     meta = job_config.pop("_job_meta")
     meta.update(
         {
-            "computeFamily": compute_family,
+            "computeFamily": compute_plan.family,
+            "computeEnvironment": compute_plan.environment,
+            "computeDispatch": compute_plan.dispatch,
             "retrieval": {
                 "pool": retrieved.persona_pool,
                 "matchedCount": retrieved.matched_count,
@@ -393,15 +449,7 @@ def main() -> None:
             }
         }
     )
-
-    if args.cua_backend:
-        from matraix.application_job import resolve_job_environment
-
-        job_config["environment"] = resolve_job_environment(
-            execution_mode=execution_mode,
-            trial_profile=trial_profile,
-            cua_backend=args.cua_backend,
-        )
+    job_config["environment"] = compute_plan.harbor_environment()
 
     out_path = args.out
     if out_path is None:
@@ -411,11 +459,6 @@ def main() -> None:
         out_path = REPO_ROOT / out_path
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
-    run_env_exports = collect_run_env_exports(
-        trial_profile=trial_profile,
-        task_path=args.task,
-        repo_root=REPO_ROOT,
-    )
     stratify_line = (
         ", ".join(retrieved.stratify_fields)
         if retrieved.stratify_fields
@@ -439,6 +482,7 @@ def main() -> None:
     retrieval_line = (" | ".join(filter_bits)) if filter_bits else "none"
     header = (
         f"# Generated by application/scripts/generate_application_job.py\n"
+        f"{compute_plan.header_comment()}\n"
         f"# Task: {args.task}\n"
         f"# Execution mode: {execution_mode} | trial profile: {trial_profile}\n"
         f"# Agent: {agent_name} | harbor task: {job_config['tasks'][0]['path']}\n"
@@ -448,7 +492,7 @@ def main() -> None:
         f"# Retrieval: {retrieval_line}\n"
         f"# Personas: {', '.join(meta['selected_persona_ids'])}\n"
         f"#\n"
-        f"{_format_run_env_comment(run_env_exports, model_name=args.model_name, sample_size=meta['sample_size'], compute_family=compute_family)}"
+        f"{_format_run_env_comment(run_env_exports, model_name=args.model_name, sample_size=meta['sample_size'], compute_plan=compute_plan)}"
     )
     out_path.write_text(
         header + yaml.safe_dump(job_config, sort_keys=False),
@@ -458,17 +502,9 @@ def main() -> None:
     sidecar = out_path.with_suffix(".meta.json")
     sidecar.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
 
-    print(
-        f"Matched {retrieved.matched_count} personas; selected {meta['sample_size']}"
-    )
-    print(f"Pool: {retrieved.persona_pool}")
-    if retrieved.strategy_path:
-        print(f"Strategy: {retrieved.strategy_path}")
-    print(f"Execution mode: {execution_mode} | trial profile: {trial_profile}")
-    print(f"Agent: {agent_name} | harbor task: {job_config['tasks'][0]['path']}")
+    print(f"Harbor task: {job_config['tasks'][0]['path']}")
     print(f"Job: {out_path}")
     print(f"Meta: {sidecar}")
-    print("Run:")
     primary_exports = export_hint_lines(args.model_name)
     needs_openai_sut = any(name == "MATRIX_CHATBOT_TASK_PATH" for name, _ in run_env_exports)
     openai_already = any("OPENAI_API_KEY" in line for line in primary_exports)
@@ -478,11 +514,12 @@ def main() -> None:
         print("  export OPENAI_API_KEY=...   # user-sim chatbot/SUT default")
     for name, value in run_env_exports:
         print(f"  export {name}={value}")
-    print(f"  uv run matraix run -c {_display_path(out_path)}")
-    if compute_family != "local":
-        print(
-            f"  # sidecar computeFamily={compute_family} — matraix run uses HarborJobService"
-        )
+    for line in format_run_instructions(
+        config_display=_display_path(out_path),
+        compute_plan=compute_plan,
+        n_concurrent_trials=n_concurrent_trials,
+    ):
+        print(line)
     print("Preflight:")
     for line in format_credential_preflight(
         args.model_name,

--- a/application/scripts/generate_application_job.py
+++ b/application/scripts/generate_application_job.py
@@ -5,9 +5,9 @@ Retrieval matches Playground Persona World:
   sources, dimension filters, task persona_strategy.json, cohorts,
   and matraix-persona-1m sampling via PersonaPoolService.
 
-Then run the printed ``matraix run -c`` command. Modal / GKE: pass
-``--compute-family modal|gcp`` here so the sidecar records the family;
-``matraix run`` dispatches through HarborJobService automatically.
+Then run the printed ``matraix run -c`` command. Default is ``local`` (this
+machine). For Modal / GKE, pass ``--compute-family modal|gcp`` so the sidecar
+records the family; ``matraix run`` then dispatches through HarborJobService.
 """
 
 from __future__ import annotations
@@ -278,7 +278,8 @@ def main() -> None:
         help=(
             "Where trials run (same as Playground computeFamily). Written into "
             "the sidecar so `matraix run -c` can dispatch Modal / GKE. "
-            "Default: MATRIX_COMPUTE_FAMILY or local."
+            "Omit to stay local (or MATRIX_COMPUTE_FAMILY). Pass modal/gcp "
+            "only for remote trials."
         ),
     )
     parser.add_argument(

--- a/docs/application/playground-api.md
+++ b/docs/application/playground-api.md
@@ -240,8 +240,9 @@ Returns `jobs/{job_name}/aggregation.json`, refreshing it when needed.
 ### `GET /api/harbor/jobs/{job_name}/live`
 
 Returns live progress for the Playground: launch status, trial phases, and basic
-persona labels. Survey/chat Modal Jobs overlay **status** on a few-second tick
-(full trial dirs arrive in artifact flushes). If the API host sleeps, already
+persona labels. Survey/chat Modal Functions overlay **status** on a few-second tick
+(full trial dirs arrive in artifact flushes). Web/linux Modal Sandboxes publish
+the same overlay while the sandbox is up. If the API host sleeps, already
 spawned Modal/GKE work keeps running; reopen the API on the same `jobs/` to
 reattach. GKE host workers otherwise update when a pod finishes.
 

--- a/docs/application/playground-api.md
+++ b/docs/application/playground-api.md
@@ -27,7 +27,7 @@ Playground launches evaluations through Matraix Playground batch jobs. The Playg
 Execution can stay on the API host or dispatch to a Remote Runner worker:
 
 ```bash
-MATRIX_EXECUTION_PLANE=harbor    # default — local harbor run
+MATRIX_EXECUTION_PLANE=harbor    # default — run the job locally
 MATRIX_EXECUTION_PLANE=remote    # HTTP dispatch to Remote Runner
 REMOTE_RUNNER_API_URL=http://127.0.0.1:9100
 REMOTE_RUNNER_API_KEY=...        # optional bearer token for the worker API
@@ -181,6 +181,14 @@ Request body:
 }
 ```
 
+`computeFamily` is optional (`local`, `modal`, or `gcp`; default
+`MATRIX_COMPUTE_FAMILY` or `local`). The CLI equivalent is
+`generate_application_job.py --compute-family …` then `matraix run -c`. Each job writes
+`jobs/<job_name>/compute.json`. macOS/iOS CUA stays `use-computer`
+(`cuaPinned`) even when the family is `modal`/`gcp`. See
+[large-scale-runs.md](../environment/large-scale-runs.md) and
+[runtime.md](../environment/runtime.md).
+
 Common optional fields:
 
 | Field | Purpose |
@@ -195,6 +203,7 @@ Common optional fields:
 
 `mode` must be one of `auto`, `force_docker`, or `smoke`.
 `plane` must be `harbor` or `remote`.
+`computeFamily` must be `local`, `modal`, or `gcp`.
 Large cohorts should set `useEntirePool` and point `personaPool` at the
 cohort directory. See [large-scale-runs.md](../environment/large-scale-runs.md).
 
@@ -231,7 +240,10 @@ Returns `jobs/{job_name}/aggregation.json`, refreshing it when needed.
 ### `GET /api/harbor/jobs/{job_name}/live`
 
 Returns live progress for the Playground: launch status, trial phases, and basic
-persona labels.
+persona labels. Survey/chat Modal Jobs overlay **status** on a few-second tick
+(full trial dirs arrive in artifact flushes). If the API host sleeps, already
+spawned Modal/GKE work keeps running; reopen the API on the same `jobs/` to
+reattach. GKE host workers otherwise update when a pod finishes.
 
 ### Trial inspection routes
 

--- a/docs/application/playground-api.md
+++ b/docs/application/playground-api.md
@@ -182,8 +182,10 @@ Request body:
 ```
 
 `computeFamily` is optional (`local`, `modal`, or `gcp`; default
-`MATRIX_COMPUTE_FAMILY` or `local`). The CLI equivalent is
-`generate_application_job.py --compute-family …` then `matraix run -c`. Each job writes
+`MATRIX_COMPUTE_FAMILY` or `local`). Omit it on the API and omit
+`--compute-family` on generate to stay on this machine. For remote trials,
+`generate_application_job.py --compute-family modal` (or `gcp`) then
+`matraix run -c`. Each job writes
 `jobs/<job_name>/compute.json`. macOS/iOS CUA stays `use-computer`
 (`cuaPinned`) even when the family is `modal`/`gcp`. See
 [large-scale-runs.md](../environment/large-scale-runs.md) and

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,6 +14,12 @@ uv run python application/scripts/generate_application_job.py \
   --persona-ids 0042   # or --sample-size N for batch
 
 uv run matraix run -c configs/jobs/application-task-job-recipe/<generated>.yaml
+# Modal / GKE: generate with --compute-family, then the same matraix run:
+# uv run python application/scripts/generate_application_job.py \
+#   --task application/tasks/example-survey_product-feedback \
+#   --sample-size 10 --n-concurrent-trials 32 \
+#   --compute-family modal
+# uv run matraix run -c configs/jobs/application-task-job-recipe/<generated>.yaml
 ```
 
 Walkthrough for all four types: [quickstart.md §6–7](quickstart.md#6-one-persona--cli-with-mode-auto-default).
@@ -303,7 +309,12 @@ uv run python application/scripts/generate_application_job.py \
   --persona-ids 0042,0100,0200
 ```
 
-The script outputs a YAML recipe and a Matraix Playground command to run it. The recipe pins `agents[].model_name` so you can edit it or pass `--model-name` on regenerate to change the persona LLM.
+The script outputs a YAML recipe and a `matraix run -c` command. Pass
+`--n-concurrent-trials` (default 2, same as the UI Parallel control) and
+`--compute-family local|modal|gcp` so the sidecar records where trials run.
+`matraix run` is the only executor: local wraps `harbor run`; modal/gcp
+use HarborJobService (same path as Playground). The recipe pins
+`agents[].model_name` so you can edit it or pass `--model-name` on regenerate.
 
 Generated recipes land under `configs/jobs/application-task-job-recipe/` (see [Recipe directories](#recipe-directories) above).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,7 +14,7 @@ uv run python application/scripts/generate_application_job.py \
   --persona-ids 0042   # or --sample-size N for batch
 
 uv run matraix run -c configs/jobs/application-task-job-recipe/<generated>.yaml
-# Modal / GKE: generate with --compute-family, then the same matraix run:
+# Default is local (this machine). Optional Modal / GKE — see large-scale-runs.md:
 # uv run python application/scripts/generate_application_job.py \
 #   --task application/tasks/example-survey_product-feedback \
 #   --sample-size 10 --n-concurrent-trials 32 \
@@ -310,8 +310,9 @@ uv run python application/scripts/generate_application_job.py \
 ```
 
 The script outputs a YAML recipe and a `matraix run -c` command. Pass
-`--n-concurrent-trials` (default 2, same as the UI Parallel control) and
-`--compute-family local|modal|gcp` so the sidecar records where trials run.
+`--n-concurrent-trials` (default 2, same as the UI Parallel control). Omit
+`--compute-family` to stay `local`. Pass `modal` or `gcp` only when trials
+should run remotely; the sidecar records that family.
 `matraix run` is the only executor: local wraps `harbor run`; modal/gcp
 use HarborJobService (same path as Playground). The recipe pins
 `agents[].model_name` so you can edit it or pass `--model-name` on regenerate.

--- a/docs/environment/README.md
+++ b/docs/environment/README.md
@@ -57,10 +57,20 @@ All paths share:
 
 | Plane | Meaning | Configure |
 |-------|---------|-----------|
-| `harbor` (default) | API or laptop runs `harbor run` locally | `MATRIX_EXECUTION_PLANE=harbor` |
+| `harbor` (default) | API or laptop runs the job locally | `MATRIX_EXECUTION_PLANE=harbor` |
 | `remote` | API dispatches to a Remote Runner worker over HTTP | `MATRIX_EXECUTION_PLANE=remote` + `REMOTE_RUNNER_API_URL` |
 
 Remote plane details: [unified-runtime.md](runtime.md).
+
+### Compute family
+
+| Family | Meaning | Configure |
+|--------|---------|-----------|
+| `local` (default) | Trials on the Harbor orchestrator | `MATRIX_COMPUTE_FAMILY=local` |
+| `modal` | Survey, chat, web, Linux on Modal | `MATRIX_COMPUTE_FAMILY=modal` + Modal deploy |
+| `gcp` | Survey, chat, web, Linux on GKE | `MATRIX_COMPUTE_FAMILY=gcp` + cluster + host image |
+
+Switch when daily concurrency saturates Modal (especially web). See [runtime.md](runtime.md).
 
 **Security note:** the remote plane sends only `PYTHONPATH` and `MATRIX_*` task exports over HTTP. API keys must live on the **worker**, not in the dispatch payload.
 
@@ -99,6 +109,15 @@ Python import names stay stable: `harbor.*`, `matraix.agents.*`, `playground.*`.
 | Variable | Purpose |
 |----------|---------|
 | `MATRIX_EXECUTION_PLANE` | `harbor` (default) or `remote` |
+| `MATRIX_COMPUTE_FAMILY` | `local` (default), `modal`, or `gcp` |
+| `MATRIX_SHARD_CONCURRENCY` | Max workers for one job (default `8`) |
+| `MATRIX_HOST_PACK_CONCURRENCY` | Max survey/chat processes per Modal / GKE host worker (default `32`; does not override Playground Parallel) |
+| `MATRIX_WEB_PACK_CONCURRENCY` | Max browsers per Modal / GKE web worker (default `1`) |
+| `MATRIX_MAX_CONCURRENT_TRIALS` | Optional cap on Playground Parallel |
+| `MATRIX_GKE_CLUSTER` / `MATRIX_GKE_REGION` / `MATRIX_GKE_REGISTRY` | GKE cluster for `computeFamily=gcp` |
+| `MATRIX_GKE_HOST_IMAGE` | Image for survey/chat GKE host workers |
+| `MATRIX_CHATBOT_PUBLIC_URL` | Tunnel/public URL forwarded to Modal/GKE instead of localhost sidecars |
+| `MATRIX_CHATBOT_TUNNEL` | `auto` (default) opens cloudflared/ngrok for local Modal/GKE chat; `0` off |
 | `REMOTE_RUNNER_API_URL` | Remote runner base URL (required for `remote`) |
 | `REMOTE_RUNNER_API_KEY` | Optional bearer token for the worker API |
 | `REMOTE_RUNNER_HARBOR_COMMAND` | Override `harbor` CLI on the worker |
@@ -107,7 +126,7 @@ Python import names stay stable: `harbor.*`, `matraix.agents.*`, `playground.*`.
 ### Task exports (local + remote worker)
 
 `matraix run` sets these automatically from the generated job files. Export
-them manually only when calling `harbor run` directly:
+them manually only when bypassing `matraix run`:
 
 | Variable | When |
 |----------|------|

--- a/docs/environment/README.md
+++ b/docs/environment/README.md
@@ -117,7 +117,7 @@ Python import names stay stable: `harbor.*`, `matraix.agents.*`, `playground.*`.
 | `MATRIX_GKE_CLUSTER` / `MATRIX_GKE_REGION` / `MATRIX_GKE_REGISTRY` | GKE cluster for `computeFamily=gcp` |
 | `MATRIX_GKE_HOST_IMAGE` | Image for survey/chat GKE host workers |
 | `MATRIX_CHATBOT_PUBLIC_URL` | Tunnel/public URL forwarded to Modal/GKE instead of localhost sidecars |
-| `MATRIX_CHATBOT_TUNNEL` | `auto` (default) opens cloudflared/ngrok for local Modal/GKE chat; `0` off |
+| `MATRIX_CHATBOT_TUNNEL` | `auto` / `cloudflared` / `ngrok` publishes the local chat sidecar to Modal/GKE. Unset keeps the sidecar private |
 | `REMOTE_RUNNER_API_URL` | Remote runner base URL (required for `remote`) |
 | `REMOTE_RUNNER_API_KEY` | Optional bearer token for the worker API |
 | `REMOTE_RUNNER_HARBOR_COMMAND` | Override `harbor` CLI on the worker |

--- a/docs/environment/README.md
+++ b/docs/environment/README.md
@@ -70,7 +70,9 @@ Remote plane details: [unified-runtime.md](runtime.md).
 | `modal` | Survey, chat, web, Linux on Modal | `MATRIX_COMPUTE_FAMILY=modal` + Modal deploy |
 | `gcp` | Survey, chat, web, Linux on GKE | `MATRIX_COMPUTE_FAMILY=gcp` + cluster + host image |
 
-Switch when daily concurrency saturates Modal (especially web). See [runtime.md](runtime.md).
+Default is `local`. Set `modal` / `gcp` only for remote trials. If you already
+run on Modal, switch web to GKE when daily concurrency saturates. See
+[runtime.md](runtime.md).
 
 **Security note:** the remote plane sends only `PYTHONPATH` and `MATRIX_*` task exports over HTTP. API keys must live on the **worker**, not in the dispatch payload.
 

--- a/docs/environment/large-scale-runs.md
+++ b/docs/environment/large-scale-runs.md
@@ -30,8 +30,8 @@ uv run matraix run -c configs/jobs/application-task-job-recipe/<generated>.yaml
 ```
 
 `--compute-family modal|gcp` on the generator records the family in the sidecar.
-`matraix run -c` then dispatches through HarborJobService (Modal Jobs / GKE
-workers + shards), same as Playground. Override with
+`matraix run -c` then dispatches through HarborJobService (Modal Function /
+Sandbox or GKE workers + shards), same as Playground. Override with
 `matraix run -c <job.yaml> --compute-family local` to force this machine.
 
 One launch covers the whole cohort. Do not start a separate job per persona.
@@ -56,8 +56,9 @@ macOS / iOS always use use.computer, even when `computeFamily` is `modal` or
 `gcp`. Set `MATRIX_COMPUTE_FAMILY` or pass `computeFamily` on launch.
 
 **Modal** (`survey`, `chat`, `web`, Linux os-app): credentials on the API host
-and one deploy. The first web/Linux job builds the task image; later jobs
-reuse it. Chat needs a sidecar URL that Modal can reach. Setup:
+and one deploy. Survey/chat run as a Function; web/Linux as a Sandbox with
+Docker. The first web/Linux job builds the task image; later jobs reuse it.
+Chat needs a sidecar URL that Modal can reach. Setup:
 [runtime.md](runtime.md).
 
 Start on `modal`. Switch web/Linux to `gcp` first when daily concurrency stays
@@ -70,15 +71,16 @@ lands in `jobs/<job_name>/`. Survey/chat pack up to
 pack `MATRIX_WEB_PACK_CONCURRENCY` (default `1`) browser per worker.
 `MATRIX_SHARD_CONCURRENCY` (default `8`) is the max workers.
 `MATRIX_MAX_CONCURRENT_TRIALS` optionally caps Parallel.
-Survey/chat on Modal Jobs and GKE host workers publish **status** every few
+Survey/chat on Modal Functions and GKE host workers publish **status** every few
 seconds so the mosaic ticks; artifacts flush in batches (Modal) or when the
-pod packs the tree (GKE). All shards are spawned up front so closing the
+pod packs the tree (GKE). Web/linux Modal Sandboxes publish the same overlay
+while the sandbox is up. All shards are spawned up front so closing the
 laptop does not cancel already-queued Modal / GKE work; restart the API to
 reattach.
 
-Chat on Modal/GKE needs a sidecar URL the worker can reach. Production: a
-public endpoint. Local: Playground opens a cloudflared/ngrok tunnel if one
-is installed, or set `MATRIX_CHATBOT_PUBLIC_URL`, or use `computeFamily=local`.
+Chat on Modal/GKE needs a sidecar URL the worker can reach. Set a public
+endpoint, or `MATRIX_CHATBOT_PUBLIC_URL`, or `MATRIX_CHATBOT_TUNNEL=auto` so
+Playground can start cloudflared/ngrok, or use `computeFamily=local`.
 
 Optional knobs: `MATRIX_HOST_PACK_CONCURRENCY`, `MATRIX_WEB_PACK_CONCURRENCY`,
 `MATRIX_SHARD_CONCURRENCY`, `MATRIX_MAX_CONCURRENT_TRIALS`,

--- a/docs/environment/large-scale-runs.md
+++ b/docs/environment/large-scale-runs.md
@@ -9,13 +9,82 @@ First single-persona walkthrough: [quickstart](../quickstart.md).
 
 ## Launch
 
-Use one of:
+Pick one surface. They all write the same `jobs/<job_name>/` tree.
 
-- Playground
-- `POST /api/harbor/jobs`
-- `matraix run -c <job.yaml>`
+| Surface | Use when |
+|---------|----------|
+| **Playground** | Interactive launch and inspection |
+| **`POST /api/harbor/jobs`** | Automation |
+| **`matraix run -c <job.yaml>`** | CLI that matches Playground (local, Modal, or GCP) |
+
+A thousand-persona Modal (or GCP) batch:
+
+```bash
+uv run python application/scripts/generate_application_job.py \
+  --task application/tasks/example-survey_product-feedback \
+  --sample-size 1000 \
+  --n-concurrent-trials 32 \
+  --compute-family modal
+
+uv run matraix run -c configs/jobs/application-task-job-recipe/<generated>.yaml
+```
+
+`--compute-family modal|gcp` on the generator records the family in the sidecar.
+`matraix run -c` then dispatches through HarborJobService (Modal Jobs / GKE
+workers + shards), same as Playground. Override with
+`matraix run -c <job.yaml> --compute-family local` to force this machine.
 
 One launch covers the whole cohort. Do not start a separate job per persona.
+
+### Compute family
+
+`plane` is who starts the job. `computeFamily` is where trials run.
+
+```bash
+export MATRIX_COMPUTE_FAMILY=modal   # or gcp when daily concurrency saturates
+```
+
+Or pass `"computeFamily"` on `POST /api/harbor/jobs`.
+
+| | Survey / chat | Web / Linux app | macOS / iOS app |
+|--|---------------|-----------------|-----------------|
+| `local` | This machine | Docker on this machine | use.computer |
+| `modal` | Modal | Modal | use.computer |
+| `gcp` | GKE | GKE | use.computer |
+
+macOS / iOS always use use.computer, even when `computeFamily` is `modal` or
+`gcp`. Set `MATRIX_COMPUTE_FAMILY` or pass `computeFamily` on launch.
+
+**Modal** (`survey`, `chat`, `web`, Linux os-app): credentials on the API host
+and one deploy. The first web/Linux job builds the task image; later jobs
+reuse it. Chat needs a sidecar URL that Modal can reach. Setup:
+[runtime.md](runtime.md).
+
+Start on `modal`. Switch web/Linux to `gcp` first when daily concurrency stays
+high. Flip with `MATRIX_COMPUTE_FAMILY=gcp` or `"computeFamily": "gcp"`.
+
+`nConcurrentTrials` (Playground **Parallel**) is how many trials run at once.
+Large Modal and GCP jobs split across workers automatically. Every trial still
+lands in `jobs/<job_name>/`. Survey/chat pack up to
+`MATRIX_HOST_PACK_CONCURRENCY` (default `32`) processes per worker; web/linux
+pack `MATRIX_WEB_PACK_CONCURRENCY` (default `1`) browser per worker.
+`MATRIX_SHARD_CONCURRENCY` (default `8`) is the max workers.
+`MATRIX_MAX_CONCURRENT_TRIALS` optionally caps Parallel.
+Survey/chat on Modal Jobs and GKE host workers publish **status** every few
+seconds so the mosaic ticks; artifacts flush in batches (Modal) or when the
+pod packs the tree (GKE). All shards are spawned up front so closing the
+laptop does not cancel already-queued Modal / GKE work; restart the API to
+reattach.
+
+Chat on Modal/GKE needs a sidecar URL the worker can reach. Production: a
+public endpoint. Local: Playground opens a cloudflared/ngrok tunnel if one
+is installed, or set `MATRIX_CHATBOT_PUBLIC_URL`, or use `computeFamily=local`.
+
+Optional knobs: `MATRIX_HOST_PACK_CONCURRENCY`, `MATRIX_WEB_PACK_CONCURRENCY`,
+`MATRIX_SHARD_CONCURRENCY`, `MATRIX_MAX_CONCURRENT_TRIALS`,
+`MATRIX_MODAL_LIVE_PUSH_SEC`, `MATRIX_MODAL_LIVE_PULL_SEC`,
+`MATRIX_MODAL_ARTIFACT_FLUSH_TRIALS`, `MATRIX_MODAL_ARTIFACT_FLUSH_SEC`
+([runtime.md](runtime.md)).
 
 ---
 

--- a/docs/environment/large-scale-runs.md
+++ b/docs/environment/large-scale-runs.md
@@ -17,7 +17,9 @@ Pick one surface. They all write the same `jobs/<job_name>/` tree.
 | **`POST /api/harbor/jobs`** | Automation |
 | **`matraix run -c <job.yaml>`** | CLI that matches Playground (local, Modal, or GCP) |
 
-A thousand-persona Modal (or GCP) batch:
+A thousand-persona batch on this machine is the same generate + `matraix run -c`
+path as the [quickstart](../quickstart.md) (no `--compute-family`; default
+`local`). For Modal (or GKE) so the laptop can close:
 
 ```bash
 uv run python application/scripts/generate_application_job.py \
@@ -41,10 +43,11 @@ One launch covers the whole cohort. Do not start a separate job per persona.
 `plane` is who starts the job. `computeFamily` is where trials run.
 
 ```bash
-export MATRIX_COMPUTE_FAMILY=modal   # or gcp when daily concurrency saturates
+# unset / local = this machine (default)
+export MATRIX_COMPUTE_FAMILY=modal   # remote; or gcp when daily concurrency saturates
 ```
 
-Or pass `"computeFamily"` on `POST /api/harbor/jobs`.
+Or pass `"computeFamily"` on `POST /api/harbor/jobs`. Omit it to stay `local`.
 
 | | Survey / chat | Web / Linux app | macOS / iOS app |
 |--|---------------|-----------------|-----------------|
@@ -61,8 +64,9 @@ Docker. The first web/Linux job builds the task image; later jobs reuse it.
 Chat needs a sidecar URL that Modal can reach. Setup:
 [runtime.md](runtime.md).
 
-Start on `modal`. Switch web/Linux to `gcp` first when daily concurrency stays
-high. Flip with `MATRIX_COMPUTE_FAMILY=gcp` or `"computeFamily": "gcp"`.
+Once you leave `local`, start remote batches on `modal`. Switch web/Linux to
+`gcp` first when daily concurrency stays high. Flip with
+`MATRIX_COMPUTE_FAMILY=gcp` or `"computeFamily": "gcp"`.
 
 `nConcurrentTrials` (Playground **Parallel**) is how many trials run at once.
 Large Modal and GCP jobs split across workers automatically. Every trial still

--- a/docs/environment/runtime.md
+++ b/docs/environment/runtime.md
@@ -70,24 +70,23 @@ export MATRIX_COMPUTE_FAMILY=modal
 export MATRIX_EXECUTION_PLANE=harbor
 ```
 
-That one deploy covers survey, chat, web, and Linux. The first web/Linux job
-builds the shared task image; later jobs reuse it.
+That one deploy covers survey, chat, web, and Linux. Survey and chat run as a
+Modal Function. Web and Linux run as a Sandbox with Docker. The first web/Linux
+job builds the shared task image; later jobs reuse it.
 
 Chat tasks need a sidecar URL reachable from Modal (`CHATBOT_API_URL` or the
 task’s upstream env). Production uses a public (or VPC) endpoint.
 
-Local sidecars on `127.0.0.1` are invisible from Modal/GKE. On launch,
-Playground tries to open a **temporary public door** to that sidecar if
-`cloudflared` (or `ngrok`) is on PATH — same idea as exposing a local website.
-The door URL is stored in `MATRIX_CHATBOT_PUBLIC_URL` for this API process
-only. Install with `brew install cloudflared`. Disable with
-`MATRIX_CHATBOT_TUNNEL=0`. You can still set `MATRIX_CHATBOT_PUBLIC_URL`
-yourself, or use `computeFamily=local` so everything stays on the laptop.
+Local sidecars on `127.0.0.1` are not reachable from Modal or GKE. Set
+`MATRIX_CHATBOT_PUBLIC_URL` to a URL those workers can call, or set
+`MATRIX_CHATBOT_TUNNEL=auto` so Playground starts cloudflared (or ngrok) for
+this API process. Install with `brew install cloudflared`. Leave the tunnel
+unset to keep the sidecar private. You can also use `computeFamily=local`.
 
 Artifacts land in the same `jobs/<job_name>/` tree as a local run
 (`compute.json`, per-trial `agent/` / `verifier/` / `result.json`, `job.log`).
 
-Survey/chat **Modal Jobs** keep two channels. Status (pending / running / done)
+Survey/chat **Modal Functions** keep two channels. Status (pending / running / done)
 goes to a Modal Dict plus `live_status.json` about every
 `MATRIX_MODAL_LIVE_PUSH_SEC` seconds (default `5`) — no volume commit. Full
 trial trees flush every `MATRIX_MODAL_ARTIFACT_FLUSH_TRIALS` completions
@@ -95,18 +94,22 @@ trial trees flush every `MATRIX_MODAL_ARTIFACT_FLUSH_TRIALS` completions
 `volume.commit()`. The API overlays that status onto local `jobs/<job_name>/`
 so the mosaic ticks without re-downloading logs.
 
+Web/linux **Modal Sandboxes** publish the same mosaic overlay while the sandbox
+is up (`/tmp/matraix-live.json`, plus the jobs volume). Task images persist on
+`matraix-docker-images` so later jobs skip `compose build`.
+
 GKE host workers (`dispatch=gke_workers`) do the same overlay from
 `/tmp/matraix-live.json` about every `MATRIX_GKE_LIVE_PUSH_SEC` seconds
 (default `5`) while the pod is running.
 
 Closing the laptop does **not** stop shards already spawned on Modal (or GKE
 Jobs already created). Launch writes `jobs/<job>/_generated/cloud_run.json`
-with FunctionCall / Job ids **after each spawn**, then waits. Restart the
-Playground API on the same checkout/`jobs/` to reattach and pull artifacts.
-Shards that were never spawned (killed during the brief spawn loop) will not
-run until you retry. The live mosaic is gone while the API is down; it
-catches up on resume. Survey, chat, web, and Linux all use this path when
-`computeFamily` is `modal` or `gcp`.
+with worker ids **after each spawn**, then waits. Restart the Playground API
+on the same checkout/`jobs/` to reattach and pull artifacts. Shards that were
+never spawned (killed during the brief spawn loop) will not run until you
+retry. The live mosaic is gone while the API is down; it catches up on resume.
+Survey, chat, web, and Linux all use this path when `computeFamily` is `modal`
+or `gcp`.
 
 macOS / iOS computer-use always stays on use.computer, even when
 `MATRIX_COMPUTE_FAMILY` is `modal` or `gcp`. Set the family with
@@ -147,8 +150,8 @@ mounts a PVC at `/matraix/jobs` inside the worker; otherwise the Job uses
 `emptyDir` and the API copies `jobs/<job_name>/` back when Harbor finishes.
 
 Chat tasks need a sidecar URL reachable from the GKE pod (not localhost on the
-API host). Same automatic tunnel as Modal: `cloudflared` on PATH, or
-`MATRIX_CHATBOT_PUBLIC_URL`, or `computeFamily=local`.
+API host). Set `MATRIX_CHATBOT_PUBLIC_URL`, or `MATRIX_CHATBOT_TUNNEL=auto`, or
+use `computeFamily=local`.
 
 Then flip the family (restart the Playground API so it picks up the env):
 
@@ -254,7 +257,8 @@ Optional dev-only `taskType=web` returns a deterministic mock when
 | `MATRIX_GKE_JOBS_PVC` | Optional PVC name mounted at `/matraix/jobs` |
 | `MATRIX_GKE_LIVE_PUSH_SEC` | GKE survey/chat status tick (`/tmp/matraix-live.json`, default `5`) |
 | `MATRIX_CHATBOT_PUBLIC_URL` | Public/tunnel chatbot URL for Modal/GKE workers (replaces localhost) |
-| `MATRIX_CHATBOT_TUNNEL` | `auto` (default): start cloudflared/ngrok for local sidecars. `0` disables |
+| `MATRIX_CHATBOT_TUNNEL` | `auto` / `cloudflared` / `ngrok` publishes the local chat sidecar to Modal/GKE. Unset keeps the sidecar private |
+| `MATRIX_RUN_WAIT_TIMEOUT_SEC` | `matraix run -c` wait cap for HarborJobService (default 4 hours) |
 | `GCP_PROJECT` / `MATRIX_GCP_PROJECT` | GCP project id |
 | `REMOTE_RUNNER_API_URL` | Remote runner base URL (required for `remote`) |
 | `REMOTE_RUNNER_API_KEY` | Optional bearer token |
@@ -265,8 +269,8 @@ Optional dev-only `taskType=web` returns a deterministic mock when
 
 Matraix Playground resolves execution per task `metadata.type`:
 
-- `survey` / `chatbot` → host-native agents in `auto` mode (Modal Jobs or GKE host workers when `computeFamily` is `modal` / `gcp`)
-- `web` / `os-app` → docker, Harbor `modal` / `gke`, or `use-computer` backends
+- `survey` / `chatbot` → host-native agents in `auto` mode (Modal Function or GKE host workers when `computeFamily` is `modal` / `gcp`)
+- `web` / `os-app` → Modal Sandbox / GKE / local Docker, or `use-computer` for macOS / iOS
 
 See [large-scale-runs.md](large-scale-runs.md) and
 [quickstart.md](../quickstart.md) for terminal `matraix run` examples.

--- a/docs/environment/runtime.md
+++ b/docs/environment/runtime.md
@@ -7,7 +7,7 @@ Playground launches evaluations through **Matraix Playground batch jobs**. The P
 
 | Plane | Meaning |
 |-------|---------|
-| `harbor` (default) | API machine or local dev runs `harbor run` directly |
+| `harbor` (default) | API machine or local dev runs the job locally |
 | `remote` | API dispatches `taskType=harbor_job` to a **Remote Runner** HTTP worker |
 
 Configure the default plane:
@@ -18,6 +18,157 @@ export MATRIX_EXECUTION_PLANE=harbor   # or remote
 
 Optional per-request override: `"plane": "harbor"` or `"plane": "remote"` on
 `POST /api/harbor/jobs`.
+
+### Compute family
+
+Set where trial compute runs (independent of `plane`):
+
+```bash
+export MATRIX_COMPUTE_FAMILY=local   # or modal or gcp
+```
+
+Optional per-request override: `"computeFamily": "local"`, `"modal"`, or `"gcp"`
+on `POST /api/harbor/jobs`.
+
+| family | Survey / chatbot | Web / Linux app | macOS / iOS app |
+|--------|------------------|-----------------|-----------------|
+| `local` | This machine | Docker on this machine | use.computer |
+| `modal` | Modal | Modal (task images cached after the first build) | use.computer |
+| `gcp` | GKE | GKE | use.computer |
+
+Each run writes `jobs/<job_name>/compute.json` with `family` and `environment`.
+
+**When to switch.** Start on `modal`. Move web / Linux to `gcp` first when
+daily concurrency stays high. Survey / chat can stay packed on Modal until
+concurrency or cost says otherwise, then set the same `computeFamily=gcp`.
+
+Switch globally:
+
+```bash
+export MATRIX_COMPUTE_FAMILY=gcp     # was modal
+```
+
+Or per job: `"computeFamily": "gcp"`. `plane` stays `harbor`.
+Artifacts still land in `jobs/<job_name>/`.
+
+Survey/chat on Modal or GKE pack many I/O-bound host processes into one small
+worker (`cpu=1`, `memory=4096` on Modal; 1 CPU / 4Gi request on GKE).
+Playground Parallel / `nConcurrentTrials` is the Harbor cap as set — Modal
+and GKE do not rewrite it.
+
+Modal needs credentials on the API host (`MODAL_TOKEN_ID` /
+`MODAL_TOKEN_SECRET` or `~/.modal.toml`) and one deployed app. From the
+repository root:
+
+```bash
+uv pip install -e ".[modal]"
+modal setup
+modal secret create matraix-llm ANTHROPIC_API_KEY=... OPENAI_API_KEY=...
+export MATRIX_REPO_ROOT="$PWD"
+uv run --extra modal modal deploy application/playground/backend/service/modal_host_app.py
+export MATRIX_COMPUTE_FAMILY=modal
+export MATRIX_EXECUTION_PLANE=harbor
+```
+
+That one deploy covers survey, chat, web, and Linux. The first web/Linux job
+builds the shared task image; later jobs reuse it.
+
+Chat tasks need a sidecar URL reachable from Modal (`CHATBOT_API_URL` or the
+task’s upstream env). Production uses a public (or VPC) endpoint.
+
+Local sidecars on `127.0.0.1` are invisible from Modal/GKE. On launch,
+Playground tries to open a **temporary public door** to that sidecar if
+`cloudflared` (or `ngrok`) is on PATH — same idea as exposing a local website.
+The door URL is stored in `MATRIX_CHATBOT_PUBLIC_URL` for this API process
+only. Install with `brew install cloudflared`. Disable with
+`MATRIX_CHATBOT_TUNNEL=0`. You can still set `MATRIX_CHATBOT_PUBLIC_URL`
+yourself, or use `computeFamily=local` so everything stays on the laptop.
+
+Artifacts land in the same `jobs/<job_name>/` tree as a local run
+(`compute.json`, per-trial `agent/` / `verifier/` / `result.json`, `job.log`).
+
+Survey/chat **Modal Jobs** keep two channels. Status (pending / running / done)
+goes to a Modal Dict plus `live_status.json` about every
+`MATRIX_MODAL_LIVE_PUSH_SEC` seconds (default `5`) — no volume commit. Full
+trial trees flush every `MATRIX_MODAL_ARTIFACT_FLUSH_TRIALS` completions
+(default `25`) or `MATRIX_MODAL_ARTIFACT_FLUSH_SEC` (default `30`), then
+`volume.commit()`. The API overlays that status onto local `jobs/<job_name>/`
+so the mosaic ticks without re-downloading logs.
+
+GKE host workers (`dispatch=gke_workers`) do the same overlay from
+`/tmp/matraix-live.json` about every `MATRIX_GKE_LIVE_PUSH_SEC` seconds
+(default `5`) while the pod is running.
+
+Closing the laptop does **not** stop shards already spawned on Modal (or GKE
+Jobs already created). Launch writes `jobs/<job>/_generated/cloud_run.json`
+with FunctionCall / Job ids **after each spawn**, then waits. Restart the
+Playground API on the same checkout/`jobs/` to reattach and pull artifacts.
+Shards that were never spawned (killed during the brief spawn loop) will not
+run until you retry. The live mosaic is gone while the API is down; it
+catches up on resume. Survey, chat, web, and Linux all use this path when
+`computeFamily` is `modal` or `gcp`.
+
+macOS / iOS computer-use always stays on use.computer, even when
+`MATRIX_COMPUTE_FAMILY` is `modal` or `gcp`. Set the family with
+`MATRIX_COMPUTE_FAMILY`, `"computeFamily"` on the API, or
+`--compute-family` on the generator or `matraix run --compute-family`.
+
+### GCP / GKE (high-concurrency / always-on)
+
+`computeFamily=gcp` runs survey, chat, web, and Linux on GKE. macOS / iOS
+still use use.computer.
+
+Install the extra on the API host, then point at the cluster:
+
+```bash
+uv pip install -e ".[gke]"
+export MATRIX_GKE_CLUSTER=your-cluster
+export MATRIX_GKE_REGION=us-central1
+export MATRIX_GKE_REGISTRY=matraix          # Artifact Registry repository
+export MATRIX_GKE_NAMESPACE=default         # optional
+export GCP_PROJECT=your-project             # or MATRIX_GCP_PROJECT
+gcloud container clusters get-credentials "$MATRIX_GKE_CLUSTER" --region "$MATRIX_GKE_REGION"
+```
+
+Harbor `type: gke` also accepts those cluster fields as `environment.kwargs`.
+
+Survey/chat workers need an image that contains this checkout plus Harbor:
+
+```bash
+export MATRIX_GKE_HOST_IMAGE=REGION-docker.pkg.dev/PROJECT/REPO/matraix-host:latest
+application/playground/backend/service/build_gke_host_image.sh "$MATRIX_GKE_HOST_IMAGE"
+docker push "$MATRIX_GKE_HOST_IMAGE"
+export MATRIX_COMPUTE_FAMILY=gcp
+export MATRIX_EXECUTION_PLANE=harbor
+```
+
+The cluster must be able to pull that image. Optional `MATRIX_GKE_JOBS_PVC`
+mounts a PVC at `/matraix/jobs` inside the worker; otherwise the Job uses
+`emptyDir` and the API copies `jobs/<job_name>/` back when Harbor finishes.
+
+Chat tasks need a sidecar URL reachable from the GKE pod (not localhost on the
+API host). Same automatic tunnel as Modal: `cloudflared` on PATH, or
+`MATRIX_CHATBOT_PUBLIC_URL`, or `computeFamily=local`.
+
+Then flip the family (restart the Playground API so it picks up the env):
+
+```bash
+# burst / not yet saturated
+export MATRIX_COMPUTE_FAMILY=modal
+
+# daily saturation — especially Type 3/4 browsers
+export MATRIX_COMPUTE_FAMILY=gcp
+```
+
+Per-request override still wins: a survey can stay `"computeFamily": "modal"`
+while a web job uses `"gcp"`.
+
+`MATRIX_SHARD_CONCURRENCY` (default 8) is the max Modal/GKE workers for one
+job. `MATRIX_HOST_PACK_CONCURRENCY` (default 32) is the max survey/chat
+processes packed onto one of those workers. Playground Parallel is the
+global in-flight cap; the planner fills pack first, then adds workers.
+Results still write to one `jobs/<job_name>/`. See
+[large-scale-runs.md](large-scale-runs.md).
 
 ## Option A: Local Matraix Playground (default)
 
@@ -85,6 +236,26 @@ Optional dev-only `taskType=web` returns a deterministic mock when
 | Variable | Purpose |
 |----------|---------|
 | `MATRIX_EXECUTION_PLANE` | Default `harbor` or `remote` |
+| `MATRIX_COMPUTE_FAMILY` | Default `local`, `modal`, or `gcp` |
+| `MATRIX_SHARD_CONCURRENCY` | Max workers for one job (default `8`) |
+| `MATRIX_HOST_PACK_CONCURRENCY` | Max survey/chat processes per Modal / GKE host worker (default `32`; does not override Playground Parallel) |
+| `MATRIX_WEB_PACK_CONCURRENCY` | Max browsers per Modal / GKE web worker (default `1`) |
+| `MATRIX_MAX_CONCURRENT_TRIALS` | Optional cap on Playground Parallel |
+| `MATRIX_MODAL_LIVE_PUSH_SEC` | Modal survey/chat status tick (Dict / `live_status.json`, default `5`) |
+| `MATRIX_MODAL_LIVE_PULL_SEC` | How often the API reads that status into local `jobs/<job>/` (default `5`) |
+| `MATRIX_MODAL_ARTIFACT_FLUSH_TRIALS` | Copy full trial trees to the jobs volume after this many new dones (default `25`) |
+| `MATRIX_MODAL_ARTIFACT_FLUSH_SEC` | Or after this many seconds with new dones (default `30`) |
+| `MATRIX_GKE_CLUSTER` | GKE cluster name (`computeFamily=gcp`) |
+| `MATRIX_GKE_REGION` | GKE region |
+| `MATRIX_GKE_NAMESPACE` | Kubernetes namespace (default `default`) |
+| `MATRIX_GKE_REGISTRY` | Artifact Registry repository name (Harbor `type: gke`) |
+| `MATRIX_GKE_REGISTRY_LOCATION` | Artifact Registry location (defaults to `MATRIX_GKE_REGION`) |
+| `MATRIX_GKE_HOST_IMAGE` | Image for survey/chat GKE host workers |
+| `MATRIX_GKE_JOBS_PVC` | Optional PVC name mounted at `/matraix/jobs` |
+| `MATRIX_GKE_LIVE_PUSH_SEC` | GKE survey/chat status tick (`/tmp/matraix-live.json`, default `5`) |
+| `MATRIX_CHATBOT_PUBLIC_URL` | Public/tunnel chatbot URL for Modal/GKE workers (replaces localhost) |
+| `MATRIX_CHATBOT_TUNNEL` | `auto` (default): start cloudflared/ngrok for local sidecars. `0` disables |
+| `GCP_PROJECT` / `MATRIX_GCP_PROJECT` | GCP project id |
 | `REMOTE_RUNNER_API_URL` | Remote runner base URL (required for `remote`) |
 | `REMOTE_RUNNER_API_KEY` | Optional bearer token |
 | `REMOTE_RUNNER_INLINE` | Run jobs inline in the API process (tests) |
@@ -94,7 +265,8 @@ Optional dev-only `taskType=web` returns a deterministic mock when
 
 Matraix Playground resolves execution per task `metadata.type`:
 
-- `survey` / `chatbot` → host-native agents in `auto` mode
-- `web` / `os-app` → docker or `use-computer` backends
+- `survey` / `chatbot` → host-native agents in `auto` mode (Modal Jobs or GKE host workers when `computeFamily` is `modal` / `gcp`)
+- `web` / `os-app` → docker, Harbor `modal` / `gke`, or `use-computer` backends
 
-See [quickstart.md](../quickstart.md) for terminal `matraix run` examples.
+See [large-scale-runs.md](large-scale-runs.md) and
+[quickstart.md](../quickstart.md) for terminal `matraix run` examples.

--- a/docs/environment/runtime.md
+++ b/docs/environment/runtime.md
@@ -21,10 +21,13 @@ Optional per-request override: `"plane": "harbor"` or `"plane": "remote"` on
 
 ### Compute family
 
-Set where trial compute runs (independent of `plane`):
+Set where trial compute runs (independent of `plane`). Omit the variable (or
+set `local`) to stay on this machine. `modal` / `gcp` are opt-in:
 
 ```bash
-export MATRIX_COMPUTE_FAMILY=local   # or modal or gcp
+export MATRIX_COMPUTE_FAMILY=local   # default — laptop / API host
+# export MATRIX_COMPUTE_FAMILY=modal
+# export MATRIX_COMPUTE_FAMILY=gcp
 ```
 
 Optional per-request override: `"computeFamily": "local"`, `"modal"`, or `"gcp"`
@@ -38,9 +41,11 @@ on `POST /api/harbor/jobs`.
 
 Each run writes `jobs/<job_name>/compute.json` with `family` and `environment`.
 
-**When to switch.** Start on `modal`. Move web / Linux to `gcp` first when
-daily concurrency stays high. Survey / chat can stay packed on Modal until
-concurrency or cost says otherwise, then set the same `computeFamily=gcp`.
+**When to leave local.** Day-to-day CLI and Playground stay `local`. Use
+`modal` when you want trials to keep running after the laptop closes, or for
+a large batch. Move web / Linux to `gcp` first when daily Modal concurrency
+stays high. Survey / chat can stay packed on Modal until concurrency or cost
+says otherwise, then set the same `computeFamily=gcp`.
 
 Switch globally:
 
@@ -239,7 +244,7 @@ Optional dev-only `taskType=web` returns a deterministic mock when
 | Variable | Purpose |
 |----------|---------|
 | `MATRIX_EXECUTION_PLANE` | Default `harbor` or `remote` |
-| `MATRIX_COMPUTE_FAMILY` | Default `local`, `modal`, or `gcp` |
+| `MATRIX_COMPUTE_FAMILY` | Default `local`. Set `modal` or `gcp` for remote trials |
 | `MATRIX_SHARD_CONCURRENCY` | Max workers for one job (default `8`) |
 | `MATRIX_HOST_PACK_CONCURRENCY` | Max survey/chat processes per Modal / GKE host worker (default `32`; does not override Playground Parallel) |
 | `MATRIX_WEB_PACK_CONCURRENCY` | Max browsers per Modal / GKE web worker (default `1`) |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -622,7 +622,7 @@ Full task checklist: [tasks/README.md](../application/tasks/README.md).
 | Goal | Tool | Output |
 |------|------|--------|
 | Explore / debug visually | Playground (Mode **auto**) | `jobs/` |
-| Any of 4 types (terminal, single or batch) | `generate_application_job.py --execution-mode auto` + `matraix run -c` | `jobs/<job_name>/` |
+| Any of 4 types (terminal, single or batch) | `generate_application_job.py --execution-mode auto` then `matraix run -c` (add `--compute-family modal` / `gcp` on generate) | `jobs/<job_name>/` |
 | Deterministic job summary / export | `matraix results <job>` | text / JSON / CSV |
 | Persona narrative batch PDF | Playground **Runs** → **Download PDF** | UI PDF |
 | Install check — Survey & Chat (no Docker) | `matraix smoke <survey-task>` | `Smoke: ok` |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -622,7 +622,8 @@ Full task checklist: [tasks/README.md](../application/tasks/README.md).
 | Goal | Tool | Output |
 |------|------|--------|
 | Explore / debug visually | Playground (Mode **auto**) | `jobs/` |
-| Any of 4 types (terminal, single or batch) | `generate_application_job.py --execution-mode auto` then `matraix run -c` (add `--compute-family modal` / `gcp` on generate) | `jobs/<job_name>/` |
+| Any of 4 types (terminal, single or batch) | `generate_application_job.py --execution-mode auto` then `matraix run -c` | `jobs/<job_name>/` (local) |
+| Same recipe on Modal / GKE (optional) | add `--compute-family modal` or `gcp` on generate; see [large-scale runs](environment/large-scale-runs.md) | remote trials; laptop can close |
 | Deterministic job summary / export | `matraix results <job>` | text / JSON / CSV |
 | Persona narrative batch PDF | Playground **Runs** → **Download PDF** | UI PDF |
 | Install check — Survey & Chat (no Docker) | `matraix smoke <survey-task>` | `Smoke: ok` |

--- a/environment/task-environments/application/shared-os-app-linux/.dockerignore
+++ b/environment/task-environments/application/shared-os-app-linux/.dockerignore
@@ -1,0 +1,2 @@
+*
+!Dockerfile

--- a/environment/task-environments/application/shared-web-browser-use/.dockerignore
+++ b/environment/task-environments/application/shared-web-browser-use/.dockerignore
@@ -1,0 +1,2 @@
+*
+!Dockerfile

--- a/environment/task-environments/application/shared-web-cli/.dockerignore
+++ b/environment/task-environments/application/shared-web-cli/.dockerignore
@@ -1,0 +1,3 @@
+*
+!Dockerfile
+!install-claude-code.sh

--- a/environment/task-environments/application/shared-web-cua-linux/.dockerignore
+++ b/environment/task-environments/application/shared-web-cua-linux/.dockerignore
@@ -1,0 +1,2 @@
+*
+!Dockerfile

--- a/environment/task-environments/application/shared-web-playwright/.dockerignore
+++ b/environment/task-environments/application/shared-web-playwright/.dockerignore
@@ -1,0 +1,2 @@
+*
+!Dockerfile

--- a/packages/playground/src/playground/__main__.py
+++ b/packages/playground/src/playground/__main__.py
@@ -10,7 +10,7 @@ def main() -> int:
         "playground no longer provides a standalone in-process CLI.\n"
         "Launch evaluations through Harbor instead:\n"
         "  uv run python application/scripts/generate_application_job.py --task <task> --execution-mode auto\n"
-        "  uv run harbor run -c configs/jobs/application-task-job-recipe/<job>.yaml\n"
+        "  uv run matraix run -c configs/jobs/application-task-job-recipe/<job>.yaml\n"
         "Or use the Playground (POST /api/harbor/jobs).",
         file=sys.stderr,
     )

--- a/packages/playground/src/playground/cli.py
+++ b/packages/playground/src/playground/cli.py
@@ -1,7 +1,7 @@
 """CLI helpers for the playground package.
 
-Headless end-to-end runs now launch through Harbor (``harbor run`` or
-``POST /api/harbor/jobs``). This module keeps :func:`format_transcript` for
+Headless end-to-end runs now launch through ``matraix run`` or
+``POST /api/harbor/jobs``. This module keeps :func:`format_transcript` for
 tests and tooling.
 """
 

--- a/src/matraix/application_job.py
+++ b/src/matraix/application_job.py
@@ -52,10 +52,9 @@ def resolve_job_environment(
     """Pick the Harbor environment block for a job spec.
 
     ``compute_family`` (``local`` / ``modal`` / ``gcp``) selects the provider.
-    Survey/chat on ``modal`` keep Harbor ``type: host`` (Modal Jobs dispatch).
-    Web/linux os-app on ``modal`` keep Harbor ``type: docker`` and dispatch
-    the same Modal Jobs workers (task images are prebuilt/cached there).
-    CUA macOS/iOS still pins ``use-computer``.
+    Survey/chat on ``modal`` keep Harbor ``type: host`` (Modal Function).
+    Web/linux on ``modal`` keep Harbor ``type: docker`` and run in a Sandbox
+    (task images cached on a Volume). CUA macOS/iOS still pins ``use-computer``.
     """
     return resolve_compute_plan(
         execution_mode=execution_mode,

--- a/src/matraix/application_job.py
+++ b/src/matraix/application_job.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import yaml
 
+from matraix.compute_family import resolve_compute_plan
 from matraix.persona_agent_context import apply_persona_context_to_agent_spec
 from matraix.persona_job import (
     load_manifest,
@@ -17,7 +18,6 @@ from matraix.persona_job import (
 
 DEFAULT_APPLICATION_JOBS_DIR = "configs/jobs/application-task-job-recipe"
 _EXECUTION_MODES = frozenset({"auto", "force_docker", "smoke"})
-_NATIVE_TRIAL_PROFILES = frozenset({"json_survey", "user_sim_chat"})
 
 
 def resolve_harbor_task_path(task_path: str, *, trial_profile: str) -> str:
@@ -32,7 +32,7 @@ def collect_run_env_exports(
     task_path: str,
     repo_root: Path,
 ) -> list[tuple[str, str]]:
-    """Return ``(VAR, value)`` pairs to export before ``harbor run``."""
+    """Return ``(VAR, value)`` pairs to export before ``matraix run``."""
     _ = repo_root
     exports: list[tuple[str, str]] = []
     if trial_profile == "json_survey":
@@ -47,30 +47,22 @@ def resolve_job_environment(
     execution_mode: str,
     trial_profile: str,
     cua_backend: str | None = None,
+    compute_family: str | None = None,
 ) -> dict[str, Any]:
-    """Pick the Harbor environment block for a job spec."""
-    if cua_backend:
-        normalized = cua_backend.strip().lower().replace("-", "_")
-        if normalized in {
-            "macos",
-            "ios",
-            "use_computer",
-            "use_computer_desktop",
-            "desktop",
-            "anthropic",
-            "anthropic_cua",
-            "ubuntu",
-        }:
-            env: dict[str, Any] = {"type": "use-computer", "delete": True}
-            if normalized == "ios":
-                env["kwargs"] = {"platform": "ios"}
-            return env
-        if normalized in {"docker", "linux", "docker_computer1", "computer1", "computer_1"}:
-            return {"type": "docker", "delete": True}
+    """Pick the Harbor environment block for a job spec.
 
-    if execution_mode == "auto" and trial_profile in _NATIVE_TRIAL_PROFILES:
-        return {"type": "host", "delete": True}
-    return {"type": "docker", "delete": True}
+    ``compute_family`` (``local`` / ``modal`` / ``gcp``) selects the provider.
+    Survey/chat on ``modal`` keep Harbor ``type: host`` (Modal Jobs dispatch).
+    Web/linux os-app on ``modal`` keep Harbor ``type: docker`` and dispatch
+    the same Modal Jobs workers (task images are prebuilt/cached there).
+    CUA macOS/iOS still pins ``use-computer``.
+    """
+    return resolve_compute_plan(
+        execution_mode=execution_mode,
+        trial_profile=trial_profile,
+        cua_backend=cua_backend,
+        compute_family=compute_family,
+    ).harbor_environment()
 
 
 def select_personas(
@@ -249,6 +241,11 @@ def build_application_job_config(
                 execution_mode=execution_mode,
                 trial_profile=trial_profile,
                 cua_backend=str(cua_backend) if cua_backend else None,
+                compute_family=(
+                    str(spec.get("compute_family")).strip()
+                    if spec.get("compute_family")
+                    else None
+                ),
             ),
         ),
         "agents": agents,

--- a/src/matraix/cli.py
+++ b/src/matraix/cli.py
@@ -1,9 +1,7 @@
 """Product-facing ``matraix`` CLI.
 
-``matraix run -c`` is the only job executor. Local recipes wrap Harbor with
-the same PYTHONPATH and MATRIX_* exports Playground injects. A non-local
-sidecar ``computeFamily`` (or ``--compute-family``) uses HarborJobService —
-the same path as Playground / ``POST /api/harbor/jobs``.
+``matraix run -c`` is the only job executor: local recipes wrap ``harbor run``;
+Modal / GKE recipes go through HarborJobService (same path as Playground).
 Harbor remains available directly as the underlying runtime.
 """
 
@@ -150,7 +148,7 @@ def _cmd_run(args: argparse.Namespace, passthrough: list[str]) -> None:
         if dispatch:
             if passthrough:
                 print(
-                    "matraix run: ignoring extra harbor args on Playground dispatch: {}".format(
+                    "matraix run: ignoring harbor args on Playground dispatch: {}".format(
                         " ".join(passthrough)
                     ),
                     file=sys.stderr,
@@ -291,11 +289,11 @@ def main(argv: list[str] | None = None) -> None:
         "run",
         help="Run a job with the complete MatrAIx launch environment.",
         description=(
-            "Runs a generated job YAML. Local recipes wrap Harbor with the same "
-            "PYTHONPATH and MATRIX_* exports Playground injects. A non-local "
-            "sidecar computeFamily (or --compute-family) uses HarborJobService — "
-            "the same path as Playground / POST /api/harbor/jobs. Ad-hoc "
-            "arguments (e.g. -p/-a) still pass through to Harbor."
+            "Runs a generated job YAML. Local recipes wrap `harbor run` with the "
+            "same PYTHONPATH and MATRIX_* exports Playground injects. Modal / GKE "
+            "recipes (sidecar computeFamily, or --compute-family) use HarborJobService "
+            "— the same path as Playground / POST /api/harbor/jobs. Ad-hoc "
+            "arguments (e.g. -p/-a) still pass through to harbor run."
         ),
     )
     run_parser.add_argument(
@@ -324,12 +322,12 @@ def main(argv: list[str] | None = None) -> None:
     )
     run_parser.add_argument(
         "--compute-family",
+        choices=("local", "modal", "gcp"),
         default=None,
-        metavar="FAMILY",
         help=(
-            "Execution family for this job (same field as Playground computeFamily). "
-            "Default: sidecar computeFamily, else local. local wraps Harbor; "
-            "any other value uses HarborJobService."
+            "Where trials run (same as Playground computeFamily). Default: "
+            "sidecar computeFamily, then MATRIX_COMPUTE_FAMILY, then local. "
+            "modal/gcp dispatch through HarborJobService."
         ),
     )
     run_parser.add_argument(
@@ -337,8 +335,8 @@ def main(argv: list[str] | None = None) -> None:
         choices=("harbor", "remote"),
         default=None,
         help=(
-            "Who starts Harbor on HarborJobService dispatch (same as Playground plane). "
-            "Default: MATRIX_EXECUTION_PLANE or harbor. Ignored for local recipes."
+            "Who starts Harbor on Playground dispatch (same as Playground plane). "
+            "Default: MATRIX_EXECUTION_PLANE or harbor. Ignored for local harbor run."
         ),
     )
 

--- a/src/matraix/compute_family.py
+++ b/src/matraix/compute_family.py
@@ -1,0 +1,170 @@
+"""Resolve Playground compute family to a Harbor environment (+ optional dispatch).
+
+Users set ``computeFamily`` / ``MATRIX_COMPUTE_FAMILY`` (``local`` | ``modal`` | ``gcp``).
+Harbor still receives a normal ``environment.type``. ``dispatch`` is set when
+trials run on a cloud job runner (Modal Jobs / GKE workers), including web/linux
+Docker workers.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+from matraix.gke_settings import gke_harbor_kwargs
+
+COMPUTE_FAMILIES = frozenset({"local", "modal", "gcp"})
+COMPUTE_FAMILY_ENV = "MATRIX_COMPUTE_FAMILY"
+HOST_PACK_CONCURRENCY_ENV = "MATRIX_HOST_PACK_CONCURRENCY"
+DEFAULT_HOST_PACK_CONCURRENCY = 32
+_NATIVE_TRIAL_PROFILES = frozenset({"json_survey", "user_sim_chat"})
+
+
+@dataclass(frozen=True)
+class ComputePlan:
+    family: str
+    environment: str
+    dispatch: str | None = None
+    cua_pinned: bool = False
+    environment_kwargs: dict[str, Any] | None = None
+
+    def harbor_environment(self) -> dict[str, Any]:
+        block: dict[str, Any] = {"type": self.environment, "delete": True}
+        if self.environment_kwargs:
+            block["kwargs"] = dict(self.environment_kwargs)
+        return block
+
+    def to_public_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "family": self.family,
+            "environment": self.environment,
+        }
+        if self.dispatch:
+            payload["dispatch"] = self.dispatch
+        if self.cua_pinned:
+            payload["cuaPinned"] = True
+        return payload
+
+    def header_comment(self) -> str:
+        parts = ["family={}".format(self.family), "environment={}".format(self.environment)]
+        if self.dispatch:
+            parts.append("dispatch={}".format(self.dispatch))
+        if self.cua_pinned:
+            parts.append("cua=pinned")
+        return "# matraix {}".format(" ".join(parts))
+
+    def needs_playground_dispatch(self) -> bool:
+        """True when ``matraix run`` must go through HarborJobService.
+
+        Modal Jobs / GKE workers (and gcp web ``type: gke``) are Playground
+        dispatch. CUA stays on this machine even if the family is modal/gcp.
+        """
+        if self.cua_pinned:
+            return False
+        return bool(self.dispatch) or self.family in {"modal", "gcp"}
+
+
+def normalize_compute_family(
+    value: str | None = None,
+    *,
+    default_from_env: bool = True,
+) -> str:
+    raw = (value or "").strip().lower().replace("-", "_")
+    if raw:
+        if raw not in COMPUTE_FAMILIES:
+            raise ValueError("computeFamily must be one of local, modal, gcp")
+        return raw
+    if default_from_env:
+        env_raw = os.environ.get(COMPUTE_FAMILY_ENV, "").strip().lower().replace("-", "_")
+        if env_raw:
+            if env_raw not in COMPUTE_FAMILIES:
+                raise ValueError(
+                    "{} must be one of local, modal, gcp".format(COMPUTE_FAMILY_ENV)
+                )
+            return env_raw
+    return "local"
+
+
+def host_pack_concurrency() -> int:
+    """Concurrent host trials packed into one Modal Job (I/O-bound survey/chat)."""
+    raw = (os.environ.get(HOST_PACK_CONCURRENCY_ENV) or "").strip()
+    if raw:
+        try:
+            return max(1, int(raw))
+        except ValueError:
+            pass
+    return DEFAULT_HOST_PACK_CONCURRENCY
+
+
+def packed_n_concurrent_trials(requested: int, *, dispatch: str | None) -> int:
+    """Return the requested Harbor concurrency.
+
+    Playground Parallel is the job cap on every compute family. Modal/GKE
+    still pack I/O-bound host processes into one worker; they do not rewrite
+    the number the operator set.
+    """
+    del dispatch
+    return max(1, int(requested or 1))
+
+
+def resolve_compute_plan(
+    *,
+    execution_mode: str,
+    trial_profile: str,
+    cua_backend: str | None = None,
+    compute_family: str | None = None,
+) -> ComputePlan:
+    """Return the Harbor environment and optional host-cloud dispatch."""
+    family = normalize_compute_family(compute_family)
+    cua_env = _cua_environment(cua_backend)
+    if cua_env is not None and cua_env[0] == "use-computer":
+        env_type, kwargs = cua_env
+        return ComputePlan(
+            family=family,
+            environment=env_type,
+            cua_pinned=True,
+            environment_kwargs=kwargs,
+        )
+
+    native = trial_profile in _NATIVE_TRIAL_PROFILES
+    mode = (execution_mode or "auto").strip().lower()
+
+    if family == "modal":
+        if native and mode != "force_docker":
+            return ComputePlan(family=family, environment="host", dispatch="modal_jobs")
+        return ComputePlan(family=family, environment="docker", dispatch="modal_jobs")
+
+    if family == "gcp":
+        if native and mode != "force_docker":
+            return ComputePlan(family=family, environment="host", dispatch="gke_workers")
+        return ComputePlan(
+            family=family,
+            environment="gke",
+            environment_kwargs=gke_harbor_kwargs() or None,
+        )
+
+    if mode == "force_docker" or not native:
+        return ComputePlan(family="local", environment="docker")
+    return ComputePlan(family="local", environment="host")
+
+
+def _cua_environment(cua_backend: str | None) -> tuple[str, dict[str, Any] | None] | None:
+    if not cua_backend:
+        return None
+    normalized = cua_backend.strip().lower().replace("-", "_")
+    if normalized in {
+        "macos",
+        "ios",
+        "use_computer",
+        "use_computer_desktop",
+        "desktop",
+        "anthropic",
+        "anthropic_cua",
+        "ubuntu",
+    }:
+        kwargs = {"platform": "ios"} if normalized == "ios" else None
+        return "use-computer", kwargs
+    if normalized in {"docker", "linux", "docker_computer1", "computer1", "computer_1"}:
+        return "docker", None
+    return None

--- a/src/matraix/compute_family.py
+++ b/src/matraix/compute_family.py
@@ -1,9 +1,9 @@
 """Resolve Playground compute family to a Harbor environment (+ optional dispatch).
 
 Users set ``computeFamily`` / ``MATRIX_COMPUTE_FAMILY`` (``local`` | ``modal`` | ``gcp``).
-Harbor still receives a normal ``environment.type``. ``dispatch`` is set when
-trials run on a cloud job runner (Modal Jobs / GKE workers), including web/linux
-Docker workers.
+Harbor still receives a normal ``environment.type``. When the family is ``modal``
+or ``gcp``, Playground starts the workers: Modal Functions for survey/chat,
+Modal Sandboxes for web/linux, or GKE Jobs.
 """
 
 from __future__ import annotations
@@ -57,8 +57,8 @@ class ComputePlan:
     def needs_playground_dispatch(self) -> bool:
         """True when ``matraix run`` must go through HarborJobService.
 
-        Modal Jobs / GKE workers (and gcp web ``type: gke``) are Playground
-        dispatch. CUA stays on this machine even if the family is modal/gcp.
+        Modal Functions / Sandboxes and GKE Jobs are Playground dispatch.
+        CUA stays on this machine even if the family is modal/gcp.
         """
         if self.cua_pinned:
             return False

--- a/src/matraix/gke_settings.py
+++ b/src/matraix/gke_settings.py
@@ -1,0 +1,122 @@
+"""Read GKE / GCP settings from the environment for Harbor ``type: gke``."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+GKE_CLUSTER_ENV = "MATRIX_GKE_CLUSTER"
+GKE_REGION_ENV = "MATRIX_GKE_REGION"
+GKE_NAMESPACE_ENV = "MATRIX_GKE_NAMESPACE"
+GKE_REGISTRY_ENV = "MATRIX_GKE_REGISTRY"
+GKE_REGISTRY_LOCATION_ENV = "MATRIX_GKE_REGISTRY_LOCATION"
+GKE_HOST_IMAGE_ENV = "MATRIX_GKE_HOST_IMAGE"
+GKE_JOBS_PVC_ENV = "MATRIX_GKE_JOBS_PVC"
+GCP_PROJECT_ENVS = ("MATRIX_GCP_PROJECT", "GCP_PROJECT", "GOOGLE_CLOUD_PROJECT")
+
+
+def _first_env(*names: str) -> str:
+    for name in names:
+        value = (os.environ.get(name) or "").strip()
+        if value:
+            return value
+    return ""
+
+
+def gke_namespace() -> str:
+    return _first_env(GKE_NAMESPACE_ENV) or "default"
+
+
+def gke_project_id() -> str:
+    return _first_env(*GCP_PROJECT_ENVS)
+
+
+def gke_harbor_kwargs() -> dict[str, Any]:
+    """Constructor kwargs Harbor's GKE environment expects.
+
+    Empty until a cluster is configured so job YAML does not emit a
+    namespace-only stub.
+    """
+    cluster = _first_env(GKE_CLUSTER_ENV)
+    region = _first_env(GKE_REGION_ENV)
+    registry = _first_env(GKE_REGISTRY_ENV)
+    registry_location = _first_env(GKE_REGISTRY_LOCATION_ENV) or region
+    if not cluster:
+        return {}
+    kwargs: dict[str, Any] = {
+        "cluster_name": cluster,
+        "region": region,
+        "namespace": gke_namespace(),
+        "registry_name": registry,
+        "registry_location": registry_location,
+    }
+    project = gke_project_id()
+    if project:
+        kwargs["project_id"] = project
+    return {key: value for key, value in kwargs.items() if value}
+
+
+def missing_gke_harbor_keys() -> list[str]:
+    kwargs = gke_harbor_kwargs()
+    required = ("cluster_name", "region", "registry_name", "registry_location")
+    return [key for key in required if not kwargs.get(key)]
+
+
+def gke_host_image() -> str:
+    return _first_env(GKE_HOST_IMAGE_ENV)
+
+
+def kubeconfig_path() -> Path:
+    raw = (os.environ.get("KUBECONFIG") or "").strip()
+    return Path(raw).expanduser() if raw else Path.home() / ".kube" / "config"
+
+
+def gke_kube_configured() -> bool:
+    path = kubeconfig_path()
+    return path.is_file() or bool((os.environ.get("KUBERNETES_SERVICE_HOST") or "").strip())
+
+
+def gke_can_authenticate() -> bool:
+    if gke_kube_configured():
+        return True
+    kwargs = gke_harbor_kwargs()
+    return bool(kwargs.get("cluster_name") and kwargs.get("region"))
+
+
+def ensure_gke_kubeconfig() -> None:
+    """Fetch cluster credentials with gcloud when kubeconfig is missing."""
+    if gke_kube_configured():
+        return
+    kwargs = gke_harbor_kwargs()
+    cluster = str(kwargs.get("cluster_name") or "")
+    region = str(kwargs.get("region") or "")
+    project = str(kwargs.get("project_id") or gke_project_id())
+    if not cluster or not region:
+        raise RuntimeError(
+            "computeFamily=gcp needs kubeconfig or "
+            "{} + {}".format(GKE_CLUSTER_ENV, GKE_REGION_ENV)
+        )
+    command = [
+        "gcloud",
+        "container",
+        "clusters",
+        "get-credentials",
+        cluster,
+        "--region",
+        region,
+    ]
+    if project:
+        command.extend(["--project", project])
+    result = subprocess.run(command, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(
+            "gcloud container clusters get-credentials failed: {}".format(
+                (result.stderr or result.stdout or "").strip() or result.returncode
+            )
+        )
+
+
+def gke_host_workers_ready() -> bool:
+    return gke_can_authenticate() and bool(gke_host_image())

--- a/src/matraix/job_run.py
+++ b/src/matraix/job_run.py
@@ -7,6 +7,7 @@ Local Harbor recipes stay on ``harbor run``. Modal / GKE recipes use the same
 from __future__ import annotations
 
 import json
+import os
 import sys
 import time
 from pathlib import Path
@@ -21,6 +22,8 @@ from matraix.persona_job import DEFAULT_DATASET
 _TERMINAL_LAUNCH_STATUSES = frozenset(
     {"completed", "completed_with_errors", "failed", "cancelled"}
 )
+_DEFAULT_WAIT_TIMEOUT_SEC = 4 * 60 * 60
+_WAIT_TIMEOUT_ENV = "MATRIX_RUN_WAIT_TIMEOUT_SEC"
 
 
 def load_job_sidecar(config_path: Path) -> dict[str, Any]:
@@ -148,8 +151,27 @@ def jobs_dir_from_job_config(config_path: Path, repo_root: Path) -> Path:
     return repo_root / path
 
 
-def wait_for_harbor_job(service: object, job_name: str, *, poll_s: float = 2.0) -> dict[str, Any]:
+def _wait_timeout_sec(timeout_s: float | None) -> float:
+    if timeout_s is not None:
+        return max(0.0, float(timeout_s))
+    raw = (os.environ.get(_WAIT_TIMEOUT_ENV) or "").strip()
+    if raw:
+        try:
+            return max(0.0, float(raw))
+        except ValueError:
+            pass
+    return float(_DEFAULT_WAIT_TIMEOUT_SEC)
+
+
+def wait_for_harbor_job(
+    service: object,
+    job_name: str,
+    *,
+    poll_s: float = 2.0,
+    timeout_s: float | None = None,
+) -> dict[str, Any]:
     """Block until HarborJobService reports a terminal launch status."""
+    deadline = time.monotonic() + _wait_timeout_sec(timeout_s)
     while True:
         detail = service.get_job(job_name)  # type: ignore[attr-defined]
         if isinstance(detail, dict):
@@ -157,6 +179,12 @@ def wait_for_harbor_job(service: object, job_name: str, *, poll_s: float = 2.0) 
             status = launch.get("status") if isinstance(launch, dict) else None
             if status in _TERMINAL_LAUNCH_STATUSES:
                 return detail
+        if time.monotonic() >= deadline:
+            raise TimeoutError(
+                "timed out waiting for Harbor job {} after {}s".format(
+                    job_name, _wait_timeout_sec(timeout_s)
+                )
+            )
         time.sleep(poll_s)
 
 

--- a/src/matraix/job_run.py
+++ b/src/matraix/job_run.py
@@ -1,15 +1,12 @@
 """Dispatch ``matraix run -c`` through Harbor or HarborJobService.
 
-``matraix run -c`` is the only job executor. Local recipes wrap the Harbor CLI
-with Playground's launch env. A non-local sidecar ``computeFamily`` (or
-``--compute-family``) uses ``HarborJobService.launch`` — the same path as
-Playground / ``POST /api/harbor/jobs``.
+Local Harbor recipes stay on ``harbor run``. Modal / GKE recipes use the same
+``HarborJobService.launch`` path as Playground / ``POST /api/harbor/jobs``.
 """
 
 from __future__ import annotations
 
 import json
-import os
 import sys
 import time
 from pathlib import Path
@@ -17,6 +14,7 @@ from typing import Any
 
 import yaml
 
+from matraix.compute_family import COMPUTE_FAMILIES, resolve_compute_plan
 from matraix.launch_env import required_pythonpath_entries
 from matraix.persona_job import DEFAULT_DATASET
 
@@ -62,25 +60,27 @@ def resolve_run_compute_family(
     cli_family: str | None,
     sidecar: dict[str, Any],
 ) -> str | None:
-    """CLI flag, then sidecar ``computeFamily``. Do not inherit process env.
-
-    A hand-written local YAML must stay on the Harbor wrap unless the sidecar
-    or ``--compute-family`` says otherwise.
-    """
+    """CLI flag, then sidecar ``computeFamily``, else env / local via launch."""
     if cli_family:
         raw = cli_family.strip().lower()
-        return raw or None
+        if raw not in COMPUTE_FAMILIES:
+            raise ValueError("computeFamily must be one of local, modal, gcp")
+        return raw
     sidecar_family = sidecar.get("computeFamily") or sidecar.get("compute_family")
     if sidecar_family:
         raw = str(sidecar_family).strip().lower()
-        return raw or None
+        if raw not in COMPUTE_FAMILIES:
+            raise ValueError("computeFamily must be one of local, modal, gcp")
+        return raw
     return None
 
 
 def launch_kwargs_from_job_config(
     config_path: Path,
     *,
+    compute_family: str | None = None,
     execution_plane: str | None = None,
+    extra_launch_env: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Rebuild ``HarborJobService.launch`` kwargs from a generated recipe."""
     sidecar = load_job_sidecar(config_path)
@@ -114,6 +114,7 @@ def launch_kwargs_from_job_config(
         "task_path": task_path,
         "persona_pool": persona_pool,
         "execution_mode": str(sidecar.get("execution_mode") or "auto"),
+        "compute_family": compute_family,
         "execution_plane": execution_plane,
     }
     if persona_ids:
@@ -133,6 +134,8 @@ def launch_kwargs_from_job_config(
         launch_kwargs["job_name"] = job_name
     if cua_backend:
         launch_kwargs["cua_backend"] = str(cua_backend)
+    if extra_launch_env:
+        launch_kwargs["extra_launch_env"] = dict(extra_launch_env)
     return launch_kwargs
 
 
@@ -170,9 +173,23 @@ def should_dispatch_via_playground(
 ) -> tuple[bool, str | None]:
     sidecar = load_job_sidecar(config_path)
     family = resolve_run_compute_family(cli_family=cli_family, sidecar=sidecar)
-    if family is None or family == "local":
-        return False, family
-    return True, family
+    # Do not inherit MATRIX_COMPUTE_FAMILY here: a hand-written local YAML
+    # must stay on harbor run unless the sidecar or --compute-family says so.
+    if family is None:
+        return False, None
+    execution_mode = str(sidecar.get("execution_mode") or "auto")
+    trial_profile = str(sidecar.get("trial_profile") or "docker_agent")
+    job = load_job_yaml(config_path)
+    agent = _first_agent(job)
+    kwargs = agent.get("kwargs") if isinstance(agent.get("kwargs"), dict) else {}
+    cua_backend = sidecar.get("cua_backend") or kwargs.get("cua_backend")
+    plan = resolve_compute_plan(
+        execution_mode=execution_mode,
+        trial_profile=trial_profile,
+        cua_backend=str(cua_backend) if cua_backend else None,
+        compute_family=family,
+    )
+    return plan.needs_playground_dispatch(), plan.family
 
 
 def run_via_harbor_job_service(
@@ -187,14 +204,13 @@ def run_via_harbor_job_service(
     ensure_playground_imports(repo_root)
     from backend.service.harbor_job_service import HarborJobService
 
-    if extra_launch_env:
-        os.environ.update(extra_launch_env)
-
     sidecar = load_job_sidecar(config_path)
     family = resolve_run_compute_family(cli_family=compute_family, sidecar=sidecar)
     kwargs = launch_kwargs_from_job_config(
         config_path,
+        compute_family=family,
         execution_plane=execution_plane,
+        extra_launch_env=extra_launch_env,
     )
     service = HarborJobService.from_repo(
         repo_root=repo_root,

--- a/tests/unit/application/test_generate_application_job.py
+++ b/tests/unit/application/test_generate_application_job.py
@@ -2,12 +2,19 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 from matraix.application_job import collect_run_env_exports
+from matraix.compute_family import ComputePlan
 from matraix.provider_credentials import export_hint_lines, resolve_provider_credential
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPTS = REPO_ROOT / "application" / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import generate_application_job as gen  # noqa: E402
 
 
 def test_collect_run_env_exports_survey() -> None:
@@ -36,3 +43,30 @@ def test_export_hint_lines_are_provider_aware() -> None:
         "export DASHSCOPE_API_KEY=..."
     ]
     assert resolve_provider_credential("openai/gpt-4o-mini").env_var != "ANTHROPIC_API_KEY"
+
+
+def test_format_run_instructions_local_uses_matraix_run() -> None:
+    lines = gen.format_run_instructions(
+        config_display="configs/jobs/application-task-job-recipe/job.yaml",
+        compute_plan=ComputePlan(family="local", environment="host"),
+        n_concurrent_trials=2,
+    )
+    joined = "\n".join(lines)
+    assert "uv run matraix run -c" in joined
+    assert "--launch" not in joined
+    assert "HarborJobService" not in joined
+
+
+def test_format_run_instructions_modal_uses_matraix_run() -> None:
+    lines = gen.format_run_instructions(
+        config_display="configs/jobs/application-task-job-recipe/job.yaml",
+        compute_plan=ComputePlan(
+            family="modal", environment="host", dispatch="modal_jobs"
+        ),
+        n_concurrent_trials=32,
+    )
+    joined = "\n".join(lines)
+    assert "uv run matraix run -c configs/jobs/application-task-job-recipe/job.yaml" in joined
+    assert "--launch" not in joined
+    assert "sidecar computeFamily=modal" in joined
+    assert "generate_application_job.py" not in joined

--- a/tests/unit/matraix/test_job_run.py
+++ b/tests/unit/matraix/test_job_run.py
@@ -45,7 +45,7 @@ def _write_recipe(
     return config
 
 
-def test_should_dispatch_local_sidecar_stays_on_harbor_wrap(tmp_path: Path) -> None:
+def test_should_dispatch_local_sidecar_stays_on_harbor(tmp_path: Path) -> None:
     config = _write_recipe(
         tmp_path,
         sidecar={
@@ -62,21 +62,21 @@ def test_should_dispatch_local_sidecar_stays_on_harbor_wrap(tmp_path: Path) -> N
     assert family == "local"
 
 
-def test_should_dispatch_non_local_sidecar(tmp_path: Path) -> None:
+def test_should_dispatch_modal_sidecar(tmp_path: Path) -> None:
     config = _write_recipe(
         tmp_path,
         sidecar={
             "task": "application/tasks/example-survey_product-feedback",
             "trial_profile": "json_survey",
             "execution_mode": "auto",
-            "computeFamily": "hosted",
+            "computeFamily": "modal",
         },
     )
     dispatch, family = should_dispatch_via_playground(
         config_path=config, cli_family=None
     )
     assert dispatch is True
-    assert family == "hosted"
+    assert family == "modal"
 
 
 def test_cli_family_overrides_sidecar(tmp_path: Path) -> None:
@@ -86,7 +86,7 @@ def test_cli_family_overrides_sidecar(tmp_path: Path) -> None:
             "task": "application/tasks/example-survey_product-feedback",
             "trial_profile": "json_survey",
             "execution_mode": "auto",
-            "computeFamily": "hosted",
+            "computeFamily": "modal",
         },
     )
     dispatch, family = should_dispatch_via_playground(
@@ -96,10 +96,10 @@ def test_cli_family_overrides_sidecar(tmp_path: Path) -> None:
     assert family == "local"
 
 
-def test_process_env_does_not_hijack_local_yaml(
+def test_env_compute_family_does_not_hijack_local_yaml(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setenv("MATRIX_COMPUTE_FAMILY", "hosted")
+    monkeypatch.setenv("MATRIX_COMPUTE_FAMILY", "modal")
     config = _write_recipe(tmp_path)
     dispatch, family = should_dispatch_via_playground(
         config_path=config, cli_family=None
@@ -117,11 +117,11 @@ def test_launch_kwargs_from_sidecar_and_yaml(tmp_path: Path) -> None:
             "seed": 42,
             "execution_mode": "auto",
             "trial_profile": "json_survey",
-            "computeFamily": "hosted",
+            "computeFamily": "modal",
             "retrieval": {"pool": "persona/datasets/matraix-persona-dev-sample"},
         },
     )
-    kwargs = launch_kwargs_from_job_config(config, execution_plane="harbor")
+    kwargs = launch_kwargs_from_job_config(config, compute_family="modal")
     assert kwargs["task_path"] == "application/tasks/example-survey_product-feedback"
     assert kwargs["persona_ids"] == ["0042", "0007"]
     assert kwargs["persona_pool"] == "persona/datasets/matraix-persona-dev-sample"
@@ -129,15 +129,14 @@ def test_launch_kwargs_from_sidecar_and_yaml(tmp_path: Path) -> None:
     assert kwargs["n_concurrent_trials"] == 32
     assert kwargs["agent_name"] == "persona-json-survey"
     assert kwargs["persona_model"] == "anthropic/claude-haiku-4-5"
-    assert kwargs["execution_plane"] == "harbor"
+    assert kwargs["compute_family"] == "modal"
     assert kwargs["seed"] == 42
-    assert "compute_family" not in kwargs
 
 
 def test_launch_kwargs_requires_sidecar_task(tmp_path: Path) -> None:
     config = _write_recipe(tmp_path)
     with pytest.raises(ValueError, match="sidecar task"):
-        launch_kwargs_from_job_config(config)
+        launch_kwargs_from_job_config(config, compute_family="modal")
 
 
 def test_wait_for_harbor_job_returns_terminal(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -171,7 +170,7 @@ def test_run_via_harbor_job_service_forwards_launch_kwargs(
             "seed": 7,
             "execution_mode": "auto",
             "trial_profile": "json_survey",
-            "computeFamily": "hosted",
+            "computeFamily": "modal",
             "retrieval": {"pool": "persona/datasets/matraix-persona-dev-sample"},
         },
     )
@@ -209,12 +208,12 @@ def test_run_via_harbor_job_service_forwards_launch_kwargs(
     code = run_via_harbor_job_service(
         config_path=config,
         repo_root=tmp_path,
-        compute_family="hosted",
+        compute_family="modal",
         execution_plane="harbor",
     )
     assert code == 0
+    assert captured["compute_family"] == "modal"
     assert captured["persona_ids"] == ["0042"]
     assert captured["job_name"] == "cli-survey"
     assert captured["execution_plane"] == "harbor"
-    assert "compute_family" not in captured
     assert captured["shutdown"] is True

--- a/tests/unit/matraix/test_job_run.py
+++ b/tests/unit/matraix/test_job_run.py
@@ -155,6 +155,16 @@ def test_wait_for_harbor_job_returns_terminal(monkeypatch: pytest.MonkeyPatch) -
     assert detail["launch"]["status"] == "completed"
 
 
+def test_wait_for_harbor_job_times_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    class Fake:
+        def get_job(self, job_name: str) -> dict:
+            return {"launch": {"status": "running"}}
+
+    monkeypatch.setattr("matraix.job_run.time.sleep", lambda _s: None)
+    with pytest.raises(TimeoutError, match="timed out waiting"):
+        wait_for_harbor_job(Fake(), "job-1", poll_s=0, timeout_s=0)
+
+
 def test_run_via_harbor_job_service_forwards_launch_kwargs(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/matraix/test_matraix_cli.py
+++ b/tests/unit/matraix/test_matraix_cli.py
@@ -237,7 +237,7 @@ def test_main_run_sets_max_cost_usd_env(tmp_path: Path, monkeypatch) -> None:
     ]
 
 
-def test_main_run_non_local_sidecar_uses_harbor_job_service(
+def test_main_run_modal_sidecar_uses_harbor_job_service(
     tmp_path: Path, monkeypatch
 ) -> None:
     root = _fake_checkout(tmp_path)
@@ -247,7 +247,7 @@ def test_main_run_non_local_sidecar_uses_harbor_job_service(
             "task": "application/tasks/foo",
             "trial_profile": "json_survey",
             "execution_mode": "auto",
-            "computeFamily": "hosted",
+            "computeFamily": "modal",
             "selected_persona_ids": ["0042"],
             "seed": 1,
         },
@@ -268,20 +268,20 @@ def test_main_run_non_local_sidecar_uses_harbor_job_service(
     original_sys_path = list(sys.path)
     try:
         with pytest.raises(SystemExit) as excinfo:
-            cli.main(["run", "-c", str(config), "--compute-family", "hosted"])
+            cli.main(["run", "-c", str(config), "--compute-family", "modal"])
     finally:
         os.chdir(original_cwd)
         sys.path[:] = original_sys_path
 
     assert excinfo.value.code == 0
-    assert captured["compute_family"] == "hosted"
+    assert captured["compute_family"] == "modal"
     assert captured["config_path"] == config
     assert "args" not in harbor_calls
 
 
 def test_main_run_compute_family_without_config_exits() -> None:
     with pytest.raises(SystemExit) as excinfo:
-        cli.main(["run", "--compute-family", "hosted", "-p", "application/tasks/foo"])
+        cli.main(["run", "--compute-family", "modal", "-p", "application/tasks/foo"])
     assert "--compute-family requires" in str(excinfo.value)
 
 

--- a/tests/unit/playground_core/test_application_job.py
+++ b/tests/unit/playground_core/test_application_job.py
@@ -137,6 +137,43 @@ def test_resolve_job_environment_use_computer_for_macos_and_ios() -> None:
     ) == {"type": "docker", "delete": True}
 
 
+def test_resolve_job_environment_compute_family(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        "MATRIX_GKE_CLUSTER",
+        "MATRIX_GKE_REGION",
+        "MATRIX_GKE_REGISTRY",
+        "GCP_PROJECT",
+        "GOOGLE_CLOUD_PROJECT",
+        "MATRIX_GCP_PROJECT",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    assert resolve_job_environment(
+        execution_mode="auto",
+        trial_profile="json_survey",
+        compute_family="local",
+    ) == {"type": "host", "delete": True}
+    assert resolve_job_environment(
+        execution_mode="auto",
+        trial_profile="json_survey",
+        compute_family="modal",
+    ) == {"type": "host", "delete": True}
+    assert resolve_job_environment(
+        execution_mode="auto",
+        trial_profile="user_sim_chat",
+        compute_family="modal",
+    ) == {"type": "host", "delete": True}
+    assert resolve_job_environment(
+        execution_mode="auto",
+        trial_profile="docker_agent",
+        compute_family="modal",
+    ) == {"type": "docker", "delete": True}
+    assert resolve_job_environment(
+        execution_mode="auto",
+        trial_profile="docker_agent",
+        compute_family="gcp",
+    ) == {"type": "gke", "delete": True}
+
+
 def test_build_application_job_config_macos_cua_uses_use_computer(tmp_path: Path) -> None:
     repo = tmp_path
     pool = repo / "persona" / "datasets" / "matraix-persona-dev-sample"

--- a/tests/unit/playground_core/test_compute_family.py
+++ b/tests/unit/playground_core/test_compute_family.py
@@ -1,0 +1,159 @@
+"""Tests for compute family resolution."""
+
+from __future__ import annotations
+
+import pytest
+
+from matraix.compute_family import (
+    packed_n_concurrent_trials,
+    normalize_compute_family,
+    resolve_compute_plan,
+)
+
+
+def test_normalize_compute_family(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MATRIX_COMPUTE_FAMILY", raising=False)
+    assert normalize_compute_family(None) == "local"
+    assert normalize_compute_family("modal") == "modal"
+    monkeypatch.setenv("MATRIX_COMPUTE_FAMILY", "modal")
+    assert normalize_compute_family(None) == "modal"
+
+
+def test_resolve_compute_plan_modal_family() -> None:
+    survey = resolve_compute_plan(
+        execution_mode="auto",
+        trial_profile="json_survey",
+        compute_family="modal",
+    )
+    assert survey.to_public_dict() == {
+        "family": "modal",
+        "environment": "host",
+        "dispatch": "modal_jobs",
+    }
+    web = resolve_compute_plan(
+        execution_mode="auto",
+        trial_profile="docker_agent",
+        compute_family="modal",
+    )
+    assert web.to_public_dict() == {
+        "family": "modal",
+        "environment": "docker",
+        "dispatch": "modal_jobs",
+    }
+    assert web.harbor_environment() == {"type": "docker", "delete": True}
+
+
+def test_packed_n_concurrent_trials_keeps_requested(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("MATRIX_HOST_PACK_CONCURRENCY", raising=False)
+    assert packed_n_concurrent_trials(2, dispatch="modal_jobs") == 2
+    assert packed_n_concurrent_trials(8, dispatch="modal_jobs") == 8
+    assert packed_n_concurrent_trials(2, dispatch="gke_workers") == 2
+    assert packed_n_concurrent_trials(1, dispatch="modal_jobs") == 1
+    assert packed_n_concurrent_trials(2, dispatch=None) == 2
+    monkeypatch.setenv("MATRIX_HOST_PACK_CONCURRENCY", "48")
+    assert packed_n_concurrent_trials(2, dispatch="modal_jobs") == 2
+    assert packed_n_concurrent_trials(2, dispatch="gke_workers") == 2
+
+
+def test_resolve_compute_plan_gcp_family(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        "MATRIX_GKE_CLUSTER",
+        "MATRIX_GKE_REGION",
+        "MATRIX_GKE_REGISTRY",
+        "MATRIX_GCP_PROJECT",
+        "GCP_PROJECT",
+        "GOOGLE_CLOUD_PROJECT",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    survey = resolve_compute_plan(
+        execution_mode="auto",
+        trial_profile="json_survey",
+        compute_family="gcp",
+    )
+    assert survey.to_public_dict() == {
+        "family": "gcp",
+        "environment": "host",
+        "dispatch": "gke_workers",
+    }
+    web = resolve_compute_plan(
+        execution_mode="auto",
+        trial_profile="docker_agent",
+        compute_family="gcp",
+    )
+    assert web.to_public_dict() == {"family": "gcp", "environment": "gke"}
+    assert web.harbor_environment() == {"type": "gke", "delete": True}
+
+
+def test_resolve_compute_plan_gcp_web_injects_gke_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MATRIX_GKE_CLUSTER", "demo")
+    monkeypatch.setenv("MATRIX_GKE_REGION", "us-central1")
+    monkeypatch.setenv("MATRIX_GKE_REGISTRY", "matraix")
+    monkeypatch.setenv("GCP_PROJECT", "proj-1")
+    web = resolve_compute_plan(
+        execution_mode="auto",
+        trial_profile="docker_agent",
+        compute_family="gcp",
+    )
+    assert web.harbor_environment() == {
+        "type": "gke",
+        "delete": True,
+        "kwargs": {
+            "cluster_name": "demo",
+            "region": "us-central1",
+            "namespace": "default",
+            "registry_name": "matraix",
+            "registry_location": "us-central1",
+            "project_id": "proj-1",
+        },
+    }
+
+
+def test_resolve_compute_plan_cua_pins_use_computer_on_modal() -> None:
+    plan = resolve_compute_plan(
+        execution_mode="auto",
+        trial_profile="docker_agent",
+        cua_backend="macos",
+        compute_family="modal",
+    )
+    assert plan.to_public_dict() == {
+        "family": "modal",
+        "environment": "use-computer",
+        "cuaPinned": True,
+    }
+    assert plan.dispatch is None
+    assert plan.harbor_environment() == {"type": "use-computer", "delete": True}
+
+
+def test_resolve_compute_plan_linux_cua_uses_modal_jobs() -> None:
+    plan = resolve_compute_plan(
+        execution_mode="auto",
+        trial_profile="docker_agent",
+        cua_backend="linux",
+        compute_family="modal",
+    )
+    assert plan.to_public_dict() == {
+        "family": "modal",
+        "environment": "docker",
+        "dispatch": "modal_jobs",
+    }
+    assert not plan.cua_pinned
+
+
+def test_needs_playground_dispatch() -> None:
+    from matraix.compute_family import ComputePlan
+
+    assert not ComputePlan(family="local", environment="host").needs_playground_dispatch()
+    assert ComputePlan(
+        family="modal", environment="host", dispatch="modal_jobs"
+    ).needs_playground_dispatch()
+    assert ComputePlan(
+        family="modal", environment="docker", dispatch="modal_jobs"
+    ).needs_playground_dispatch()
+    assert ComputePlan(family="gcp", environment="gke").needs_playground_dispatch()
+    assert not ComputePlan(
+        family="modal", environment="use-computer", cua_pinned=True
+    ).needs_playground_dispatch()

--- a/tests/unit/playground_core/test_gke_settings.py
+++ b/tests/unit/playground_core/test_gke_settings.py
@@ -1,0 +1,73 @@
+"""Tests for GKE / GCP environment settings."""
+
+from __future__ import annotations
+
+import pytest
+
+from matraix.gke_settings import (
+    gke_can_authenticate,
+    gke_harbor_kwargs,
+    gke_host_workers_ready,
+    missing_gke_harbor_keys,
+)
+
+_GKE_ENV = (
+    "MATRIX_GKE_CLUSTER",
+    "MATRIX_GKE_REGION",
+    "MATRIX_GKE_NAMESPACE",
+    "MATRIX_GKE_REGISTRY",
+    "MATRIX_GKE_REGISTRY_LOCATION",
+    "MATRIX_GKE_HOST_IMAGE",
+    "MATRIX_GKE_JOBS_PVC",
+    "MATRIX_GCP_PROJECT",
+    "GCP_PROJECT",
+    "GOOGLE_CLOUD_PROJECT",
+    "KUBECONFIG",
+    "KUBERNETES_SERVICE_HOST",
+)
+
+
+def _clear_gke(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in _GKE_ENV:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_gke_harbor_kwargs_empty_without_cluster(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_gke(monkeypatch)
+    assert gke_harbor_kwargs() == {}
+    assert missing_gke_harbor_keys() == [
+        "cluster_name",
+        "region",
+        "registry_name",
+        "registry_location",
+    ]
+
+
+def test_gke_harbor_kwargs_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_gke(monkeypatch)
+    monkeypatch.setenv("MATRIX_GKE_CLUSTER", "demo")
+    monkeypatch.setenv("MATRIX_GKE_REGION", "us-central1")
+    monkeypatch.setenv("MATRIX_GKE_REGISTRY", "matraix")
+    monkeypatch.setenv("GCP_PROJECT", "proj-1")
+    assert gke_harbor_kwargs() == {
+        "cluster_name": "demo",
+        "region": "us-central1",
+        "namespace": "default",
+        "registry_name": "matraix",
+        "registry_location": "us-central1",
+        "project_id": "proj-1",
+    }
+    assert missing_gke_harbor_keys() == []
+
+
+def test_gke_host_workers_ready(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    _clear_gke(monkeypatch)
+    monkeypatch.setattr("matraix.gke_settings.Path.home", lambda: tmp_path)
+    assert not gke_can_authenticate()
+    assert not gke_host_workers_ready()
+    monkeypatch.setenv("MATRIX_GKE_CLUSTER", "demo")
+    monkeypatch.setenv("MATRIX_GKE_REGION", "us-central1")
+    assert gke_can_authenticate()
+    assert not gke_host_workers_ready()
+    monkeypatch.setenv("MATRIX_GKE_HOST_IMAGE", "us-central1-docker.pkg.dev/p/r/host:latest")
+    assert gke_host_workers_ready()


### PR DESCRIPTION
## Summary
- Port `computeFamily` (`local` | `modal` | `gcp`) 
- Local stays the default. macOS/iOS still pin `use.computer` even when the family is `modal` or `gcp`.
- Credentials stay in env (`MODAL_TOKEN_*`, `MATRIX_GKE_*`). This does not include the in-the-wild experiment CLI.

## Test plan
- [x] Local unit tests for compute family, Modal/GKE host dispatch, HarborJobService, CLI (`186 passed`)
- [ ] `matraix run -c` with sidecar `computeFamily=local` still wraps Harbor
- [ ] Playground launch without `MATRIX_COMPUTE_FAMILY` stays local
- [ ] `generate_application_job.py --compute-family modal` writes sidecar + `matraix run -c` takes HarborJobService (fails cleanly without Modal creds)
- [ ] Optional: live Modal survey smoke with `MODAL_TOKEN_*` and a deployed `modal_host_app`


Made with [Cursor](https://cursor.com)